### PR TITLE
perf: add LCP image preload hints for all page types

### DIFF
--- a/app/[locale]/e/[eventId]/components/EventHeroImageClient.tsx
+++ b/app/[locale]/e/[eventId]/components/EventHeroImageClient.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import ImgDefaultServer from "@components/ui/imgDefault/ImgDefaultServer";
+
+/**
+ * Minimal client component for the event hero image error fallback.
+ * The <picture> element is server-rendered for faster LCP;
+ * this wrapper only adds onError state to swap in a default image.
+ */
+export default function EventHeroImageClient({
+  sources,
+  safeTitle,
+  title,
+}: {
+  sources: { avif: string; webp: string; fallback: string };
+  safeTitle: string;
+  title: string;
+}) {
+  const [hasFailed, setHasFailed] = useState(false);
+  const sizes = "(max-width: 768px) 80vw, (max-width: 1280px) 70vw, 1200px";
+
+  if (hasFailed) {
+    return (
+      <div className="absolute inset-0">
+        <ImgDefaultServer title={title} />
+      </div>
+    );
+  }
+
+  return (
+    <picture>
+      <source srcSet={sources.webp} type="image/webp" sizes={sizes} />
+      <source srcSet={sources.avif} type="image/avif" sizes={sizes} />
+      <img
+        src={sources.fallback}
+        alt={safeTitle}
+        loading="eager"
+        decoding="sync"
+        fetchPriority="high"
+        sizes={sizes}
+        className="object-cover w-full h-full absolute inset-0 z-10"
+        onError={() => setHasFailed(true)}
+      />
+    </picture>
+  );
+}

