### PR TITLE
ci(dependabot-auto-merge): auto-merge dev-dependency majors

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,15 +29,29 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # npm patch + minor auto-merge.
+      # npm patch + minor auto-merge (any dependency-type).
       # Safety: branch protection on main/develop must require the e2e + quality
       # checks. `gh pr merge --auto` queues the merge and only completes when
-      # all required checks pass. Major bumps are intentionally excluded.
+      # all required checks pass. Production majors are still gated below.
       - name: Auto-merge npm patch and minor updates
         if: |
           steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
            steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # npm major auto-merge ONLY for dev-dependencies (e.g. @types/*,
+      # lint-staged, test tooling). Green CI is a strong signal for dev deps
+      # because they don't ship to production. Production majors (react, next,
+      # zod, sentry, etc.) still require human review.
+      - name: Auto-merge npm dev-dependency major updates
+        if: |
+          steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major' &&
+          steps.metadata.outputs.dependency-type == 'direct:development'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

Extends `.github/workflows/dependabot-auto-merge.yml` to also auto-merge **major** version bumps of **dev-dependencies** (e.g. `@types/*`, `lint-staged`, test tooling), while keeping production-dep majors gated on human review.

Combined with the existing cooldown in `.github/dependabot.yml` (`semver-major-days: 14`), fresh majors get a 14-day soak before they're even proposed, and green CI is a strong safety signal for code that never ships to production.

## Rationale

Five Dependabot PRs (#320–#324) are currently green but stuck waiting for human approval — all dev-only majors (`@types/jsdom`, `@types/node`, `cssnano`, `lint-staged`, `react-day-picker`). Letting these flow through removes review toil with negligible production risk.

Production-dep majors (`react`, `next`, `zod`, `sentry`, etc.) still require human review — they pass `direct:production` rather than `direct:development` in `dependabot/fetch-metadata` output.

## What changed

- `.github/workflows/dependabot-auto-merge.yml`: new step `Auto-merge npm dev-dependency major updates`, gated on `dependency-type == 'direct:development'` AND `update-type == 'version-update:semver-major'`.

## Test plan

- [ ] Workflow YAML parses (CI will validate)
- [ ] Observe behavior on next dev-dependency major from Dependabot — should enable auto-merge automatically
- [ ] Confirm production-dep majors still require manual approval


---
_Generated by [Claude Code](https://claude.ai/code/session_01MGBvTzGaewGz2vKRHwAYwX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `dependabot-auto-merge.yml` to auto-merge major version bumps for dev dependencies (e.g., `@types/*`, `lint-staged`, test tools) after the 14-day cooldown. Production majors (`react`, `next`, `zod`, `sentry`, etc.) still require manual review.

- **New Features**
  - Adds an auto-merge step gated by `package-ecosystem == 'npm_and_yarn'`, `update-type == 'version-update:semver-major'`, and `dependency-type == 'direct:development'`.

<sup>Written for commit 2e44d7f3bd2e90505575806abee859e61f6094ae. Summary will update on new commits. <a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency update automation to auto-merge patch and minor version updates across all dependencies
  * Expanded auto-merge logic for major version updates in development tooling while maintaining manual review requirements for production dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Esdeveniments/esdeveniments-frontend/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->