### PR TITLE
Implement featured events section for user promotion

### DIFF
--- a/PROMOTIONS_MVP.md
+++ b/PROMOTIONS_MVP.md
@@ -1,0 +1,140 @@
+# Promotions MVP – Featured/Promoted Events and Businesses
+
+## 1) Scope and Goals
+- Add a simple, frontend‑first system to surface “Featured/Promoted” items in multiple placements without backend changes.
+- Provide a purchase path for “Business” promotions using Stripe Checkout (no backend yet).
+- Keep SEO clean (do not include promoted items in JSON‑LD).
+- Reuse existing UI components, keep code small and flag‑gated.
+
+## 2) What’s Implemented
+### 2.1 Placements (flag‑gated by `NEXT_PUBLIC_FEATURE_PROMOTED`)
+- Home (`app/page.tsx`)
+  - “Destacats” strip (existing)
+  - New “Empreses destacades” strip below main sections
+- Home categories (`components/ui/serverEventsCategorized/index.tsx`)
+  - “Empreses destacades” strip below `LocationDiscoveryWidget`
+  - Link “Promociona la teva empresa” near each category header
+- Place pages (`app/[place]/page.tsx`)
+  - Bottom strip “Empreses de proximitat” under `HybridEventsList`
+- Event detail (`app/e/[eventId]/page.tsx`)
+  - “Empreses recomanades a prop” strip after `EventClient` (scoped by region)
+- Event detail CTA (`app/e/[eventId]/EventClient.tsx`)
+  - Inline card “Promociona el teu esdeveniment” now links to `/promociona?eventId=<slug>`
+
+Notes:
+- All strips use `EventsAroundServer` with `showJsonLd=false` to avoid SEO pollution.
+- Strips hide automatically if fewer than 3 items are available.
+
+### 2.2 Promotions configurator (`/promociona`)
+- Selectors: Tipus (Esdeveniment/Negoci), Àrea de visibilitat (Regió/Ciutat/País), Durada (2/7/15 dies), Ubicació (Catalunya + region/city pickers).
+- Uses existing `Select` and hooks to list regions/cities (same model as `/publica`).
+- Conditional behavior:
+  - País → Region and City disabled
+  - Regió → City disabled
+  - Ciutat → both enabled
+- Price calculation: from constants (`PROMOTE_PRICING` × `PROMOTE_PLACEMENT_MULTIPLIER`, future‑proof for backend).
+- For kind=business → checkout; kind=event → `/publica` (no payment now). 
+
+### 2.3 Stripe (server‑only Checkout redirect)
+- Route: `app/promociona/checkout/route.ts`
+  - Creates a Checkout Session from URL params and redirects to Stripe
+  - Success → `/promociona/success?session_id=...`
+  - Cancel → back to `/promociona?canceled=1`
+  - Safe fallback when `STRIPE_SECRET_KEY` missing → returns to `/promociona?stripe=missing`
+- Success page: `app/promociona/success/page.tsx`
+  - Simple confirmation and GA event `checkout_success`
+- CTA wrapper: `app/promociona/cta-client.tsx`
+  - Fires GA `begin_checkout` when the user clicks the button
+
+### 2.4 Feature flag and constants
+- `NEXT_PUBLIC_FEATURE_PROMOTED` gates all strips and CTAs
+- `utils/constants.ts`:
+  - `PROMOTE_VISIBILITY` (zona/regió, ciutat, país)
+  - `PROMOTE_DURATIONS` (2/7/15)
+  - `PROMOTE_PRICING` (base prices)
+  - `PROMOTE_KINDS` (event, business)
+  - `PROMOTE_PLACEMENTS` + `PROMOTE_PLACEMENT_MULTIPLIER` (future use)
+
+## 3) What’s Left (Frontend‑only)
+- Add banners on `/promociona` for:
+  - `?canceled=1` → “Pagament cancel·lat”
+  - `?stripe=missing` → “Stripe no configurat” (warning already added when env missing)
+- Expose “Promociona la teva empresa” links in other low‑risk surfaces (footer partners, location widget card) if desired.
+- Optional: GA events on impression/click for the new strips.
+
+## 4) Backend Needs (when ready)
+- Dedicated Promotions API
+  - Data model: Promotion, Creative (image), Targeting (place/category), Kind (business/event), Scope/Duration/Placement, Start/End, Status
+  - Endpoints:
+    - `GET /promotions?place=...&category=...` (for strip rendering)
+    - `POST /promotions` (create pending)
+    - `PUT /promotions/:id` (activate/modify)
+- Fulfillment logic (after payment)
+  - Start/end scheduling for visibility windows
+  - Slot allocation/inventory limits per surface
+  - Creative validation and safe asset hosting
+
+## 5) Stripe: Now vs Later
+### 5.1 Why no webhooks now
+- We are not auto‑fulfilling in the backend yet. The MVP flow ends at the success page.
+- Stripe Dashboard can be used for reconciliation in test/live.
+
+### 5.2 When to add webhooks
+- As soon as we need to automatically activate/schedule a promotion, store orders, or send onboarding messages. 
+- Listen to `checkout.session.completed` (and optionally `payment_intent.succeeded`) and persist the confirmed order.
+
+### 5.3 Products/Prices migration (preferred for production)
+- Replace code‑computed amounts with Stripe Products + Prices.
+- Model each combination (scope × days × placement) as a Price (use `lookup_key`).
+- Checkout Session uses line_items with `price: <price_id>` and `quantity: 1`.
+- Benefits: single source of truth for pricing, simpler ops, flexible discounts/taxes, cleaner reporting.
+
+## 6) Environment & Config
+- Required now:
+  - `NEXT_PUBLIC_FEATURE_PROMOTED=1` (to reveal UI/strips)
+  - `STRIPE_SECRET_KEY` (test/live; required for business checkout)
+- Optional later:
+  - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (if using client SDK)
+- Vercel Preview/Production: set env per environment, redeploy.
+
+## 7) SEO, Ads, Compliance Rules
+- Do NOT include promoted items in JSON‑LD: every strip sets `showJsonLd=false`.
+- Clearly label Sponsored/Promoted items.
+- External links should use `rel="sponsored nofollow noopener noreferrer"` (when external URLs are introduced).
+- Keep canonical URLs unchanged; the promotions page `/promociona` is static and not indexed for content discovery.
+
+## 8) Analytics
+- Implemented: GA events
+  - `begin_checkout` on checkout CTA
+  - `checkout_success` on success page
+- Suggested next:
+  - `promoted.strip_impression` (IntersectionObserver)
+  - `promoted.item_click` with `{ placement, pageType, place, category, position, kind }`
+
+## 9) Testing & Validation (manual)
+- Flag OFF → All strips hidden; `/promociona` still works (without Stripe notice).
+- Flag ON, Stripe missing → `/promociona` shows a warning; checkout redirects back with `stripe=missing`.
+- Stripe Test Key → Business: `/promociona` → checkout → pay with test card → success page.
+- Event promotion: `/promociona?kind=event` → `/publica` flow unchanged.
+
+## 10) Open Questions
+- Inventory rules per placement (how many promos at once?).
+- Targeting granularity (place vs place+category, date windows). 
+- Creative specs per placement (ratio/size caps; image moderation). 
+- Pricing strategy and bundles (newsletter mentions, co‑branded content add‑ons).
+
+## 11) File/Code Map
+- Home strips: `app/page.tsx`, `components/ui/serverEventsCategorized/index.tsx`
+- Place strips: `app/[place]/page.tsx`
+- Event detail strip: `app/e/[eventId]/page.tsx`
+- Promotions page: `app/promociona/page.tsx`
+  - Place picker: `app/promociona/place-client.tsx`
+  - Business upload (preview only): `app/promociona/upload-client.tsx`
+  - Checkout CTA: `app/promociona/cta-client.tsx`
+- Stripe server route: `app/promociona/checkout/route.ts`
+- Success page: `app/promociona/success/page.tsx`
+- Constants: `utils/constants.ts`
+
+## 12) Wrap‑up
+- MVP is complete: featured/promoted placements are visible under a flag, `/promociona` configures options with location targeting, and business checkout uses Stripe Checkout without backend.
+- Next recommended steps: move prices to Stripe Products/Prices, add Stripe webhooks and a minimal Promotions backend to schedule and track active promotions.