--- a/app/[locale]/e/[eventId]/components/EventImage.tsx
+++ b/app/[locale]/e/[eventId]/components/EventImage.tsx
@@ -1,7 +1,5 @@
-"use client";
-
-import { EventImageProps } from "types/event";
-import { FC, useCallback, useMemo, useState } from "react";
+import { FC } from "react";
+import type { EventImageProps } from "types/event";
 import ImgDefaultServer from "@components/ui/imgDefault/ImgDefaultServer";
 import { getOptimalImageQuality, getOptimalImageWidth } from "@utils/image-quality";
 import {
@@ -9,52 +7,15 @@ import {
   normalizeExternalImageUrl,
 } from "@utils/image-cache";
 import { escapeXml } from "@utils/xml-escape";
+import EventHeroImageClient from "./EventHeroImageClient";
 
-function EventHeroImage({
-  sources,
-  safeTitle,
-  title,
-  onError,
-}: {
-  sources: { avif: string; webp: string; fallback: string };
-  safeTitle: string;
-  title: string;
-  onError: () => void;
-}) {
-  const [hasFailed, setHasFailed] = useState(false);
-  const sizes = "(max-width: 768px) 80vw, (max-width: 1280px) 70vw, 1200px";
-
-  if (hasFailed) {
-    return (
-      <div className="absolute inset-0">
-        <ImgDefaultServer title={title} />
-      </div>
-    );
-  }
-
-  return (
-    <picture>
-      <source srcSet={sources.webp} type="image/webp" sizes={sizes} />
-      <source srcSet={sources.avif} type="image/avif" sizes={sizes} />
-      <img
-        src={sources.fallback}
-        alt={safeTitle}
-        loading="eager"
-        decoding="sync"
-        fetchPriority="high"
-        sizes={sizes}
-        className="object-cover w-full h-full absolute inset-0 z-10"
-        onError={() => {
-          onError();
-          setHasFailed(true);
-        }}
-      />
-    </picture>
-  );
-}
-
+/**
+ * Server component for the event hero image.
+ * Computes deterministic image URLs server-side, delegates only error
+ * handling to a tiny client component (EventHeroImageClient).
+ * This keeps the <picture> element in pure SSR HTML for faster LCP.
+ */
 const EventImage: FC<EventImageProps> = ({ image, title, eventId }) => {
-  // Escape title for safe use in HTML attributes (React also escapes, but this is defensive)
   const safeTitle = escapeXml(title || "");
 
   const imageQuality = getOptimalImageQuality({
@@ -64,28 +25,16 @@ const EventImage: FC<EventImageProps> = ({ image, title, eventId }) => {
 
   const imageWidth = getOptimalImageWidth("hero");
 
-  const normalizedImage = useMemo(
-    () => (image ? normalizeExternalImageUrl(image) : ""),
-    [image]
-  );
-  
-  // Generate AVIF, WebP, and JPEG URLs for <picture> element
-  const sources = useMemo(
-    () => (image ? buildPictureSourceUrls(image, undefined, {
-      width: imageWidth,
-      quality: imageQuality,
-    }) : null),
-    [image, imageWidth, imageQuality]
-  );
+  const normalizedImage = image ? normalizeExternalImageUrl(image) : "";
 
-  // If URL normalization failed (e.g., overly long URL), treat as no image
+  const sources = image ? buildPictureSourceUrls(image, undefined, {
+    width: imageWidth,
+    quality: imageQuality,
+  }) : null;
+
   const hasValidImage = Boolean(image && sources);
 
   const anchorHref = normalizedImage || image || "";
-
-  const handleImageError = useCallback(() => {
-    // Error handling - image failed to load, fallback UI will show
-  }, []);
 
   if (!hasValidImage || !sources) {
     return (
@@ -107,11 +56,10 @@ const EventImage: FC<EventImageProps> = ({ image, title, eventId }) => {
         className="block w-full h-full cursor-pointer hover:opacity-95 transition-opacity relative"
         aria-label={`Veure imatge completa de ${safeTitle}`}
       >
-        <EventHeroImage
+        <EventHeroImageClient
           sources={sources}
           safeTitle={safeTitle}
           title={title}
-          onError={handleImageError}
         />
       </a>
     </div>

--- a/app/[locale]/e/[eventId]/page.tsx
+++ b/app/[locale]/e/[eventId]/page.tsx
@@ -37,6 +37,8 @@ import type { AppLocale } from "types/i18n";
 import { getLocalizedCategoryLabelFromConfig } from "@utils/category-helpers";
 import FavoriteButton from "@components/ui/common/favoriteButton";
 import SponsorBannerSlot from "@components/ui/sponsor/SponsorBannerSlot";
+import { buildPictureSourceUrls } from "@utils/image-cache";
+import { getOptimalImageQuality, getOptimalImageWidth } from "@utils/image-quality";
 import EventStickyCTA from "./components/EventStickyCTA";
 import EventSidebar from "./components/EventSidebar";
 import SocialProofCounter from "./components/SocialProofCounter";
@@ -261,8 +263,28 @@ export default async function EventPage({
   ];
   const breadcrumbJsonLd = generateBreadcrumbList(breadcrumbItems);
 
+  // Preload LCP hero image — React 19 hoists <link> to <head> automatically.
+  // This lets the browser start downloading the image while parsing HTML,
+  // instead of discovering it late when the <picture> element is parsed.
+  const lcpPreloadUrl = event.imageUrl
+    ? buildPictureSourceUrls(event.imageUrl, undefined, {
+      width: getOptimalImageWidth("hero"),
+      quality: getOptimalImageQuality({ isPriority: true, isExternal: true }),
+    }).webp
+    : null;
+
   return (
     <>
+      {/* Preload LCP hero image for faster Largest Contentful Paint */}
+      {lcpPreloadUrl && (
+        <link
+          rel="preload"
+          as="image"
+          href={lcpPreloadUrl}
+          type="image/webp"
+          fetchPriority="high"
+        />
+      )}
       {/* Main Event JSON-LD */}
       <JsonLdServer
         id={event.id ? String(event.id) : undefined}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -143,6 +143,15 @@ export default async function Page(): Promise<JSX.Element> {
 
   return (
     <>
+      {/* Preload LCP hero image — React 19 hoists <link> to <head> automatically */}
+      <link
+        rel="preload"
+        as="image"
+        href="/static/images/hero-castellers.webp"
+        type="image/webp"
+        fetchPriority="high"
+      />
+
       {siteNavigationSchema && (
         <JsonLdServer id="site-navigation" data={siteNavigationSchema} />
       )}

--- a/components/partials/PlacePageShell.tsx
+++ b/components/partials/PlacePageShell.tsx
@@ -25,6 +25,9 @@ import {
 } from "@utils/breadcrumb-helpers";
 import type { BreadcrumbItem } from "types/common";
 import type { AppLocale } from "types/i18n";
+import { buildPictureSourceUrls } from "@utils/image-cache";
+import { getOptimalImageQuality, getOptimalImageWidth } from "@utils/image-quality";
+import { isEventSummaryResponseDTO } from "types/api/isEventSummaryResponseDTO";
 
 // Lazy load below-the-fold client component via client component wrapper
 // This allows us to use ssr: false in Next.js 16 (required for client components)
@@ -254,6 +257,21 @@ async function PlacePageContent({
   const tByDates = await getTranslations("Config.ByDates");
   const locale = await getLocaleSafely();
 
+  // Preload LCP image — first real event card image.
+  // React 19 hoists <link> to <head>, letting the browser start the fetch
+  // before it parses the <picture> element deep in the card grid.
+  const firstRealEvent = events.find(isEventSummaryResponseDTO);
+  const lcpPreloadUrl = firstRealEvent?.imageUrl
+    ? buildPictureSourceUrls(
+      firstRealEvent.imageUrl,
+      firstRealEvent.hash || firstRealEvent.updatedAt,
+      {
+        width: getOptimalImageWidth("list"),
+        quality: getOptimalImageQuality({ isPriority: true, isExternal: true }),
+      }
+    ).webp
+    : null;
+
   // Generate webPageSchema after shell data is available
   const webPageSchema = webPageSchemaFactory
     ? webPageSchemaFactory({ placeTypeLabel, pageData })
@@ -290,6 +308,17 @@ async function PlacePageContent({
 
   return (
     <>
+      {/* Preload LCP card image for faster Largest Contentful Paint */}
+      {lcpPreloadUrl && (
+        <link
+          rel="preload"
+          as="image"
+          href={lcpPreloadUrl}
+          type="image/webp"
+          fetchPriority="high"
+        />
+      )}
+
       {webPageSchema && (
         <JsonLdServer id="webpage-schema" data={webPageSchema} />
       )}


### PR DESCRIPTION
## Summary

Adds server-side `<link rel="preload">` hints for the LCP (Largest Contentful Paint) image on each page type, using React 19's automatic `<head>` hoisting. No client-side JavaScript added.

## Changes

### Event detail page (`/e/[eventId]`)
- Preloads hero image via `buildPictureSourceUrls` (WebP, quality 50, width 1200)
- Splits `EventImage.tsx` from monolithic `"use client"` into a server component + tiny `EventHeroImageClient.tsx` (49 lines, only `useState` for error fallback)

### Homepage (`/`)
- Preloads static hero image `/static/images/hero-castellers.webp`

### Listing pages (`/[place]`)
- Dynamically preloads the first event card image using `isEventSummaryResponseDTO` type guard and `buildPictureSourceUrls` (WebP, quality 50, width from `getOptimalImageWidth("list")`)

## Why

PageSpeed data showed high LCP times (lab: ~7s on event detail and listing pages) caused by late image discovery — the browser only found the LCP image after parsing the full HTML + hydrating JS. The preload hints let the browser start fetching the image as soon as it parses `<head>`.

## What this does NOT change

- No `warm` instance changes (stays at 1) — PageSpeed showed no TTFB issues
- No new client components beyond the minimal `EventHeroImageClient` error fallback
- No barrel file imports — all imports are direct file paths

## Verification

- `yarn typecheck`: 0 errors
- `yarn lint`: 0 errors
- `yarn test`: all 1759 tests pass
- Skills audit: verified against `react-nextjs-patterns`, `bundle-optimization`, and `vercel-react-best-practices` skills


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side image preload hints for the LCP image on event detail, homepage, and listing pages to start fetching in head and improve LCP. Also splits the event hero image into a server component with a tiny client fallback; no client JS added for preloads.

- New Features
  - Preload event detail hero via `buildPictureSourceUrls` (WebP, width 1200, quality 50).
  - Preload homepage hero at `/static/images/hero-castellers.webp`.
  - Preload first listing card image using `getOptimalImageWidth("list")`.
  - Uses React 19 head hoisting for `<link rel="preload">`.

- Refactors
  - Split `EventImage` into a server component + `EventHeroImageClient` (error fallback only).
  - Keeps the `<picture>` server-rendered to reduce LCP.

<sup>Written for commit b8924e0e68e19fce2ad538807646ae42db0d59f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

