### PR TITLE
Fix calendar share end date fallback

### DIFF
--- a/test/calendar-utils.test.tsx
+++ b/test/calendar-utils.test.tsx
@@ -73,6 +73,118 @@ describe("calendar utils (black-box)", () => {
     expect(decodedIcs).not.toContain("\nX-EVIL:YES");
   });
 
+  it("generateCalendarUrls falls back to the start date when endDate is null", () => {
+    const urls = generateCalendarUrls({
+      title: "Presentació del llibre",
+      description: "Presentació del llibre 'Entendre els mapes'",
+      location: "Altafulla",
+      startDate: "2026-07-27T00:00:00.000Z",
+      endDate: null,
+      canonical: "https://www.esdeveniments.cat/e/presentacio",
+      labels: {
+        moreInfoHtml: "More info: {url}",
+        moreInfoText: "More info: {url}",
+        dateRange: "From {start} to {end}",
+        dateSingle: "From {start}",
+      },
+    });
+
+    const googleParams = new URL(urls.google).searchParams;
+    const outlookParams = new URL(urls.outlook).searchParams;
+    const decodedIcal = decodeURIComponent(urls.ical);
+
+    expect(googleParams.get("dates")).toBe(
+      "20260727T000000Z/20260727T000000Z"
+    );
+    expect(outlookParams.get("enddt")).toBe("20260727T000000Z");
+    expect(decodedIcal).toContain("DTEND:20260727T000000Z");
+    expect(urls.google).not.toContain("19700101");
+  });
+
+  it("generateCalendarUrls parses whitespace-padded ISO date strings", () => {
+    const urls = generateCalendarUrls({
+      title: "Presentació del llibre",
+      description: "Presentació del llibre 'Entendre els mapes'",
+      location: "Altafulla",
+      startDate: " 2026-07-27T00:00:00.000Z ",
+      endDate: " 2026-07-27T01:00:00.000Z ",
+      canonical: "https://www.esdeveniments.cat/e/presentacio",
+      labels: {
+        moreInfoHtml: "More info: {url}",
+        moreInfoText: "More info: {url}",
+        dateRange: "From {start} to {end}",
+        dateSingle: "From {start}",
+      },
+    });
+
+    expect(new URL(urls.google).searchParams.get("dates")).toBe(
+      "20260727T000000Z/20260727T010000Z"
+    );
+  });
+
+  it("generateCalendarUrls ignores non-date runtime endDate values", () => {
+    const urls = generateCalendarUrls({
+      title: "Presentació del llibre",
+      description: "Presentació del llibre 'Entendre els mapes'",
+      location: "Altafulla",
+      startDate: "2026-07-27T00:00:00.000Z",
+      endDate: 0 as unknown as Date,
+      canonical: "https://www.esdeveniments.cat/e/presentacio",
+      labels: {
+        moreInfoHtml: "More info: {url}",
+        moreInfoText: "More info: {url}",
+        dateRange: "From {start} to {end}",
+        dateSingle: "From {start}",
+      },
+    });
+
+    expect(new URL(urls.google).searchParams.get("dates")).toBe(
+      "20260727T000000Z/20260727T000000Z"
+    );
+    expect(urls.google).not.toContain("19700101");
+  });
+
+  it("generateCalendarUrls falls back when endDate is before startDate", () => {
+    const urls = generateCalendarUrls({
+      title: "Presentació del llibre",
+      description: "Presentació del llibre 'Entendre els mapes'",
+      location: "Altafulla",
+      startDate: "2026-07-27T00:00:00.000Z",
+      endDate: "1970-01-01T00:00:00.000Z",
+      canonical: "https://www.esdeveniments.cat/e/presentacio",
+      labels: {
+        moreInfoHtml: "More info: {url}",
+        moreInfoText: "More info: {url}",
+        dateRange: "From {start} to {end}",
+        dateSingle: "From {start}",
+      },
+    });
+
+    expect(new URL(urls.google).searchParams.get("dates")).toBe(
+      "20260727T000000Z/20260727T000000Z"
+    );
+    expect(urls.google).not.toContain("19700101");
+  });
+
+  it("generateCalendarUrls returns empty URLs for invalid startDate values", () => {
+    const urls = generateCalendarUrls({
+      title: "Presentació del llibre",
+      description: "Presentació del llibre 'Entendre els mapes'",
+      location: "Altafulla",
+      startDate: "not-a-date",
+      endDate: "2026-07-27T00:00:00.000Z",
+      canonical: "https://www.esdeveniments.cat/e/presentacio",
+      labels: {
+        moreInfoHtml: "More info: {url}",
+        moreInfoText: "More info: {url}",
+        dateRange: "From {start} to {end}",
+        dateSingle: "From {start}",
+      },
+    });
+
+    expect(urls).toEqual({ google: "", outlook: "", ical: "" });
+  });
+
   it("formatEventDateRange returns string and jsx in expected shape", () => {
     const labels = {
       dateRange: "From {start} to {end}",

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -3,7 +3,7 @@ export interface CalendarParams {
   description: string;
   location: string;
   startDate: string | Date;
-  endDate: string | Date;
+  endDate?: string | Date | null;
   canonical: string;
 }
 

--- a/types/common.ts
+++ b/types/common.ts
@@ -246,7 +246,7 @@ export interface AddToCalendarProps {
   description: string;
   location: string;
   startDate: DateString;
-  endDate: DateString;
+  endDate?: DateString | null;
   canonical: string;
   hideText?: boolean;
 }

--- a/utils/calendarUtils.tsx
+++ b/utils/calendarUtils.tsx
@@ -2,8 +2,25 @@ import type { CalendarParams, CalendarUrls, CalendarLabels } from "types/calenda
 
 import * as React from "react";
 
-const formatDate = (date: string | Date): string =>
-  new Date(date).toISOString().replace(/-|:|\.\d+/g, "");
+const parseCalendarDate = (date: unknown): Date | null => {
+  if (date instanceof Date) {
+    if (Number.isNaN(date.getTime())) return null;
+    return date;
+  }
+
+  if (typeof date !== "string") return null;
+
+  const trimmedDate = date.trim();
+  if (trimmedDate === "") return null;
+  if (!/^\d{4}-\d{2}-\d{2}(?:T|\s|$)/.test(trimmedDate)) return null;
+
+  const parsedDate = new Date(trimmedDate);
+  if (Number.isNaN(parsedDate.getTime())) return null;
+  return parsedDate;
+};
+
+const formatDate = (date: Date): string =>
+  date.toISOString().replace(/-|:|\.\d+/g, "");
 
 const encodeParams = (params: Record<string, string>): string =>
   Object.entries(params)
@@ -60,8 +77,16 @@ export const generateCalendarUrls = ({
   canonical,
   labels,
 }: CalendarParams & { labels: CalendarLabels }): CalendarUrls => {
-  const start = formatDate(startDate);
-  const end = formatDate(endDate);
+  const parsedStart = parseCalendarDate(startDate);
+  if (!parsedStart) {
+    return { google: "", outlook: "", ical: "" };
+  }
+
+  const parsedEnd = parseCalendarDate(endDate);
+  const safeEnd =
+    parsedEnd && parsedEnd >= parsedStart ? parsedEnd : parsedStart;
+  const start = formatDate(parsedStart);
+  const end = formatDate(safeEnd);
 
   const moreInfoHtml = labels.moreInfoHtml.replace("{url}", canonical);
   const moreInfoText = labels.moreInfoText.replace("{url}", canonical);


### PR DESCRIPTION
## Summary
- Prevent missing or invalid calendar end dates from becoming Unix epoch dates in Google/Outlook/iCal links
- Allow AddToCalendar/calendar params to receive nullish end dates at the type boundary
- Add regression coverage for null endDate using the reported 2026 event shape

## Verification
- yarn test --run test/calendar-utils.test.tsx
- yarn typecheck
- yarn lint (0 errors; existing repo-wide warnings only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix calendar share links to avoid 1970 end dates by falling back to `startDate` when `endDate` is missing, invalid, or earlier. `endDate` is now optional/null-safe; invalid `startDate` returns empty URLs.

- **Bug Fixes**
  - `generateCalendarUrls`: trims and parses ISO-like strings; ignores non-date `endDate`; falls back to `startDate` if end is null/invalid/before start; invalid `startDate` returns empty URLs; prevents "19700101" in Google/Outlook/iCal.
  - Types/tests: `endDate` optional/nullable in `CalendarParams` and `AddToCalendarProps`; tests for null/invalid/before-start `endDate`, whitespace-padded dates, and invalid `startDate`.

<sup>Written for commit da360ee94ca2c93803361209cecb31acf682b7f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