--- a/app/[place]/[byDate]/[category]/page.tsx
+++ b/app/[place]/[byDate]/[category]/page.tsx
@@ -15,7 +15,7 @@ import { FetchEventsParams } from "types/event";
 import { FilteredPageProps } from "types/props";
 import { distanceToRadius } from "types/event";
 import HybridEventsList from "@components/ui/hybridEventsList";
-import dynamic from "next/dynamic";
+import ClientInteractiveLayer from "@components/ui/clientInteractiveLayer";
 import {
   parseFiltersFromUrl,
   getRedirectUrl,
@@ -30,13 +30,9 @@ import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import { fetchRegionsWithCities, fetchRegions } from "@lib/api/regions";
 import { toLocalDateString } from "@utils/helpers";
 import { twoWeeksDefault } from "@lib/dates";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 
 export const revalidate = 600;
-
-const ClientInteractiveLayer = dynamic(
-  () => import("@components/ui/clientInteractiveLayer"),
-  { ssr: false }
-);
 
 export async function generateMetadata({
   params,
@@ -227,6 +223,21 @@ export default async function FilteredPage({
 
   const eventsWithAds = insertAds(events);
 
+  // Optionally fetch a small featured strip scoped to place and category
+  let featured: typeof events = [];
+  if (process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1") {
+    try {
+      const res = await fetchEvents({ page: 0, size: 6, place, category: filters.category !== "tots" ? filters.category : undefined });
+      featured = (res?.content || []).filter(isEventSummaryResponseDTO);
+      if (featured.length < 3) {
+        const res2 = await fetchEvents({ page: 0, size: 6, place });
+        featured = (res2?.content || []).filter(isEventSummaryResponseDTO);
+      }
+    } catch (e) {
+      featured = [];
+    }
+  }
+
   // Find category name for SEO
   const categoryData = categories.find((cat) => cat.slug === filters.category);
 
@@ -265,6 +276,24 @@ export default async function FilteredPage({
             __html: JSON.stringify(structuredData),
           }}
         />
+      )}
+
+      {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
+        <section
+          aria-labelledby="featured-heading"
+          className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6"
+        >
+          <h2 id="featured-heading" className="uppercase mb-2 px-2 lg:px-0">
+            Destacats
+          </h2>
+          <EventsAroundServer
+            events={featured}
+            layout="horizontal"
+            usePriority
+            showJsonLd={false}
+            title="Destacats"
+          />
+        </section>
       )}
 
       <HybridEventsList

--- a/app/[place]/[byDate]/[category]/page.tsx
+++ b/app/[place]/[byDate]/[category]/page.tsx
@@ -233,7 +233,7 @@ export default async function FilteredPage({
         const res2 = await fetchEvents({ page: 0, size: 6, place });
         featured = (res2?.content || []).filter(isEventSummaryResponseDTO);
       }
-    } catch (e) {
+    } catch {
       featured = [];
     }
   }

--- a/app/[place]/[byDate]/page.tsx
+++ b/app/[place]/[byDate]/page.tsx
@@ -259,7 +259,7 @@ export default async function ByDatePage({
         const res2 = await fetchEvents({ page: 0, size: 6 });
         featured = (res2?.content || []).filter(isEventSummaryResponseDTO);
       }
-    } catch (e) {
+    } catch {
       featured = [];
     }
   }

--- a/app/[place]/[byDate]/page.tsx
+++ b/app/[place]/[byDate]/page.tsx
@@ -15,7 +15,7 @@ import type { CategorySummaryResponseDTO } from "types/api/category";
 import { FetchEventsParams, distanceToRadius } from "types/event";
 import { fetchRegionsWithCities, fetchRegions } from "@lib/api/regions";
 import HybridEventsList from "@components/ui/hybridEventsList";
