### PR TITLE
perf: reduce client bundle by 1.36 MB (-18.4%)

### DIFF
--- a/app/[locale]/e/[eventId]/EventClient.tsx
+++ b/app/[locale]/e/[eventId]/EventClient.tsx
@@ -16,10 +16,6 @@ import AdArticle from "components/ui/adArticle";
 import SectionHeading from "@components/ui/common/SectionHeading";
 import { useTranslations } from "next-intl";
 
-// const Tooltip = dynamic(() => import("components/ui/tooltip"), {
-//   ssr: false,
-// });
-
 // computeTemporalStatus now imported from utils/event-status for reuse & testability
 
 export default function EventClient({

--- a/components/ui/tooltip/index.tsx
+++ b/components/ui/tooltip/index.tsx
@@ -1,9 +1,1 @@
-import { Tooltip } from "react-tooltip";
-import type { TooltipComponentProps } from "types/common";
-
-export default function TooltipComponent({
-  id,
-  children,
-}: TooltipComponentProps) {
-  return <Tooltip id={id}>{children}</Tooltip>;
-}
+// DEPRECATED: react-tooltip has been removed. Delete this file.

--- a/next.config.js
+++ b/next.config.js
@@ -51,7 +51,6 @@ const nextConfig = {
       "react-day-picker",
       "react-select",
       "react-share",
-      "react-tooltip",
     ],
     // --- Server Actions Configuration ---
     serverActions: {
@@ -176,10 +175,10 @@ module.exports = withSentryConfig(
         removeDebugLogging: true,
         // Remove tracing code since tracesSampleRate is 0
         removeTracing: true,
-        // Remove iframe capture code from Session Replay
+        // Remove all Session Replay code (replay is fully disabled)
         excludeReplayIframe: true,
-        // Remove shadow DOM capture code from Session Replay
         excludeReplayShadowDOM: true,
+        excludeReplayCanvas: true,
       },
       automaticVercelMonitors: true,
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "react-dom": "19.2.4",
     "react-select": "^5.7.0",
     "react-share": "^5.0.3",
-    "react-tooltip": "^5.26.0",
     "sharp": "^0.34.5",
     "sst": "3.19.3",
     "swr": "^2.2.5",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,15 +2,10 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import {
-  init,
-  addIntegration,
-  captureRouterTransitionStart,
-} from "@sentry/nextjs";
+import { init, captureRouterTransitionStart } from "@sentry/nextjs";
 import type { BrowserOptions } from "@sentry/nextjs";
 import {
   beforeSendClient,
-  beforeSendMetric,
   SENTRY_IGNORE_ERRORS,
   SENTRY_DENY_URLS,
 } from "@utils/sentry-helpers";
@@ -32,10 +27,10 @@ if (process.env.NODE_ENV === "production") {
     // Errors-only: disable performance tracing.
     tracesSampleRate: 0,
 
-    // Session replay: only capture replays when an error occurs.
-    // This keeps debugging capability without ingesting baseline session replays.
+    // Session Replay disabled — saves ~299 KB of @sentry-internal/replay.
+    // Error context (stack traces, breadcrumbs) is still captured.
     replaysSessionSampleRate: 0,
-    replaysOnErrorSampleRate: 1.0,
+    replaysOnErrorSampleRate: 0,
     // Privacy: explicitly disable sending PII by default
     sendDefaultPii: false,
     debug: false,
@@ -43,31 +38,14 @@ if (process.env.NODE_ENV === "production") {
     ignoreErrors: SENTRY_IGNORE_ERRORS,
     // Don't report errors from browser extension scripts
     denyUrls: SENTRY_DENY_URLS,
-    // Session Replay is lazy-loaded below for smaller initial bundle (~60KB savings)
     integrations: [],
     // Errors-only: do not send console logs as Sentry logs.
     enableLogs: false,
-    // Metrics: automatically enabled in v10.25.0+ (no explicit enableMetrics needed)
-    // Use Sentry.metrics.count(), Sentry.metrics.gauge(), Sentry.metrics.distribution()
-    // Filter and sanitize metrics before sending (removes sensitive data from attributes)
-    beforeSendMetric,
     // Filter and sanitize events before sending (removes sensitive data, filters non-critical errors)
     beforeSend: beforeSendClient,
   };
 
   init(config);
-
-  // Lazy-load Session Replay to reduce initial bundle size (~60KB savings)
-  // Replay is only loaded when needed (replaysOnErrorSampleRate: 1.0)
-  import("@sentry/nextjs").then((lazyLoadedSentry) => {
-    addIntegration(
-      lazyLoadedSentry.replayIntegration({
-        // Privacy defaults: avoid capturing typed content.
-        maskAllText: true,
-        blockAllMedia: false,
-      }),
-    );
-  });
 }
 
 // Export router transition tracking for Next.js App Router navigation monitoring

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,7 +6,6 @@ import { init } from "@sentry/nextjs";
 import type { EdgeOptions } from "@sentry/nextjs";
 import {
   beforeSendEdge,
-  beforeSendMetric,
   SENTRY_IGNORE_ERRORS,
 } from "@utils/sentry-helpers";
 
@@ -29,10 +28,6 @@ if (process.env.NODE_ENV === "production") {
     ignoreErrors: SENTRY_IGNORE_ERRORS,
     // Errors-only: do not send console logs as Sentry logs.
     enableLogs: false,
-    // Metrics: automatically enabled in v10.25.0+ (no explicit enableMetrics needed)
-    // Use Sentry.metrics.count(), Sentry.metrics.gauge(), Sentry.metrics.distribution()
-    // Filter and sanitize metrics before sending (removes sensitive data from attributes)
-    beforeSendMetric,
     // Filter and sanitize events before sending (removes sensitive data, filters non-critical errors)
     beforeSend: beforeSendEdge,
   };

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,7 +6,6 @@ import { init } from "@sentry/nextjs";
 import type { NodeOptions } from "@sentry/nextjs";
 import {
   beforeSendServer,
-  beforeSendMetric,
   SENTRY_IGNORE_ERRORS,
 } from "@utils/sentry-helpers";
 
@@ -33,10 +32,6 @@ if (process.env.NODE_ENV === "production") {
     ignoreErrors: SENTRY_IGNORE_ERRORS,
     // Errors-only: do not send console logs as Sentry logs.
     enableLogs: false,
-    // Metrics: automatically enabled in v10.25.0+ (no explicit enableMetrics needed)
-    // Use Sentry.metrics.count(), Sentry.metrics.gauge(), Sentry.metrics.distribution()
-    // Filter and sanitize metrics before sending (removes sensitive data from attributes)
-    beforeSendMetric,
     // Filter and sanitize events before sending (removes sensitive data, filters non-critical errors)
     beforeSend: beforeSendServer,
   };

--- a/types/common.ts
+++ b/types/common.ts
@@ -390,11 +390,6 @@ export interface ListProps {
   children: (event: ListEvent, index: number) => React.ReactElement;
 }
 
-export interface TooltipComponentProps {
-  id: string;
-  children: React.ReactNode;
-}
-
 export interface ViewCounterProps {
   visits: number;
   hideText?: boolean;

--- a/utils/sentry-helpers.ts
+++ b/utils/sentry-helpers.ts
@@ -1,4 +1,4 @@
-import type { Event, EventHint, ErrorEvent, Metric } from "@sentry/nextjs";
+import type { Event, EventHint, ErrorEvent } from "@sentry/nextjs";
 
 /**
  * Well-known error patterns to ignore at SDK level (before serialization).
@@ -213,33 +213,3 @@ export function beforeSendEdge(
   return beforeSend(event, hint) as ErrorEvent | null;
 }
 
-/**
- * Filters and sanitizes Sentry metrics before sending.
- * Implements best practices for metrics monitoring:
- * - Scrubs sensitive data from metric attributes
- * - Filters out metrics that shouldn't be sent
- * - Prevents information disclosure
- *
- * Use with beforeSendMetric option in Sentry.init()
- */
-export function beforeSendMetric(metric: Metric): Metric | null {
-  // Scrub sensitive data from metric attributes
-  if (metric.attributes) {
-    const sensitiveKeys = [
-      "password",
-      "token",
-      "api_key",
-      "apikey",
-      "secret",
-      "auth",
-      "authorization",
-    ];
-    sensitiveKeys.forEach((key) => {
-      if (metric.attributes?.[key]) {
-        metric.attributes[key] = "[Filtered]";
-      }
-    });
-  }
-
-  return metric;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,7 +3010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.1, @floating-ui/dom@npm:^1.6.1":
+"@floating-ui/dom@npm:^1.0.1":
   version: 1.7.2
   resolution: "@floating-ui/dom@npm:1.7.2"
   dependencies:
@@ -9102,7 +9102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.3.0, classnames@npm:^2.3.2":
+"classnames@npm:^2.3.2":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -15398,19 +15398,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^5.26.0":
-  version: 5.29.1
-  resolution: "react-tooltip@npm:5.29.1"
-  dependencies:
-    "@floating-ui/dom": "npm:^1.6.1"
-    classnames: "npm:^2.3.0"
-  peerDependencies:
-    react: ">=16.14.0"
-    react-dom: ">=16.14.0"
-  checksum: 10c0/f5bbdf7d3e27497d71098a9a054f528f4c45c0823914bbf1351f01d992fd526709793112ebcbf775287a829d157551d4880075cfd90cd9489308dc5a1de4d0e0
-  languageName: node
-  linkType: hard
-
 "react-transition-group@npm:^4.3.0":
   version: 4.4.5
   resolution: "react-transition-group@npm:4.4.5"
@@ -15985,7 +15972,6 @@ __metadata:
     react-dom: "npm:19.2.4"
     react-select: "npm:^5.7.0"
     react-share: "npm:^5.0.3"
-    react-tooltip: "npm:^5.26.0"
     sharp: "npm:^0.34.5"
     sst: "npm:3.19.3"
     swr: "npm:^2.2.5"


### PR DESCRIPTION
## Summary

Reduces the client-side JavaScript bundle from 7.37 MB to 6.01 MB (-1.36 MB, -18.4%) by disabling unused Sentry features and removing dead dependencies.

## Changes

### Sentry Optimization (saves ~1,123 KB)
- Disable Session Replay (replaysOnErrorSampleRate: 0): Removes @sentry-internal/replay (299 KB), @sentry/browser (211 KB), @sentry/browser-utils (91 KB), and replay-dependent code from @sentry/core (166 KB)
- Remove unused beforeSendMetric from all 3 Sentry configs - metrics API was configured but never called
- Add excludeReplayCanvas to tree-shake config for complete replay removal
- Error capturing, stack traces, and breadcrumbs remain fully functional

### Dead Dependency Removal
- Remove react-tooltip - package was unused (only a commented-out import remained). Deletes wrapper component, type definition, and optimizePackageImports entry

## Bundle Analysis (webpack analyzer)

Sentry total: 1,553 KB -> 430 KB (-72%)
- @sentry/nextjs: 627 KB -> 270 KB (-357 KB)
- @sentry/core: 327 KB -> 161 KB (-166 KB)
- @sentry/browser: 211 KB -> 0 KB (-211 KB)
- @sentry-internal/replay: 299 KB -> 0 KB (-299 KB)
- @sentry/browser-utils: 91 KB -> 0 KB (-91 KB)

Total client bundle: 7.37 MB -> 6.01 MB
Module count: 1,572 -> 1,341

## Verification
- yarn typecheck: pass
- yarn lint: 0 errors
- yarn test: 1,759 tests pass

## Note
Please delete components/ui/tooltip/index.tsx after merge - it was emptied but rm was policy-restricted during development.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the client bundle by 1.36 MB (-18.4%) by disabling Sentry Session Replay and removing an unused tooltip dependency. Error reporting remains fully functional.

- **Refactors**
  - Disable Sentry Session Replay (`replaysSessionSampleRate: 0`, `replaysOnErrorSampleRate: 0`); remove lazy replay integration.
  - Add `excludeReplayCanvas` (with existing iframe/shadow DOM excludes) to fully tree-shake replay code in `@sentry/nextjs`.
  - Remove unused metrics hook (`beforeSendMetric`) from client/edge/server configs and helpers.
  - Keep errors, stack traces, and breadcrumbs.

- **Dependencies**
  - Remove `react-tooltip` and its wrapper/type; drop from `next.config.js`, `package.json`, and `yarn.lock`.
  - Result: Sentry bundle 1,553 KB -> 430 KB (-72%); total client bundle 7.37 MB -> 6.01 MB.

<sup>Written for commit 8aa61109fa439313f5a5405ed56b3893a0873112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed tooltip functionality from the application.

* **Chores**
  * Removed `react-tooltip` dependency.
  * Disabled Sentry Session Replay capture in error scenarios.
  * Removed metric filtering from Sentry error tracking configurations.
  * Cleaned up related internal code and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->