### PR TITLE
feat(events): add fallbackLevel + telemetry to events fallback (Phase 0)

### DIFF
--- a/app/[locale]/[place]/[byDate]/[category]/page.tsx
+++ b/app/[locale]/[place]/[byDate]/[category]/page.tsx
@@ -372,7 +372,7 @@ async function buildCategoryEventsPromise({
   categoryName?: string;
   locale: AppLocale;
 }): Promise<PlacePageEventsResult> {
-  const { eventsResponse, events, noEventsFound } =
+  const { eventsResponse, events, noEventsFound, fallbackLevel } =
     await fetchEventsWithFallback({
       place: filters.place,
       initialParams: fetchParams,
@@ -432,6 +432,7 @@ async function buildCategoryEventsPromise({
   return {
     events: eventsWithAds,
     noEventsFound,
+    fallbackLevel,
     serverHasMore,
     structuredScripts: structuredScripts.length ? structuredScripts : undefined,
   };

--- a/app/[locale]/[place]/[byDate]/page.tsx
+++ b/app/[locale]/[place]/[byDate]/page.tsx
@@ -389,7 +389,7 @@ async function buildPlaceByDateEventsPromise({
   pageDataPromise: Promise<PageData>;
   locale: AppLocale;
 }): Promise<PlacePageEventsResult> {
-  const { eventsResponse, events, noEventsFound } =
+  const { eventsResponse, events, noEventsFound, fallbackLevel } =
     await fetchEventsWithFallback({
       place,
       initialParams: paramsForFetch,
@@ -449,6 +449,7 @@ async function buildPlaceByDateEventsPromise({
   return {
     events: eventsWithAds,
     noEventsFound,
+    fallbackLevel,
     serverHasMore,
     structuredScripts: structuredScripts.length
       ? structuredScripts

--- a/app/[locale]/[place]/page.tsx
+++ b/app/[locale]/[place]/page.tsx
@@ -227,7 +227,7 @@ export async function buildPlaceEventsPromise({
     fetchParams.place = place;
   }
 
-  const { eventsResponse, events, noEventsFound } =
+  const { eventsResponse, events, noEventsFound, fallbackLevel } =
     await fetchEventsWithFallback({
       place,
       initialParams: fetchParams,
@@ -269,6 +269,7 @@ export async function buildPlaceEventsPromise({
   return {
     events: eventsWithAds,
     noEventsFound,
+    fallbackLevel,
     serverHasMore,
     structuredScripts,
   };

--- a/lib/helpers/event-fallback.ts
+++ b/lib/helpers/event-fallback.ts
@@ -87,7 +87,7 @@ export async function fetchEventsWithFallback(
 
   latestResponse = await fetchEvents(finalParams);
 
-  const finalLevel: EventFallbackLevel = hasEvents(latestResponse)
+  const finalLevel = hasEvents(latestResponse)
     ? "catalonia"
     : "none";
   recordFallbackUsage(place, finalLevel);

--- a/lib/helpers/event-fallback.ts
+++ b/lib/helpers/event-fallback.ts
@@ -1,8 +1,10 @@
+import { addBreadcrumb } from "@sentry/nextjs";
 import { fetchEvents } from "@lib/api/events";
 import { fetchRegionsWithCities, fetchRegions } from "@lib/api/regions";
 import { toLocalDateString } from "@utils/helpers";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 import type {
+  EventFallbackLevel,
   EventFallbackStageOptions,
   FetchEventsParams,
   FetchEventsWithFallbackOptions,
@@ -26,12 +28,13 @@ export async function fetchEventsWithFallback(
       eventsResponse: initialResponse,
       events: initialResponse.content,
       noEventsFound: false,
+      fallbackLevel: "local",
     };
   }
 
   let latestResponse: PagedResponseDTO<EventSummaryResponseDTO> | null =
     initialResponse;
-  let noEventsFound = true;
+  const noEventsFound = true;
 
   if (shouldAttemptRegionFallback(place, options.regionFallback)) {
     const regionSlug = await resolveRegionSlugForPlace(place);
@@ -50,20 +53,24 @@ export async function fetchEventsWithFallback(
       latestResponse = await fetchEvents(regionParams);
 
       if (hasEvents(latestResponse)) {
+        recordFallbackUsage(place, "region", regionSlug);
         return {
           eventsResponse: latestResponse,
           events: latestResponse.content,
           noEventsFound,
+          fallbackLevel: "region",
         };
       }
     }
   }
 
   if (options.finalFallback?.enabled === false) {
+    recordFallbackUsage(place, "none");
     return {
       eventsResponse: latestResponse,
       events: latestResponse?.content ?? [],
       noEventsFound,
+      fallbackLevel: "none",
     };
   }
 
@@ -80,11 +87,37 @@ export async function fetchEventsWithFallback(
 
   latestResponse = await fetchEvents(finalParams);
 
+  const finalLevel: EventFallbackLevel = hasEvents(latestResponse)
+    ? "catalonia"
+    : "none";
+  recordFallbackUsage(place, finalLevel);
+
   return {
     eventsResponse: latestResponse,
     events: latestResponse?.content ?? [],
     noEventsFound,
+    fallbackLevel: finalLevel,
   };
+}
+
+/**
+ * Phase 0 telemetry: emits a Sentry breadcrumb (free, attached to any error)
+ * and a structured console.info line (collected by Coolify/Docker logs).
+ * Only called for non-"local" outcomes — successful town queries are silent.
+ */
+function recordFallbackUsage(
+  place: string,
+  level: Exclude<EventFallbackLevel, "local">,
+  regionSlug?: string
+): void {
+  const data = { place, level, ...(regionSlug ? { regionSlug } : {}) };
+  addBreadcrumb({
+    category: "events.fallback",
+    message: `events.fallback level=${level} place=${place}`,
+    level: "info",
+    data,
+  });
+  console.info("events.fallback", data);
 }
 
 function hasEvents(

--- a/test/app/place-page-events.test.ts
+++ b/test/app/place-page-events.test.ts
@@ -75,6 +75,7 @@ describe("buildPlaceEventsPromise", () => {
       eventsResponse: emptyResponse,
       events: [],
       noEventsFound: true,
+      fallbackLevel: "none",
     });
 
     await buildPlaceEventsPromise({ place: "catalunya" });
@@ -100,6 +101,7 @@ describe("buildPlaceEventsPromise", () => {
       },
       events: [eventA, eventB],
       noEventsFound: false,
+      fallbackLevel: "local",
     });
 
     const result = await buildPlaceEventsPromise({ place: "catalunya" });
@@ -111,6 +113,7 @@ describe("buildPlaceEventsPromise", () => {
 
     expect(result.events).toEqual(localized);
     expect(result.noEventsFound).toBe(false);
+    expect(result.fallbackLevel).toBe("local");
     expect(result.serverHasMore).toBe(true);
   });
 });

--- a/test/lib/helpers/event-fallback.test.ts
+++ b/test/lib/helpers/event-fallback.test.ts
@@ -76,6 +76,7 @@ describe("fetchEventsWithFallback", () => {
 
     expect(result.events).toEqual(initialEvents);
     expect(result.noEventsFound).toBe(false);
+    expect(result.fallbackLevel).toBe("local");
     expect(mockFetchEvents).toHaveBeenCalledTimes(1);
     expect(mockFetchRegionsWithCities).not.toHaveBeenCalled();
   });
@@ -117,6 +118,7 @@ describe("fetchEventsWithFallback", () => {
 
     expect(result.events).toHaveLength(1);
     expect(result.noEventsFound).toBe(true);
+    expect(result.fallbackLevel).toBe("region");
     expect(mockFetchEvents).toHaveBeenCalledTimes(2);
     const regionCall = mockFetchEvents.mock.calls[1][0] as FetchEventsParams;
     expect(regionCall.place).toBe("catalunya-central");
@@ -168,6 +170,7 @@ describe("fetchEventsWithFallback", () => {
 
     expect(result.events).toHaveLength(1);
     expect(result.noEventsFound).toBe(true);
+    expect(result.fallbackLevel).toBe("catalonia");
     expect(mockFetchEvents).toHaveBeenCalledTimes(3);
     const finalCall =
       mockFetchEvents.mock.calls[mockFetchEvents.mock.calls.length - 1][0];
@@ -176,5 +179,42 @@ describe("fetchEventsWithFallback", () => {
     expect(finalCall.category).toBeUndefined();
     expect(finalCall.from).toBe(dateRange.from.toISOString().slice(0, 10));
     expect(finalCall.to).toBe(dateRange.until.toISOString().slice(0, 10));
+  });
+
+  it("returns fallbackLevel \"none\" when every stage is empty", async () => {
+    mockFetchEvents
+      .mockResolvedValueOnce(createResponse([]))
+      .mockResolvedValueOnce(createResponse([]))
+      .mockResolvedValueOnce(createResponse([]));
+
+    mockFetchRegionsWithCities.mockResolvedValue([
+      {
+        id: 10,
+        name: "Region",
+        slug: "region",
+        cities: [
+          {
+            id: 1,
+            value: "barcelona",
+            label: "Barcelona",
+            latitude: 1,
+            longitude: 1,
+          },
+        ],
+      },
+    ]);
+    mockFetchRegions.mockResolvedValue([
+      { id: 10, name: "Region", slug: "catalunya-central" },
+    ]);
+
+    const result = await fetchEventsWithFallback({
+      place: "barcelona",
+      initialParams: { page: 0, size: 10 },
+      finalFallback: { place: undefined },
+    });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.noEventsFound).toBe(true);
+    expect(result.fallbackLevel).toBe("none");
   });
 });

--- a/test/place-page-alias-query-preserved.test.tsx
+++ b/test/place-page-alias-query-preserved.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@lib/helpers/event-fallback", () => {
       eventsResponse: { last: true },
       events: [],
       noEventsFound: false,
+      fallbackLevel: "local",
     })),
   };
 });

--- a/types/event.ts
+++ b/types/event.ts
@@ -193,10 +193,20 @@ export interface FetchEventsWithFallbackOptions {
   finalFallback?: EventFallbackStageOptions;
 }
 
+/**
+ * Which stage of the fallback chain produced the rendered events.
+ * - "local"     — town-specific query returned events
+ * - "region"    — comarca rescued an empty town query
+ * - "catalonia" — final all-Catalonia rescue
+ * - "none"      — every stage returned zero
+ */
+export type EventFallbackLevel = "local" | "region" | "catalonia" | "none";
+
 export interface FetchEventsWithFallbackResult {
   eventsResponse: PagedResponseDTO<EventSummaryResponseDTO> | null;
   events: EventSummaryResponseDTO[];
   noEventsFound: boolean;
+  fallbackLevel: EventFallbackLevel;
 }
 
 /**

--- a/types/props.ts
+++ b/types/props.ts
@@ -58,6 +58,7 @@ import {
   NavigationItem,
 } from "types/common";
 import { EventSummaryResponseDTO, ListEvent } from "types/api/event";
+import type { EventFallbackLevel } from "types/event";
 import { CategorySummaryResponseDTO } from "types/api/category";
 import { RegionsGroupedByCitiesResponseDTO } from "types/api/region";
 import { RouteSegments, URLQueryParams } from "types/url-filters";
@@ -517,6 +518,7 @@ export interface SsrListWrapperProps {
 export interface PlacePageEventsResult {
   events: ListEvent[];
   noEventsFound: boolean;
+  fallbackLevel: EventFallbackLevel;
   serverHasMore: boolean;
   structuredScripts?: JsonLdScript[];
 }


### PR DESCRIPTION
## Summary

Phase 0 of the nearby-events-fallback work. **No behaviour change** — purely additive plumbing + telemetry so the next phases (and product decisions about distance-banded fallbacks) have data to work with.

- New `EventFallbackLevel` union (`"local" | "region" | "catalonia" | "none"`) on `FetchEventsWithFallbackResult` and `PlacePageEventsResult`, signalling which stage of the chain produced the listing.
- `lib/helpers/event-fallback.ts` sets the level at every return and emits a Sentry breadcrumb + structured `console.info("events.fallback", …)` line for every non-local outcome. Successful local town queries stay silent.
- All three callers (`[place]/page.tsx`, `[byDate]/page.tsx`, `[byDate]/[category]/page.tsx`) destructure the new field and forward it through `PlacePageEventsResult`. `PlacePageShell` doesn't consume it yet — that lands with Phase 3.
- Tests: existing fallback unit tests assert the new field; added a 4th case for `fallbackLevel: "none"` (every stage empty). Page-level mocks updated to include the field.

### Why

The current fallback is `town → comarca → all-Catalonia (2 weeks)`. We have no production data on which step actually rescues empty towns, and the UI can't tell "this is local" from "this is a 250 km away rescue." Phase 0 makes both observable. Phases 1–4 (town centroid resolution, distance-banded fallback replacing comarca, UI labelling, `noindex` for non-local pages) build on top.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — 0 errors (58 pre-existing warnings, none new)
- [x] `yarn test --run` — 1811/1811 pass; new "none" case asserted; telemetry observable in test stdout
- [ ] After merge: confirm `events.fallback` log lines appear in Coolify logs and breadcrumb shows up on any Sentry error from a town page
- [ ] After ~24h of telemetry: review distribution of `level=region` vs `level=catalonia` vs `level=none` to size Phase 2 (distance bands)

https://claude.ai/code/session_01NbBU7mc6eA4BoDBqJfRNef

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbBU7mc6eA4BoDBqJfRNef)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fallbackLevel` to the events fallback chain and emits telemetry for non-local outcomes to inform upcoming UI/SEO work. Also infers a narrower `finalLevel` type for compatibility with `recordFallbackUsage`; no behavior change.

- **New Features**
  - Added `EventFallbackLevel` (`"local" | "region" | "catalonia" | "none"`) and `fallbackLevel` on `fetchEventsWithFallback` and `PlacePageEventsResult`.
  - Logged a Sentry breadcrumb via `@sentry/nextjs` and `console.info("events.fallback", …)` for non-`"local"` results.
  - Plumbed `fallbackLevel` through `[place]/page.tsx`, `[byDate]/page.tsx`, and `[byDate]/[category]/page.tsx`.

- **Refactors**
  - Narrowed inferred `finalLevel` type (`"catalonia" | "none"`) for strict compatibility with `recordFallbackUsage`.

<sup>Written for commit 80d87e4a093f3120fe60ffd11cd06c20f4600adf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