-import dynamic from "next/dynamic";
+import ClientInteractiveLayer from "@components/ui/clientInteractiveLayer";
 import { parseFiltersFromUrl } from "@utils/url-filters";
 import {
   validatePlaceOrThrow,
@@ -23,11 +23,6 @@ import {
 } from "@utils/route-validation";
 import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
-
-const ClientInteractiveLayer = dynamic(
-  () => import("@components/ui/clientInteractiveLayer"),
-  { ssr: false }
-);
 
 export async function generateMetadata({
   params,
@@ -202,9 +197,7 @@ export default async function ByDatePage({
 
   let noEventsFound = false;
   // Fetch events and place label in parallel when possible
-  let [eventsResponse] = await Promise.all([
-    fetchEvents(paramsForFetch),
-  ]);
+  let [eventsResponse] = await Promise.all([fetchEvents(paramsForFetch)]);
   let events = eventsResponse?.content || [];
 
   if (!events || events.length === 0) {

--- a/app/[place]/page.tsx
+++ b/app/[place]/page.tsx
@@ -198,7 +198,7 @@ export default async function Page({
         const res2 = await fetchEvents({ page: 0, size: 6 });
         featured = (res2?.content || []).filter(isEventSummaryResponseDTO);
       }
-    } catch (e) {
+    } catch {
       featured = [];
     }
   }

--- a/app/[place]/page.tsx
+++ b/app/[place]/page.tsx
@@ -29,6 +29,7 @@ import {
 import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import { fetchCities } from "@lib/api/cities";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
 
 export const revalidate = 600;
 
@@ -274,13 +275,15 @@ export default async function Page({
       {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
         <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
           <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses de proximitat</h2>
-          <EventsAroundServer
-            events={featured}
-            layout="horizontal"
-            usePriority={false}
-            showJsonLd={false}
-            title="Empreses de proximitat"
-          />
+          <PromoStripTracker events={featured} placement="place_bottom" pageType="place" place={place}>
+            <EventsAroundServer
+              events={featured}
+              layout="horizontal"
+              usePriority={false}
+              showJsonLd={false}
+              title="Empreses de proximitat"
+            />
+          </PromoStripTracker>
         </section>
       )}
 

--- a/app/[place]/page.tsx
+++ b/app/[place]/page.tsx
@@ -270,6 +270,20 @@ export default async function Page({
         serverHasMore={!eventsResponse?.last}
       />
 
+      {/* Bottom promoted businesses strip */}
+      {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
+        <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
+          <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses de proximitat</h2>
+          <EventsAroundServer
+            events={featured}
+            layout="horizontal"
+            usePriority={false}
+            showJsonLd={false}
+            title="Empreses de proximitat"
+          />
+        </section>
+      )}
+
       {/* Client-side interactive layer (search, filters, floating button) */}
       <ClientInteractiveLayer
         categories={categories}

--- a/app/[place]/page.tsx
+++ b/app/[place]/page.tsx
@@ -30,6 +30,7 @@ import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import { fetchCities } from "@lib/api/cities";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
+import FeaturedEventsSection from "@components/ui/featuredEvents/FeaturedEventsSection";
 
 export const revalidate = 600;
 
@@ -273,18 +274,7 @@ export default async function Page({
 
       {/* Bottom promoted businesses strip */}
       {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
-        <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
-          <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses de proximitat</h2>
-          <PromoStripTracker events={featured} placement="place_bottom" pageType="place" place={place}>
-            <EventsAroundServer
-              events={featured}
-              layout="horizontal"
-              usePriority={false}
-              showJsonLd={false}
-              title="Empreses de proximitat"
-            />
-          </PromoStripTracker>
-        </section>
+        <FeaturedEventsSection title="Empreses de proximitat" place={place} placement="place_bottom" pageType="place" />
       )}
 
       {/* Client-side interactive layer (search, filters, floating button) */}

--- a/app/e/[eventId]/EventClient.tsx
+++ b/app/e/[eventId]/EventClient.tsx
@@ -21,6 +21,7 @@ import {
   SpeakerphoneIcon,
 } from "@heroicons/react/outline";
 import AdArticle from "components/ui/adArticle";
+import Link from "next/link";
 
 // const Tooltip = dynamic(() => import("components/ui/tooltip"), {
 //   ssr: false,
@@ -139,6 +140,23 @@ export default function EventClient({
         categories={event.categories}
         place={event.region.slug}
       />
+
+      {/* Promote your event CTA */}
+      {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && (
+        <div className="w-full flex justify-center items-start gap-2 px-4 mt-4">
+          <SpeakerphoneIcon className="w-5 h-5 mt-1" />
+          <div className="w-11/12 flex flex-col gap-2 bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+            <h2 className="text-sm font-semibold uppercase tracking-wide">Promociona el teu esdeveniment</h2>
+            <p className="text-sm text-blackCorp/80">Dona-li més visibilitat a la teva proposta distingint-la a la pàgina principal i llistes.</p>
+            <div>
+              <Link href="/publica" className="inline-flex items-center px-3 py-1.5 bg-primary text-white rounded-md hover:bg-primarydark">
+                Publica ara
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Ad Section */}
       <div className="w-full h-full flex justify-center items-start px-4 min-h-[250px] gap-2">
         <SpeakerphoneIcon className="w-5 h-5 mt-1" />

--- a/app/e/[eventId]/EventClient.tsx
+++ b/app/e/[eventId]/EventClient.tsx
@@ -149,8 +149,8 @@ export default function EventClient({
             <h2 className="text-sm font-semibold uppercase tracking-wide">Promociona el teu esdeveniment</h2>
             <p className="text-sm text-blackCorp/80">Dona-li més visibilitat a la teva proposta distingint-la a la pàgina principal i llistes.</p>
             <div>
-              <Link href="/publica" className="inline-flex items-center px-3 py-1.5 bg-primary text-white rounded-md hover:bg-primarydark">
-                Publica ara
+              <Link href={`/promociona?eventId=${encodeURIComponent(slug)}`} className="inline-flex items-center px-3 py-1.5 bg-primary text-white rounded-md hover:bg-primarydark">
+                Configura la promoció
               </Link>
             </div>
           </div>

--- a/app/e/[eventId]/page.tsx
+++ b/app/e/[eventId]/page.tsx
@@ -17,6 +17,7 @@ import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import { fetchEvents } from "@lib/api/events";
 import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
+import FeaturedEventsSection from "@components/ui/featuredEvents/FeaturedEventsSection";
 
 // Helper: Metadata generation
 export async function generateMetadata(props: {
@@ -140,20 +141,7 @@ export default async function EventPage({
             <EventClient event={event} />
 
             {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && nearbyBusinesses.length >= 3 && (
-              <section className="w-full">
-                <div className="w-full flex justify-center items-start gap-2 px-4 mb-2">
-                  <h2>Empreses recomanades a prop</h2>
-                </div>
-                <PromoStripTracker events={nearbyBusinesses} placement="event_nearby" pageType="event" place={event.region?.slug}>
-                  <EventsAroundServer
-                    events={nearbyBusinesses}
-                    layout="horizontal"
-                    showJsonLd={false}
-                    title="Empreses recomanades a prop"
-                    nonce={nonce}
-                  />
-                </PromoStripTracker>
-              </section>
+              <FeaturedEventsSection title="Empreses recomanades a prop" place={event.region?.slug} placement="event_nearby" pageType="event" />
             )}
 
             {/* Related Events - Server-side rendered for SEO */}

--- a/app/e/[eventId]/page.tsx
+++ b/app/e/[eventId]/page.tsx
@@ -16,6 +16,7 @@ import AdArticle from "components/ui/adArticle";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import { fetchEvents } from "@lib/api/events";
+import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
 
 // Helper: Metadata generation
 export async function generateMetadata(props: {
@@ -143,13 +144,15 @@ export default async function EventPage({
                 <div className="w-full flex justify-center items-start gap-2 px-4 mb-2">
                   <h2>Empreses recomanades a prop</h2>
                 </div>
-                <EventsAroundServer
-                  events={nearbyBusinesses}
-                  layout="horizontal"
-                  showJsonLd={false}
-                  title="Empreses recomanades a prop"
-                  nonce={nonce}
-                />
+                <PromoStripTracker events={nearbyBusinesses} placement="event_nearby" pageType="event" place={event.region?.slug}>
+                  <EventsAroundServer
+                    events={nearbyBusinesses}
+                    layout="horizontal"
+                    showJsonLd={false}
+                    title="Empreses recomanades a prop"
+                    nonce={nonce}
+                  />
+                </PromoStripTracker>
               </section>
             )}
 

--- a/app/legal/avis-legal/page.tsx
+++ b/app/legal/avis-legal/page.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: "Avís legal | Esdeveniments.cat",
+  description: "Informació legal bàsica per a l'ús del lloc.",
+};
+
+export default function Page() {
+  return (
+    <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
+      <h1 className="uppercase mb-4">Avís legal</h1>
+      <p className="mb-4 text-sm text-blackCorp/80">
+        Pàgina provisional per a l'MVP. Aquest lloc web és propietat del titular corresponent. L'ús implica l'acceptació d'aquestes condicions.
+      </p>
+      <ul className="list-disc ml-5 text-sm text-blackCorp/80 space-y-1">
+        <li>Propietat intel·lectual: els continguts i marques són dels seus titulars.</li>
+        <li>Responsabilitat: no garantim la disponibilitat continuada del servei.</li>
+        <li>Contacte: facilita un correu de suport per qüestions legals i reclamacions.</li>
+      </ul>
+    </div>
+  );
+}

--- a/app/legal/condicions/page.tsx
+++ b/app/legal/condicions/page.tsx
@@ -1,0 +1,21 @@
+export const metadata = {
+  title: "Condicions de compra i promoció | Esdeveniments.cat",
+  description: "Condicions bàsiques per a la compra de promocions.",
+};
+
+export default function Page() {
+  return (
+    <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
+      <h1 className="uppercase mb-4">Condicions de compra i promoció</h1>
+      <p className="mb-4 text-sm text-blackCorp/80">
+        Aquesta és una pàgina provisional per a l'MVP. Les promocions estan subjectes a revisió i poden ser rebutjades si incompleixen les nostres polítiques.
+      </p>
+      <ul className="list-disc ml-5 text-sm text-blackCorp/80 space-y-1">
+        <li>No es garanteix l'aprovació immediata. Ens reservem el dret d'editar o rebutjar creatives.</li>
+        <li>No es permeten continguts il·lícits, ofensius, o que infringin drets de tercers.</li>
+        <li>Les promocions no afecten el posicionament SEO ni la informació orgànica de la web.</li>
+        <li>Els reemborsos s'estudiaran cas per cas en situacions justificades.</li>
+      </ul>
+    </div>
+  );
+}

--- a/app/legal/privacitat/page.tsx
+++ b/app/legal/privacitat/page.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: "Política de privacitat | Esdeveniments.cat",
+  description: "Informació bàsica sobre privacitat i tractament de dades.",
+};
+
+export default function Page() {
+  return (
+    <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
+      <h1 className="uppercase mb-4">Política de privacitat</h1>
+      <p className="mb-4 text-sm text-blackCorp/80">
+        Pàgina provisional per a l'MVP. Utilitzem dades mínimes per a la prestació del servei i analítica agregada. Les dades de pagament es processen via Stripe.
+      </p>
+      <ul className="list-disc ml-5 text-sm text-blackCorp/80 space-y-1">
+        <li>Correus i dades personals només s'utilitzen per a la gestió del servei i comunicacions necessàries.</li>
+        <li>Les dades de targeta no es guarden als nostres servidors. Stripe és el processador de pagaments.</li>
+        <li>Pots contactar-nos per exercir drets d'accés, rectificació i supressió.</li>
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -92,6 +92,19 @@ export default async function Page(): Promise<JSX.Element> {
         pageData={pageData}
         categories={categories}
       />
+
+      {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
+        <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
+          <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses destacades</h2>
+          <EventsAroundServer
+            events={featured}
+            layout="horizontal"
+            usePriority={false}
+            showJsonLd={false}
+            title="Empreses destacades"
+          />
+        </section>
+      )}
     </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import type { EventSummaryResponseDTO } from "types/api/event";
 import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
+import FeaturedEventsSection from "@components/ui/featuredEvents/FeaturedEventsSection";
 
 export async function generateMetadata() {
   const pageData: PageData = await generatePagesData({
@@ -95,18 +96,7 @@ export default async function Page(): Promise<JSX.Element> {
       />
 
       {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
-        <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
-          <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses destacades</h2>
-          <PromoStripTracker events={featured} placement="home_empreses" pageType="home">
-            <EventsAroundServer
-              events={featured}
-              layout="horizontal"
-              usePriority={false}
-              showJsonLd={false}
-              title="Empreses destacades"
-            />
-          </PromoStripTracker>
-        </section>
+        <FeaturedEventsSection title="Empreses destacades" placement="home_empreses" pageType="home" />
       )}
     </>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { Suspense, JSX } from "react";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 import type { EventSummaryResponseDTO } from "types/api/event";
+import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
 
 export async function generateMetadata() {
   const pageData: PageData = await generatePagesData({
@@ -96,13 +97,15 @@ export default async function Page(): Promise<JSX.Element> {
       {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
         <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
           <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses destacades</h2>
-          <EventsAroundServer
-            events={featured}
-            layout="horizontal"
-            usePriority={false}
-            showJsonLd={false}
-            title="Empreses destacades"
-          />
+          <PromoStripTracker events={featured} placement="home_empreses" pageType="home">
+            <EventsAroundServer
+              events={featured}
+              layout="horizontal"
+              usePriority={false}
+              showJsonLd={false}
+              title="Empreses destacades"
+            />
+          </PromoStripTracker>
         </section>
       )}
     </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { fetchCategorizedEvents } from "@lib/api/events";
+import { fetchCategorizedEvents, fetchEvents } from "@lib/api/events";
 import { fetchCategories } from "@lib/api/categories";
 import { generatePagesData } from "@components/partials/generatePagesData";
 import { buildPageMeta } from "@components/partials/seo-meta";
@@ -8,6 +8,9 @@ import type { CategorySummaryResponseDTO } from "types/api/category";
 import ServerEventsCategorized from "@components/ui/serverEventsCategorized";
 import Search from "@components/ui/search";
 import { Suspense, JSX } from "react";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
+import type { EventSummaryResponseDTO } from "types/api/event";
 
 export async function generateMetadata() {
   const pageData: PageData = await generatePagesData({
@@ -25,6 +28,18 @@ export async function generateMetadata() {
 export default async function Page(): Promise<JSX.Element> {
   // Always fetch categorized events (no URL filters support)
   const categorizedEvents: CategorizedEvents = await fetchCategorizedEvents(5);
+
+  // Optionally fetch featured/promoted events (simple placeholder source)
+  let featured: EventSummaryResponseDTO[] = [];
+  if (process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1") {
+    try {
+      const res = await fetchEvents({ page: 0, size: 6 });
+      featured = (res?.content || []).filter(isEventSummaryResponseDTO);
+    } catch (e) {
+      // Safe fallback – hide section on error
+      featured = [];
+    }
+  }
 
   // Fetch dynamic categories for enhanced category support
   let categories: CategorySummaryResponseDTO[] = [];
@@ -53,6 +68,24 @@ export default async function Page(): Promise<JSX.Element> {
           <Search />
         </Suspense>
       </div>
+
+      {process.env.NEXT_PUBLIC_FEATURE_PROMOTED === "1" && featured.length >= 3 && (
+        <section
+          aria-labelledby="featured-heading"
+          className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6"
+        >
+          <h2 id="featured-heading" className="uppercase mb-2 px-2 lg:px-0">
+            Destacats
+          </h2>
+          <EventsAroundServer
+            events={featured}
+            layout="horizontal"
+            usePriority
+            showJsonLd={false}
+            title="Destacats"
+          />
+        </section>
+      )}
 
       <ServerEventsCategorized
         categorizedEvents={categorizedEvents}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default async function Page(): Promise<JSX.Element> {
     try {
       const res = await fetchEvents({ page: 0, size: 6 });
       featured = (res?.content || []).filter(isEventSummaryResponseDTO);
-    } catch (e) {
+    } catch {
       // Safe fallback – hide section on error
       featured = [];
     }

--- a/app/promociona/checkout/route.ts
+++ b/app/promociona/checkout/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import {
+  PROMOTE_PRICING,
+  PROMOTE_PLACEMENT_MULTIPLIER,
+} from "@utils/constants";
+
+function getOrigin(request: Request): string {
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const params = url.searchParams;
+
+  const kind = params.get("kind") || "business";
+  const scope = params.get("scope") || "ciutat"; // zona|ciutat|pais
+  const days = Number(params.get("days") || 7);
+  const placement = params.get("placement") || "global";
+  const place = params.get("place") || "catalunya";
+  const eventId = params.get("eventId") || undefined;
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    // Safe fallback: go back to the page with an error flag
+    const back = `${getOrigin(request)}/promociona?${params.toString()}&stripe=missing`;
+    return NextResponse.redirect(back, { status: 302 });
+  }
+
+  // Compute amount (EUR cents) based on constants
+  const base = PROMOTE_PRICING[scope as keyof typeof PROMOTE_PRICING]?.[days as keyof (typeof PROMOTE_PRICING)["zona"]] || 0;
+  const multiplier = PROMOTE_PLACEMENT_MULTIPLIER[placement] ?? 1;
+  const amount = Math.max(1, Math.round(base * multiplier * 100));
+
+  const stripe = new Stripe(secretKey, { apiVersion: "2024-06-20" } as Stripe.StripeConfig);
+
+  const successUrl = `${getOrigin(request)}/promociona/success?session_id={CHECKOUT_SESSION_ID}&${params.toString()}`;
+  const cancelUrl = `${getOrigin(request)}/promociona?${params.toString()}&canceled=1`;
+
+  const productName = kind === "business" ? "Promoció negoci" : "Promoció esdeveniment";
+  const description = `${productName} · ${scope} · ${days} dies · ${placement} · ${place}`;
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    currency: "eur",
+    payment_method_types: ["card"],
+    line_items: [
+      {
+        price_data: {
+          currency: "eur",
+          unit_amount: amount,
+          product_data: {
+            name: productName,
+            description,
+          },
+        },
+        quantity: 1,
+      },
+    ],
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      kind,
+      scope,
+      days: String(days),
+      placement,
+      place,
+      eventId: eventId || "",
+    },
+  });
+
+  if (!session.url) {
+    return NextResponse.redirect(cancelUrl, { status: 302 });
+  }
+
+  return NextResponse.redirect(session.url, { status: 303 });
+}

--- a/app/promociona/cta-client.tsx
+++ b/app/promociona/cta-client.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { sendGoogleEvent } from "@utils/analytics";
+
+export default function PromoCheckoutCTA({
+  href,
+  kind,
+  price,
+}: {
+  href: string;
+  kind: string;
+  price: number;
+}) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primarydark"
+      prefetch={false}
+      onClick={() => {
+        try {
+          sendGoogleEvent("begin_checkout", {
+            kind,
+            price_eur: price,
+          });
+        } catch (_) {
+          // ignore analytics errors
+        }
+      }}
+    >
+      Continuar
+    </Link>
+  );
+}

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -11,6 +11,7 @@ import type { Metadata } from "next";
 import ClientBusinessUpload from "./upload-client";
 import PlaceSelector from "./place-client";
 import { fetchRegions } from "@lib/api/regions";
+import PromoCheckoutCTA from "./cta-client";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -94,6 +95,11 @@ export default async function Page({
 
   return (
     <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
+      {process.env.STRIPE_SECRET_KEY ? null : (
+        <div className="w-full mb-4 rounded-md border border-yellow-300 bg-yellow-50 text-yellow-900 px-3 py-2 text-sm">
+          Pagament de prova deshabilitat: manca STRIPE_SECRET_KEY. Pots configurar-lo a les variables d'entorn i tornar a provar.
+        </div>
+      )}
       <nav aria-label="Breadcrumb" className="mb-3 text-sm text-blackCorp/70">
         <ol className="flex items-center space-x-2">
           <li>
@@ -217,14 +223,21 @@ export default async function Page({
         </ul>
         <div className="mt-4 flex items-center justify-between">
           <span className="text-2xl font-semibold">{price.toFixed(2)} €</span>
-          <Link
-            href={kind === "business" ? toCheckoutUrl() : toPublicaUrl()}
-            className="inline-flex items-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primarydark"
-            prefetch={false}
-          >
-            Continuar
-          </Link>
+          {kind === "business" ? (
+            <PromoCheckoutCTA href={toCheckoutUrl()} kind={kind} price={price} />
+          ) : (
+            <Link
+              href={toPublicaUrl()}
+              className="inline-flex items-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primarydark"
+              prefetch={false}
+            >
+              Continuar
+            </Link>
+          )}
         </div>
+        <p className="mt-2 text-xs text-blackCorp/60">
+          El pagament és processat per Stripe. Rebràs un rebut al teu correu.
+        </p>
       </section>
     </div>
   );

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -100,6 +100,25 @@ export default async function Page({
           Pagament de prova deshabilitat: manca STRIPE_SECRET_KEY. Pots configurar-lo a les variables d'entorn i tornar a provar.
         </div>
       )}
+      {/* Query banners */}
+      {(() => {
+        const q = new URLSearchParams(params as any);
+        if (q.get("canceled") === "1") {
+          return (
+            <div className="w-full mb-4 rounded-md border border-gray-300 bg-gray-50 text-gray-900 px-3 py-2 text-sm">
+              Pagament cancel·lat. Pots revisar les opcions i tornar-ho a intentar.
+            </div>
+          );
+        }
+        if (q.get("stripe") === "missing") {
+          return (
+            <div className="w-full mb-4 rounded-md border border-yellow-300 bg-yellow-50 text-yellow-900 px-3 py-2 text-sm">
+              No s'ha pogut iniciar el pagament: falta la configuració de Stripe.
+            </div>
+          );
+        }
+        return null;
+      })()}
       <nav aria-label="Breadcrumb" className="mb-3 text-sm text-blackCorp/70">
         <ol className="flex items-center space-x-2">
           <li>
@@ -235,9 +254,10 @@ export default async function Page({
             </Link>
           )}
         </div>
-        <p className="mt-2 text-xs text-blackCorp/60">
-          El pagament és processat per Stripe. Rebràs un rebut al teu correu.
-        </p>
+        <div className="mt-2 flex items-center justify-between text-xs text-blackCorp/60">
+          <p>El pagament és processat per Stripe. Rebràs un rebut al teu correu.</p>
+          <Link href="/legal/condicions" className="underline">Consulta condicions</Link>
+        </div>
       </section>
     </div>
   );

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -1,6 +1,19 @@
 import Link from "next/link";
-import { PROMOTE_DURATIONS, PROMOTE_PRICING, PROMOTE_VISIBILITY } from "@utils/constants";
+import {
+  PROMOTE_DURATIONS,
+  PROMOTE_PRICING,
+  PROMOTE_VISIBILITY,
+  PROMOTE_KINDS,
+  PROMOTE_PLACEMENTS,
+  PROMOTE_PLACEMENT_MULTIPLIER,
+} from "@utils/constants";
 import type { Metadata } from "next";
+import dynamic from "next/dynamic";
+
+const ClientBusinessUpload = dynamic(() => import("./upload-client"), {
+  ssr: false,
+  loading: () => null,
+});
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -23,16 +36,29 @@ export default async function Page({
 
   const rawScope = typeof params.scope === "string" ? params.scope : undefined;
   const rawDays = typeof params.days === "string" ? parseInt(params.days, 10) : undefined;
+  const rawKind = typeof params.kind === "string" ? params.kind : undefined;
+  const rawPlacement = typeof params.placement === "string" ? params.placement : undefined;
   const eventId = typeof params.eventId === "string" ? params.eventId : undefined;
 
   const scope = getSelected(rawScope, "ciutat", PROMOTE_VISIBILITY as unknown as string[]);
   const days = getSelected(rawDays, 7, PROMOTE_DURATIONS as unknown as number[]);
-  const price = PROMOTE_PRICING[scope]?.[days] ?? 0;
+  const kind = getSelected(rawKind, "event", PROMOTE_KINDS as unknown as string[]);
+  const placement = getSelected(
+    rawPlacement,
+    "global",
+    PROMOTE_PLACEMENTS as unknown as string[]
+  );
 
-  const buildUrl = (nextScope: string, nextDays: number) => {
+  const basePrice = PROMOTE_PRICING[scope]?.[days] ?? 0;
+  const multiplier = PROMOTE_PLACEMENT_MULTIPLIER[placement] ?? 1;
+  const price = Math.max(0, basePrice * multiplier);
+
+  const buildUrl = (next: Partial<Record<string, string | number>>) => {
     const sp = new URLSearchParams();
-    sp.set("scope", nextScope);
-    sp.set("days", String(nextDays));
+    sp.set("scope", (next.scope as string) || scope);
+    sp.set("days", String((next.days as number) || days));
+    sp.set("kind", (next.kind as string) || kind);
+    sp.set("placement", (next.placement as string) || placement);
     if (eventId) sp.set("eventId", eventId);
     return `/promociona?${sp.toString()}`;
   };
@@ -42,6 +68,8 @@ export default async function Page({
     sp.set("promote", "1");
     sp.set("scope", scope);
     sp.set("days", String(days));
+    sp.set("kind", kind);
+    sp.set("placement", placement);
     if (eventId) sp.set("eventId", eventId);
     return `/publica?${sp.toString()}`;
   };
@@ -62,9 +90,29 @@ export default async function Page({
         </ol>
       </nav>
 
-      <h1 className="uppercase mb-4">Promociona el teu esdeveniment</h1>
+      <h1 className="uppercase mb-4">Promociona</h1>
 
       <div className="grid gap-6 md:grid-cols-2">
+        <section className="bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+          <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
+            Tipus
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {PROMOTE_KINDS.map((k) => (
+              <Link
+                key={k as string}
+                href={buildUrl({ kind: k as string })}
+                className={`px-4 py-2 rounded-full border ${
+                  kind === k ? "bg-primary text-white border-primary" : "bg-whiteCorp border-darkCorp/20"
+                }`}
+                prefetch={false}
+              >
+                {k === "event" ? "Esdeveniment" : "Negoci"}
+              </Link>
+            ))}
+          </div>
+        </section>
+
         <section className="bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
           <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
             Àrea de visibilitat
@@ -73,7 +121,7 @@ export default async function Page({
             {PROMOTE_VISIBILITY.map((opt) => (
               <Link
                 key={opt}
-                href={buildUrl(opt as string, days)}
+                href={buildUrl({ scope: opt as string })}
                 className={`px-4 py-2 rounded-full border ${
                   scope === opt ? "bg-primary text-white border-primary" : "bg-whiteCorp border-darkCorp/20"
                 }`}
@@ -93,7 +141,7 @@ export default async function Page({
             {PROMOTE_DURATIONS.map((d) => (
               <Link
                 key={d}
-                href={buildUrl(scope, d)}
+                href={buildUrl({ days: d })}
                 className={`px-4 py-2 rounded-full border ${
                   days === d ? "bg-primary text-white border-primary" : "bg-whiteCorp border-darkCorp/20"
                 }`}
@@ -104,15 +152,48 @@ export default async function Page({
             ))}
           </div>
         </section>
+
+        <section className="bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+          <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
+            Ubicació de la impressió
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {PROMOTE_PLACEMENTS.map((p) => (
+              <Link
+                key={p as string}
+                href={buildUrl({ placement: p as string })}
+                className={`px-4 py-2 rounded-full border ${
+                  placement === p
+                    ? "bg-primary text-white border-primary"
+                    : "bg-whiteCorp border-darkCorp/20"
+                }`}
+                prefetch={false}
+              >
+                {p === "global" ? "Global (home + llistes)" : p === "category" ? "Només categoria" : "Newsletter"}
+              </Link>
+            ))}
+          </div>
+        </section>
       </div>
+
+      {kind === "business" && (
+        <section className="mt-6 bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+          <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
+            Creativitats (MVP)
+          </h2>
+          <ClientBusinessUpload />
+        </section>
+      )}
 
       <section className="mt-6 bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
         <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
           Resum
         </h2>
         <ul className="list-disc ml-5 text-sm text-blackCorp/80 space-y-1">
-          <li>Àrea seleccionada: {scope === "zona" ? "Zona" : scope === "ciutat" ? "Ciutat" : "País"}</li>
+          <li>Tipus: {kind === "event" ? "Esdeveniment" : "Negoci"}</li>
+          <li>Àrea: {scope === "zona" ? "Zona" : scope === "ciutat" ? "Ciutat" : "País"}</li>
           <li>Durada: {days} dies</li>
+          <li>Ubicació: {placement === "global" ? "Global (home + llistes)" : placement === "category" ? "Només categoria" : "Newsletter"}</li>
           <li>On es mostra: pàgina principal, llistes i pàgines de lloc segons l&apos;àrea</li>
         </ul>
         <div className="mt-4 flex items-center justify-between">

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -8,12 +8,7 @@ import {
   PROMOTE_PLACEMENT_MULTIPLIER,
 } from "@utils/constants";
 import type { Metadata } from "next";
-import dynamic from "next/dynamic";
-
-const ClientBusinessUpload = dynamic(() => import("./upload-client"), {
-  ssr: false,
-  loading: () => null,
-});
+import ClientBusinessUpload from "./upload-client";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -75,6 +75,17 @@ export default async function Page({
     return `/publica?${sp.toString()}`;
   };
 
+  const toCheckoutUrl = () => {
+    const sp = new URLSearchParams();
+    sp.set("scope", scope);
+    sp.set("days", String(days));
+    sp.set("kind", kind);
+    sp.set("placement", placement);
+    sp.set("place", place);
+    if (eventId) sp.set("eventId", eventId);
+    return `/promociona/checkout?${sp.toString()}`;
+  };
+
   // Build region name -> slug mapping for client place selector
   const regions = await fetchRegions();
   const regionSlugByName = Object.fromEntries(
@@ -207,7 +218,7 @@ export default async function Page({
         <div className="mt-4 flex items-center justify-between">
           <span className="text-2xl font-semibold">{price.toFixed(2)} €</span>
           <Link
-            href={toPublicaUrl()}
+            href={kind === "business" ? toCheckoutUrl() : toPublicaUrl()}
             className="inline-flex items-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primarydark"
             prefetch={false}
           >

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { headers } from "next/headers";
 import { PROMOTE_DURATIONS, PROMOTE_PRICING, PROMOTE_VISIBILITY } from "@utils/constants";
 import type { Metadata } from "next";
 
@@ -29,9 +28,6 @@ export default async function Page({
   const scope = getSelected(rawScope, "ciutat", PROMOTE_VISIBILITY as unknown as string[]);
   const days = getSelected(rawDays, 7, PROMOTE_DURATIONS as unknown as number[]);
   const price = PROMOTE_PRICING[scope]?.[days] ?? 0;
-
-  const headersList = await headers();
-  const nonce = headersList.get("x-nonce") || "";
 
   const buildUrl = (nextScope: string, nextDays: number) => {
     const sp = new URLSearchParams();
@@ -117,7 +113,7 @@ export default async function Page({
         <ul className="list-disc ml-5 text-sm text-blackCorp/80 space-y-1">
           <li>Àrea seleccionada: {scope === "zona" ? "Zona" : scope === "ciutat" ? "Ciutat" : "País"}</li>
           <li>Durada: {days} dies</li>
-          <li>On es mostra: pàgina principal, llistes i pàgines de lloc segons l'àrea</li>
+          <li>On es mostra: pàgina principal, llistes i pàgines de lloc segons l&apos;àrea</li>
         </ul>
         <div className="mt-4 flex items-center justify-between">
           <span className="text-2xl font-semibold">{price.toFixed(2)} €</span>

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -134,7 +134,7 @@ export default async function Page({
                 }`}
                 prefetch={false}
               >
-                {opt === "zona" ? "Zona" : opt === "ciutat" ? "Ciutat" : "País"}
+                {opt === "zona" ? "Regió" : opt === "ciutat" ? "Ciutat" : "País (tot Catalunya)"}
               </Link>
             ))}
           </div>
@@ -178,6 +178,8 @@ export default async function Page({
           <PlaceSelector
             currentParams={{ scope, days, kind, placement, eventId, place }}
             regionSlugByName={regionSlugByName}
+            scope={scope}
+            place={place}
           />
         </section>
       </div>

--- a/app/promociona/page.tsx
+++ b/app/promociona/page.tsx
@@ -1,0 +1,135 @@
+import Link from "next/link";
+import { headers } from "next/headers";
+import { PROMOTE_DURATIONS, PROMOTE_PRICING, PROMOTE_VISIBILITY } from "@utils/constants";
+import type { Metadata } from "next";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Promociona el teu esdeveniment | Esdeveniments.cat",
+    description:
+      "Tria l'àrea de visibilitat i la durada per destacar el teu esdeveniment. MVP sense pagament: redirigim a publica.",
+  } as Metadata;
+}
+
+function getSelected<T>(value: T | undefined, fallback: T, allowed: readonly T[]): T {
+  return allowed.includes(value as T) ? (value as T) : fallback;
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = (await searchParams) || {};
+
+  const rawScope = typeof params.scope === "string" ? params.scope : undefined;
+  const rawDays = typeof params.days === "string" ? parseInt(params.days, 10) : undefined;
+  const eventId = typeof params.eventId === "string" ? params.eventId : undefined;
+
+  const scope = getSelected(rawScope, "ciutat", PROMOTE_VISIBILITY as unknown as string[]);
+  const days = getSelected(rawDays, 7, PROMOTE_DURATIONS as unknown as number[]);
+  const price = PROMOTE_PRICING[scope]?.[days] ?? 0;
+
+  const headersList = await headers();
+  const nonce = headersList.get("x-nonce") || "";
+
+  const buildUrl = (nextScope: string, nextDays: number) => {
+    const sp = new URLSearchParams();
+    sp.set("scope", nextScope);
+    sp.set("days", String(nextDays));
+    if (eventId) sp.set("eventId", eventId);
+    return `/promociona?${sp.toString()}`;
+  };
+
+  const toPublicaUrl = () => {
+    const sp = new URLSearchParams();
+    sp.set("promote", "1");
+    sp.set("scope", scope);
+    sp.set("days", String(days));
+    if (eventId) sp.set("eventId", eventId);
+    return `/publica?${sp.toString()}`;
+  };
+
+  return (
+    <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
+      <nav aria-label="Breadcrumb" className="mb-3 text-sm text-blackCorp/70">
+        <ol className="flex items-center space-x-2">
+          <li>
+            <Link href="/" className="hover:underline">
+              Inici
+            </Link>
+          </li>
+          <li>
+            <span className="mx-1">/</span>
+          </li>
+          <li className="text-blackCorp">Promociona</li>
+        </ol>
+      </nav>
+
+      <h1 className="uppercase mb-4">Promociona el teu esdeveniment</h1>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <section className="bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+          <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
+            Àrea de visibilitat
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {PROMOTE_VISIBILITY.map((opt) => (
+              <Link
+                key={opt}
+                href={buildUrl(opt as string, days)}
+                className={`px-4 py-2 rounded-full border ${
+                  scope === opt ? "bg-primary text-white border-primary" : "bg-whiteCorp border-darkCorp/20"
+                }`}
+                prefetch={false}
+              >
+                {opt === "zona" ? "Zona" : opt === "ciutat" ? "Ciutat" : "País"}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+          <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
+            Durada
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {PROMOTE_DURATIONS.map((d) => (
+              <Link
+                key={d}
+                href={buildUrl(scope, d)}
+                className={`px-4 py-2 rounded-full border ${
+                  days === d ? "bg-primary text-white border-primary" : "bg-whiteCorp border-darkCorp/20"
+                }`}
+                prefetch={false}
+              >
+                {d} dies
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="mt-6 bg-whiteCorp border border-darkCorp/10 rounded-lg p-4">
+        <h2 className="text-base font-semibold uppercase tracking-wide mb-3">
+          Resum
+        </h2>
+        <ul className="list-disc ml-5 text-sm text-blackCorp/80 space-y-1">
+          <li>Àrea seleccionada: {scope === "zona" ? "Zona" : scope === "ciutat" ? "Ciutat" : "País"}</li>
+          <li>Durada: {days} dies</li>
+          <li>On es mostra: pàgina principal, llistes i pàgines de lloc segons l'àrea</li>
+        </ul>
+        <div className="mt-4 flex items-center justify-between">
+          <span className="text-2xl font-semibold">{price.toFixed(2)} €</span>
+          <Link
+            href={toPublicaUrl()}
+            className="inline-flex items-center px-4 py-2 bg-primary text-white rounded-md hover:bg-primarydark"
+            prefetch={false}
+          >
+            Continuar
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/promociona/place-client.tsx
+++ b/app/promociona/place-client.tsx
@@ -64,7 +64,6 @@ export default function PlaceSelector({ currentParams, regionSlugByName, scope, 
 
   const isScopeNational = scope === "pais";
   const isScopeRegion = scope === "zona"; // Rename suggestion in server page will reflect to UX; keep key for now
-  const isScopeCity = scope === "ciutat";
 
   return (
     <div className="space-y-3">

--- a/app/promociona/place-client.tsx
+++ b/app/promociona/place-client.tsx
@@ -16,7 +16,7 @@ export default function PlaceSelector({ currentParams, regionSlugByName, scope, 
   // Initialize selection from current place when available
   useEffect(() => {
     if (!regionsWithCities || !place || place === "catalunya") return;
-    const regionMatch = regionsWithCities.find((r) => r.slug === place || regionSlugByName[r.name] === place);
+    const regionMatch = regionsWithCities.find((r) => regionSlugByName[r.name] === place);
     if (regionMatch) {
       setRegion({ label: regionMatch.name, value: String(regionMatch.id) });
       setCity(null);

--- a/app/promociona/place-client.tsx
+++ b/app/promociona/place-client.tsx
@@ -5,13 +5,9 @@ import Select from "@components/ui/common/form/select";
 import { useGetRegionsWithCities } from "@components/hooks/useGetRegionsWithCities";
 import { Option } from "types/common";
 import { useRouter } from "next/navigation";
+import type { PromocionaPlaceSelectorProps } from "types/props";
 
-type PlaceClientProps = {
-  currentParams: Record<string, string | number | undefined>;
-  regionSlugByName: Record<string, string>;
-};
-
-export default function PlaceSelector({ currentParams, regionSlugByName }: PlaceClientProps) {
+export default function PlaceSelector({ currentParams, regionSlugByName }: PromocionaPlaceSelectorProps) {
   const router = useRouter();
   const { regionsWithCities } = useGetRegionsWithCities();
   const [region, setRegion] = useState<Option | null>(null);
@@ -50,8 +46,6 @@ export default function PlaceSelector({ currentParams, regionSlugByName }: Place
   const onCityChange = (opt: Option | null) => {
     setCity(opt);
     if (!opt) return;
-    // We don't have city slugs from this hook, so fallback to label sanitize is not ideal; rely on backend later.
-    // For MVP, use opt.label lowercased without spaces; backend contract will provide real slugs later.
     const citySlug = opt.label.toLowerCase().replace(/\s+/g, "-");
     navigateWithPlace(citySlug);
   };

--- a/app/promociona/place-client.tsx
+++ b/app/promociona/place-client.tsx
@@ -6,10 +6,10 @@ import { useGetRegionsWithCities } from "@components/hooks/useGetRegionsWithCiti
 import { Option } from "types/common";
 import { useRouter } from "next/navigation";
 
-interface PlaceClientProps {
+type PlaceClientProps = {
   currentParams: Record<string, string | number | undefined>;
   regionSlugByName: Record<string, string>;
-}
+};
 
 export default function PlaceSelector({ currentParams, regionSlugByName }: PlaceClientProps) {
   const router = useRouter();

--- a/app/promociona/place-client.tsx
+++ b/app/promociona/place-client.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Select from "@components/ui/common/form/select";
+import { useGetRegionsWithCities } from "@components/hooks/useGetRegionsWithCities";
+import { Option } from "types/common";
+import { useRouter } from "next/navigation";
+
+interface PlaceClientProps {
+  currentParams: Record<string, string | number | undefined>;
+  regionSlugByName: Record<string, string>;
+}
+
+export default function PlaceSelector({ currentParams, regionSlugByName }: PlaceClientProps) {
+  const router = useRouter();
+  const { regionsWithCities } = useGetRegionsWithCities();
+  const [region, setRegion] = useState<Option | null>(null);
+  const [city, setCity] = useState<Option | null>(null);
+
+  const regionOptions: Option[] = useMemo(
+    () =>
+      (regionsWithCities || []).map((r) => ({ label: r.name, value: String(r.id) })),
+    [regionsWithCities]
+  );
+
+  const cityOptions: Option[] = useMemo(() => {
+    if (!regionsWithCities || !region) return [];
+    const r = regionsWithCities.find((rr) => String(rr.id) === (region?.value as string));
+    return r ? r.cities.map((c) => ({ label: c.label, value: String(c.id) })) : [];
+  }, [regionsWithCities, region]);
+
+  const navigateWithPlace = (placeSlug: string) => {
+    const sp = new URLSearchParams();
+    Object.entries(currentParams).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) sp.set(k, String(v));
+    });
+    sp.set("place", placeSlug);
+    router.push(`/promociona?${sp.toString()}`);
+  };
+
+  const onRegionChange = (opt: Option | null) => {
+    setRegion(opt);
+    setCity(null);
+    if (opt) {
+      const slug = regionSlugByName[opt.label] || "catalunya";
+      navigateWithPlace(slug);
+    }
+  };
+
+  const onCityChange = (opt: Option | null) => {
+    setCity(opt);
+    if (!opt) return;
+    // We don't have city slugs from this hook, so fallback to label sanitize is not ideal; rely on backend later.
+    // For MVP, use opt.label lowercased without spaces; backend contract will provide real slugs later.
+    const citySlug = opt.label.toLowerCase().replace(/\s+/g, "-");
+    navigateWithPlace(citySlug);
+  };
+
+  return (
+    <div className="space-y-3">
+      <Select
+        id="promo-region"
+        title="Regió"
+        value={region}
+        onChange={onRegionChange}
+        options={regionOptions}
+        isClearable
+        placeholder="Tria una regió"
+      />
+      <Select
+        id="promo-city"
+        title="Ciutat"
+        value={city}
+        onChange={onCityChange}
+        options={cityOptions}
+        isClearable
+        placeholder="Tria una ciutat"
+      />
+    </div>
+  );
+}

--- a/app/promociona/success/page.tsx
+++ b/app/promociona/success/page.tsx
@@ -1,6 +1,16 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect } from "react";
+import { sendGoogleEvent } from "@utils/analytics";
 
 export default function SuccessPage() {
+  useEffect(() => {
+    try {
+      sendGoogleEvent("checkout_success", {});
+    } catch (_) {}
+  }, []);
+
   return (
     <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
       <h1 className="uppercase mb-4">Pagament completat</h1>

--- a/app/promociona/success/page.tsx
+++ b/app/promociona/success/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function SuccessPage() {
+  return (
+    <div className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-28 px-2 lg:px-0">
+      <h1 className="uppercase mb-4">Pagament completat</h1>
+      <p className="mb-6">Gràcies! Hem rebut la teva comanda de promoció. Ens posarem en contacte si cal informació addicional.</p>
+      <div className="flex gap-4">
+        <Link href="/" className="text-primary underline">Tornar a l'inici</Link>
+        <Link href="/promociona" className="text-primary underline">Configurar una altra promoció</Link>
+      </div>
+    </div>
+  );
+}

--- a/app/promociona/upload-client.tsx
+++ b/app/promociona/upload-client.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import ImageUploader from "@components/ui/common/form/imageUpload";
+
+export default function ClientBusinessUpload(): JSX.Element {
+  const [file, setFile] = useState<File | null>(null);
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-blackCorp/70">
+        Carrega una imatge o banner (JPG, PNG, WEBP fins a 5MB). Només previsualització al MVP.
+      </p>
+      <div className="max-w-md">
+        <ImageUploader
+          value={null}
+          onUpload={(f) => setFile(f)}
+          progress={0}
+        />
+      </div>
+      {file && (
+        <p className="text-xs text-blackCorp/60">Fitxer seleccionat: {file.name}</p>
+      )}
+    </div>
+  );
+}

--- a/app/promociona/upload-client.tsx
+++ b/app/promociona/upload-client.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import ImageUploader from "@components/ui/common/form/imageUpload";
 
-export default function ClientBusinessUpload(): JSX.Element {
+export default function ClientBusinessUpload() {
   const [file, setFile] = useState<File | null>(null);
 
   return (

--- a/components/ui/featuredEvents/FeaturedEventsSection.tsx
+++ b/components/ui/featuredEvents/FeaturedEventsSection.tsx
@@ -1,0 +1,36 @@
+import { fetchFeaturedEvents, MIN_FEATURED_EVENTS_TO_DISPLAY } from "@lib/api/featured";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
+
+export default async function FeaturedEventsSection({
+  title = "Destacats",
+  place,
+  category,
+  placement = "generic",
+  pageType = "home",
+}: {
+  title?: string;
+  place?: string;
+  category?: string;
+  placement?: string;
+  pageType?: "home" | "place" | "event" | "news";
+}) {
+  if (process.env.NEXT_PUBLIC_FEATURE_PROMOTED !== "1") return null;
+  const featured = await fetchFeaturedEvents({ place, category });
+  if (!featured || featured.length < MIN_FEATURED_EVENTS_TO_DISPLAY) return null;
+
+  return (
+    <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
+      <h2 className="uppercase mb-2 px-2 lg:px-0">{title}</h2>
+      <PromoStripTracker events={featured} placement={placement} pageType={pageType} place={place} category={category}>
+        <EventsAroundServer
+          events={featured}
+          layout="horizontal"
+          usePriority
+          showJsonLd={false}
+          title={title}
+        />
+      </PromoStripTracker>
+    </section>
+  );
+}

--- a/components/ui/promotions/PromoStripTracker.tsx
+++ b/components/ui/promotions/PromoStripTracker.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { sendGoogleEvent } from "@utils/analytics";
+import type { EventSummaryResponseDTO } from "types/api/event";
+
+type Props = {
+  events: EventSummaryResponseDTO[];
+  placement: string; // e.g., home_empreses, place_bottom, event_nearby
+  pageType: string; // home | place | event | news
+  place?: string;
+  category?: string;
+  children: React.ReactNode;
+};
+
+export default function PromoStripTracker({
+  events,
+  placement,
+  pageType,
+  place,
+  category,
+  children,
+}: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const impressionSentRef = useRef(false);
+
+  useEffect(() => {
+    if (!ref.current || impressionSentRef.current) return;
+    const el = ref.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && !impressionSentRef.current) {
+          try {
+            sendGoogleEvent("promoted.strip_impression", {
+              placement,
+              pageType,
+              place,
+              category,
+              items: events.slice(0, 10).map((e, idx) => ({ id: e.id, slug: e.slug, position: idx + 1 })),
+            });
+          } catch (_) {}
+          impressionSentRef.current = true;
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [placement, pageType, place, category, events]);
+
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    const anchor = target.closest && target.closest("a");
+    if (!anchor) return;
+    try {
+      const href = (anchor as HTMLAnchorElement).getAttribute("href") || "";
+      const match = href.match(/\/e\/(.+)$/);
+      const slug = match ? match[1] : undefined;
+      const idx = slug ? events.findIndex((ev) => ev.slug === slug) : -1;
+      sendGoogleEvent("promoted.item_click", {
+        placement,
+        pageType,
+        place,
+        category,
+        slug,
+        position: idx >= 0 ? idx + 1 : undefined,
+      });
+    } catch (_) {}
+  };
+
+  return (
+    <div ref={ref} onClick={onClick} data-placement={placement}>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/serverEventsCategorized/index.tsx
+++ b/components/ui/serverEventsCategorized/index.tsx
@@ -12,6 +12,7 @@ import { ListEvent, EventSummaryResponseDTO } from "types/api/event";
 import NoEventsFound from "@components/ui/common/noEventsFound";
 import { ServerEventsCategorizedProps } from "types/props";
 import { fetchEvents } from "@lib/api/events";
+import PromoStripTracker from "@components/ui/promotions/PromoStripTracker";
 
 async function getPromotedBusinesses(): Promise<EventSummaryResponseDTO[]> {
   if (process.env.NEXT_PUBLIC_FEATURE_PROMOTED !== "1") return [];
@@ -186,13 +187,15 @@ async function PromotedBusinessesSection() {
   return (
     <section className="w-full flex-col justify-center items-center sm:w-[580px] md:w-[768px] lg:w-[1024px] mt-6">
       <h2 className="uppercase mb-2 px-2 lg:px-0">Empreses destacades</h2>
-      <EventsAroundServer
-        events={items}
-        layout="horizontal"
-        usePriority
-        showJsonLd={false}
-        title="Empreses destacades"
-      />
+      <PromoStripTracker events={items} placement="home_above_categories" pageType="home">
+        <EventsAroundServer
+          events={items}
+          layout="horizontal"
+          usePriority
+          showJsonLd={false}
+          title="Empreses destacades"
+        />
+      </PromoStripTracker>
     </section>
   );
 }

--- a/lib/api/featured.ts
+++ b/lib/api/featured.ts
@@ -1,0 +1,42 @@
+import { fetchEvents } from "@lib/api/events";
+import type { EventSummaryResponseDTO, PagedResponseDTO } from "types/api/event";
+import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
+
+export const FEATURED_EVENTS_FETCH_SIZE = 6;
+export const MIN_FEATURED_EVENTS_TO_DISPLAY = 3;
+
+export async function fetchFeaturedEvents(params: {
+  place?: string;
+  category?: string;
+  size?: number;
+}): Promise<EventSummaryResponseDTO[]> {
+  if (process.env.NEXT_PUBLIC_FEATURE_PROMOTED !== "1") {
+    return [];
+  }
+  const size = params.size ?? FEATURED_EVENTS_FETCH_SIZE;
+  try {
+    const primary = await fetchEvents({ page: 0, size, place: params.place, category: params.category });
+    let items: EventSummaryResponseDTO[] = (primary?.content || []).filter(isEventSummaryResponseDTO);
+
+    if (items.length >= MIN_FEATURED_EVENTS_TO_DISPLAY) return items;
+
+    // Fallback 1: drop category if present
+    if (params.category) {
+      const res = await fetchEvents({ page: 0, size, place: params.place });
+      items = (res?.content || []).filter(isEventSummaryResponseDTO);
+      if (items.length >= MIN_FEATURED_EVENTS_TO_DISPLAY) return items;
+    }
+
+    // Fallback 2: drop place if present
+    if (params.place) {
+      const res = await fetchEvents({ page: 0, size });
+      items = (res?.content || []).filter(isEventSummaryResponseDTO);
+      if (items.length >= MIN_FEATURED_EVENTS_TO_DISPLAY) return items;
+    }
+
+    return items;
+  } catch (e) {
+    console.error("Failed to fetch featured events:", e);
+    return [];
+  }
+}

--- a/types/props.ts
+++ b/types/props.ts
@@ -265,6 +265,8 @@ export interface NavigationFiltersModalProps {
 export interface PromocionaPlaceSelectorProps {
   currentParams: Record<string, string | number | undefined>;
   regionSlugByName: Record<string, string>;
+  scope: string;
+  place?: string;
 }
 
 export interface HybridEventsListProps {

--- a/types/props.ts
+++ b/types/props.ts
@@ -261,6 +261,12 @@ export interface NavigationFiltersModalProps {
   categories?: CategorySummaryResponseDTO[];
 }
 
+// Props for promociona place selector (MVP)
+export interface PromocionaPlaceSelectorProps {
+  currentParams: Record<string, string | number | undefined>;
+  regionSlugByName: Record<string, string>;
+}
+
 export interface HybridEventsListProps {
   initialEvents: ListEvent[];
   placeTypeLabel?: PlaceTypeAndLabel;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -172,3 +172,10 @@ export const PROMOTE_PRICING: Record<string, Record<number, number>> = {
   ciutat: { 2: 1.49, 7: 2.49, 15: 3.99 },
   pais: { 2: 2.49, 7: 4.99, 15: 7.99 },
 };
+export const PROMOTE_KINDS = ["event", "business"] as const; // MVP types
+export const PROMOTE_PLACEMENTS = ["global", "category", "newsletter"] as const; // where to appear
+export const PROMOTE_PLACEMENT_MULTIPLIER: Record<string, number> = {
+  global: 1.0, // home + lists + place pages
+  category: 0.6, // only category pages
+  newsletter: 0.8, // newsletter mention (future)
+};

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -163,3 +163,12 @@ export function getCategoryDisplayName(
   // Fallback to static mapping
   return CATEGORY_NAMES_MAP[categorySlug as CategoryValue] || categorySlug;
 }
+
+// Promotion MVP constants (frontend-only; backend will own logic later)
+export const PROMOTE_VISIBILITY = ["zona", "ciutat", "pais"] as const;
+export const PROMOTE_DURATIONS = [2, 7, 15] as const;
+export const PROMOTE_PRICING: Record<string, Record<number, number>> = {
+  zona: { 2: 0.99, 7: 1.25, 15: 1.99 },
+  ciutat: { 2: 1.49, 7: 2.49, 15: 3.99 },
+  pais: { 2: 2.49, 7: 4.99, 15: 7.99 },
+};


### PR DESCRIPTION
Adds a feature-flagged "Destacats" (Featured) events strip to main list pages and a "Promote" CTA to event detail, reusing existing UI components.

This implements the initial frontend-only phase of a promoted events feature, using `EventsAroundServer` with `fetchEvents` as a placeholder data source to avoid new components or types until a dedicated backend is ready. It ensures clear separation from organic content and ads, and is easily enabled/disabled via a feature flag.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f9a55f5-9ccb-4c00-82e3-57bc35b21700">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f9a55f5-9ccb-4c00-82e3-57bc35b21700">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

