### PR TITLE
fix(image-proxy): repair pinned-DNS dispatcher 502s and add regression guards

### DIFF
--- a/.github/workflows/branch-drift.yml
+++ b/.github/workflows/branch-drift.yml
@@ -1,0 +1,58 @@
+name: Branch drift guard
+
+# Surfaces the root cause of the Jun 11 2026 incident: a hotfix landed on main
+# (097e1275 "scope Redis entries by build id") and was never back-merged to
+# develop, so develop shipped a self-hosted cache bug main had already fixed.
+# This flags when main is AHEAD of develop on infra-critical files, so the
+# divergence is impossible to miss before merging develop into main.
+#
+# Non-blocking by design (annotation + job summary). Flip the final `exit 0`
+# to `exit 1` if you want it to hard-block PRs until a back-merge happens.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check-infra-drift:
+    name: Detect main→develop infra drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compare infra-critical files (main vs develop)
+        run: |
+          git fetch --quiet origin main develop
+
+          # Files where "main ahead of develop" has historically meant a
+          # production-only regression waiting to ship. Keep this list tight to
+          # avoid false positives from files that legitimately diverge.
+          INFRA_FILES="cache-handler.mjs next.config.js Dockerfile proxy.ts"
+
+          drift=$(git log --oneline origin/develop..origin/main -- $INFRA_FILES)
+
+          if [ -n "$drift" ]; then
+            {
+              echo "## ⚠️ main is ahead of develop on infra-critical files"
+              echo ""
+              echo "The following commits touch \`$INFRA_FILES\` and exist on **main** but not **develop**:"
+              echo ""
+              echo '```'
+              echo "$drift"
+              echo '```'
+              echo ""
+              echo "Back-merge main into develop before merging develop → main, or a fix already on prod could be reverted (see docs/incidents/2026-06-11-coolify-redis-stale-prerender.md)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Branch drift::main has infra commits not in develop — back-merge before promoting develop."
+          else
+            echo "✅ No infra-critical drift: develop has every main commit touching $INFRA_FILES."
+          fi
+
+          # Non-blocking: surface, don't block. Change to `exit 1` to enforce.
+          exit 0

--- a/.github/workflows/prod-arch-smoke.yml
+++ b/.github/workflows/prod-arch-smoke.yml
@@ -1,0 +1,111 @@
+name: Prod-arch smoke
+
+# Item #5 from the Jun 11 2026 incident response: gate PRs on production
+# architecture, not just Vercel. Three incidents (Feb Sharp, Apr empty-HTML,
+# Jun stale-prerender) all passed on Vercel/localhost and broke only on
+# self-hosted (Docker + Redis cacheHandler + Sharp). This job builds the app
+# and runs it against a real Redis service container — the only setup that
+# exercises the cacheHandler — then asserts the things that have broken:
+# health, server-rendered metadata, and the image proxy.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  prod-arch-smoke:
+    name: Build + Redis + smoke (prod architecture)
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Generate service worker and robots.txt (prebuild)
+        env:
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_SITE_URL: https://www.esdeveniments.cat
+        run: yarn prebuild
+
+      - name: Build Next.js application
+        env:
+          HMAC_SECRET: ${{ secrets.HMAC_SECRET }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_SITE_URL: https://www.esdeveniments.cat
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: yarn build
+
+      - name: Start server against Redis (background)
+        env:
+          HMAC_SECRET: ${{ secrets.HMAC_SECRET }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_SITE_URL: https://www.esdeveniments.cat
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+          # Activates the Redis cacheHandler — the self-hosted path that
+          # Vercel and local dev never exercise. This is the whole point.
+          REDIS_URL: redis://localhost:6379
+        run: |
+          yarn start &
+          echo $! > /tmp/next.pid
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:3000/api/health --timeout 90000
+
+      - name: Assert health, SSR metadata, and image proxy
+        run: |
+          fail() { echo "❌ $1"; exit 1; }
+
+          # 1) Health endpoint
+          curl -fsS -o /dev/null http://localhost:3000/api/health \
+            || fail "/api/health did not return 2xx"
+
+          # 2) Server-rendered metadata in the RAW homepage HTML. A stale-cache
+          #    resume fallback returns 200 with an empty <head>, so check the
+          #    actual tags, not the status code.
+          html="$(curl -fsSL http://localhost:3000/)" || fail "homepage fetch failed"
+          echo "$html" | grep -qi '<title[^>]*>[^<]\+</title>' || fail "homepage has no <title> (resume fallback / metadata loss)"
+          echo "$html" | grep -qi 'name="description"' || fail "homepage has no meta description"
+          echo "$html" | grep -qi 'rel="canonical"' || fail "homepage has no canonical link"
+
+          # 3) Image proxy: exercises Sharp + the pinned-DNS dispatcher in a
+          #    production runtime. Proxy a first-party static asset.
+          IMG="https://www.esdeveniments.cat/static/icons/icon-512x512.png"
+          PROXY="http://localhost:3000/api/image-proxy?url=$(printf '%s' "$IMG" | sed 's/:/%3A/g; s|/|%2F|g')&w=64&q=50"
+          : > /tmp/proxy.head
+          if ! code=$(curl -s -D /tmp/proxy.head -o /dev/null -w "%{http_code}" \
+            -H "Accept: image/webp,image/*" --max-time 30 "$PROXY"); then
+            code="000"
+          fi
+          ctype=$(grep -i '^content-type:' /tmp/proxy.head | tail -1 | tr -d '\r' || true)
+          { [ "$code" = "200" ] && echo "$ctype" | grep -qi 'image/'; } \
+            || fail "image-proxy returned HTTP $code ($ctype) for a first-party image"
+
+          echo "✅ Prod-arch smoke passed: health, SSR metadata, and image proxy all good."
+
+      - name: Stop server
+        if: always()
+        run: kill "$(cat /tmp/next.pid)" 2>/dev/null || true

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -29,8 +29,33 @@ jobs:
             echo "error_message=Keyword 'esdeveniments.cat' not found in page content" >> $GITHUB_OUTPUT
             exit 1
           fi
-          
-          echo "✅ Site is up and content is valid"
+
+          # Probe the image proxy with a first-party static asset. A May 2026
+          # dispatcher regression 502'd every proxied image while the homepage
+          # stayed 200, so a homepage-only check would have missed it. Using our
+          # own static image (not a third party) means a failure here is our
+          # proxy, not a flaky upstream. Retry to absorb transient blips.
+          IMG="https://www.esdeveniments.cat/static/icons/icon-512x512.png"
+          PROXY="https://www.esdeveniments.cat/api/image-proxy?url=$(printf '%s' "$IMG" | sed 's/:/%3A/g; s|/|%2F|g')&w=64&q=50"
+          proxy_ok=""
+          for attempt in 1 2 3; do
+            code=$(curl -s -D /tmp/proxy.head -o /dev/null -w "%{http_code}" \
+              -H "Accept: image/webp,image/*" --max-time 20 "$PROXY")
+            ctype=$(grep -i '^content-type:' /tmp/proxy.head | tail -1 | tr -d '\r')
+            if [ "$code" = "200" ] && echo "$ctype" | grep -qi 'image/'; then
+              proxy_ok="yes"
+              break
+            fi
+            echo "⚠️ image-proxy attempt $attempt: HTTP $code, $ctype"
+            sleep 5
+          done
+          if [ -z "$proxy_ok" ]; then
+            echo "❌ Image proxy is broken (last: HTTP $code, $ctype)"
+            echo "error_message=Image proxy returned HTTP $code ($ctype) for a known-good first-party image — the proxy is broken" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          echo "✅ Site is up, content is valid, and image proxy is serving images"
 
       - name: Send email notification on failure
         if: failure()

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -39,9 +39,16 @@ jobs:
           PROXY="https://www.esdeveniments.cat/api/image-proxy?url=$(printf '%s' "$IMG" | sed 's/:/%3A/g; s|/|%2F|g')&w=64&q=50"
           proxy_ok=""
           for attempt in 1 2 3; do
-            code=$(curl -s -D /tmp/proxy.head -o /dev/null -w "%{http_code}" \
-              -H "Accept: image/webp,image/*" --max-time 20 "$PROXY")
-            ctype=$(grep -i '^content-type:' /tmp/proxy.head | tail -1 | tr -d '\r')
+            # The step runs under `bash -eo pipefail`, so guard curl and grep:
+            # a transport failure (curl exits non-zero) or an empty header file
+            # (grep finds nothing) would otherwise abort the step before the
+            # retry/fallback runs, defeating the whole loop.
+            : > /tmp/proxy.head
+            if ! code=$(curl -s -D /tmp/proxy.head -o /dev/null -w "%{http_code}" \
+              -H "Accept: image/webp,image/*" --max-time 20 "$PROXY"); then
+              code="000"
+            fi
+            ctype=$(grep -i '^content-type:' /tmp/proxy.head | tail -1 | tr -d '\r' || true)
             if [ "$code" = "200" ] && echo "$ctype" | grep -qi 'image/'; then
               proxy_ok="yes"
               break

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -55,7 +55,22 @@ jobs:
             exit 1
           fi
 
-          echo "✅ Site is up, content is valid, and image proxy is serving images"
+          # Assert server-rendered metadata is present in the RAW HTML (not
+          # after JS). On Jun 11 2026 a stale Redis prerender shell made React
+          # fall back to client rendering, dropping <title>/description/canonical
+          # from SSR — invisible to a status-code check but an SEO hard-fail.
+          # /tmp/response.html is the already-fetched homepage.
+          missing=""
+          grep -qi '<title[^>]*>[^<]\+</title>' /tmp/response.html || missing="$missing <title>"
+          grep -qi 'name="description"' /tmp/response.html || missing="$missing meta-description"
+          grep -qi 'rel="canonical"' /tmp/response.html || missing="$missing canonical"
+          if [ -n "$missing" ]; then
+            echo "❌ Homepage server HTML is missing SSR metadata:$missing"
+            echo "error_message=Homepage SSR metadata missing ($missing) — likely a prerender/resume fallback to client rendering. SEO-critical." >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          echo "✅ Site is up, content is valid, image proxy works, and SSR metadata is present"
 
       - name: Send email notification on failure
         if: failure()

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,0 +1,19 @@
+# LESSONS.md
+
+Repo-specific gotchas worth sharing. Read this during research on any task here.
+
+## A test that skips on its own failure mode is worse than no test
+
+The image-proxy e2e tests skipped on any 502 (`test.skip("Test image service unavailable")`). When the dispatcher broke and 502'd every image, the suite read it as a flaky upstream and shipped green — for weeks (the May 2026 autoSelectFamily regression). If a test exists to catch failure X, it must **fail** on X, never skip. Retry to absorb genuine flakiness, then fail once retries are exhausted. Before trusting a green e2e run, grep for `if (status >= 500) test.skip` shapes.
+
+## `yarn build` does NOT run `prebuild`
+
+Yarn 4 (Berry) dropped automatic `pre*`/`post*` lifecycle scripts — npm runs them, Yarn doesn't. `prebuild` generates `public/sw.js` and `public/robots.txt`, both gitignored. Every deploy path must invoke it explicitly: the Dockerfile/Coolify and CI already do; Vercel needs the `vercel.json` `buildCommand` (`yarn prebuild && yarn build`). The env-specific builds (`build:development|staging|production`) already chain prebuild. A bare `yarn build` ships without the service worker or robots.txt.
+
+## Vercel previews are a preview, not production
+
+Production runs on Coolify/Docker/Node 22; Vercel previews are a different runtime. Sharp is bundled via the Dockerfile and excluded on Vercel — the Sharp e2e test self-skips on `*.vercel.app`. Vercel previews also sit behind a 401 protection wall, so automated probes need the `x-vercel-protection-bypass` secret. A green Vercel preview does not prove production works; gate promotion to `main` on the Coolify/Docker path.
+
+## Image-proxy/dispatcher bugs only surface through a real socket
+
+`buildPinnedDnsDispatcher`'s `lookup` callback runs only when undici opens a real connection — autoSelectFamily (Happy Eyeballs, default since Node 20) calls it with `{ all: true }` and expects an array of records. Mocked-fetch unit tests never reach it. `test/pinned-dns-dispatcher.test.ts` fetches through a loopback server to exercise the real path; keep that style for any proxy or dispatcher change.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -17,3 +17,11 @@ Production runs on Coolify/Docker/Node 22; Vercel previews are a different runti
 ## Image-proxy/dispatcher bugs only surface through a real socket
 
 `buildPinnedDnsDispatcher`'s `lookup` callback runs only when undici opens a real connection — autoSelectFamily (Happy Eyeballs, default since Node 20) calls it with `{ all: true }` and expects an array of records. Mocked-fetch unit tests never reach it. `test/pinned-dns-dispatcher.test.ts` fetches through a loopback server to exercise the real path; keep that style for any proxy or dispatcher change.
+
+## Back-merge main hotfixes into develop the same day
+
+main and develop diverge. A fix that lands directly on main (a hotfix) does not reach develop on its own, so develop can re-ship a bug main already fixed — and merging develop→main can even revert main's fix. This caused the Jun 11 2026 incident: `097e1275 fix(cache): scope Redis entries by build id` sat on main for weeks while develop kept the broken handler. The `branch-drift` CI workflow flags when main is ahead of develop on infra files (`cache-handler.mjs`, `next.config.js`, `Dockerfile`, `proxy.ts`). When you see that warning, back-merge before promoting.
+
+## The Redis cacheHandler is self-hosted-only — and HTTP 200 ≠ rendered
+
+`next.config.js` enables the Redis `cacheHandler` only off-Vercel (`isVercel ? {} : { cacheHandler }`). So localhost and Vercel can never reproduce cache-handler bugs; only Coolify (persistent Redis across deploys) can. Keys are scoped by `buildId` so a new build never reads a previous build's prerendered shell — a stale shell makes React's resume mismatch (`Expected the resume to render ...`), fall back to client rendering, and emit HTML with no SSR `<title>`/description/canonical. The page still returns 200, so assert metadata in the **raw** HTML, not the status code. See [docs/incidents/2026-06-11-coolify-redis-stale-prerender.md](docs/incidents/2026-06-11-coolify-redis-stale-prerender.md).

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -14,7 +14,7 @@ import {
 } from "@utils/image-cache";
 import { isDevelopmentHost } from "@utils/host-validation";
 import { getPublicFetchSafety } from "@utils/public-fetch-safety";
-import type { LookupAddress } from "node:dns";
+import { buildPinnedDnsDispatcher } from "@utils/pinned-dns-dispatcher";
 // Dynamic import to avoid Turbopack bundling issues with native modules
 import type { Sharp } from "sharp";
 
@@ -58,36 +58,6 @@ const insecureTlsDispatcher = new Agent({
     rejectUnauthorized: false,
   },
 });
-
-function buildPinnedDnsDispatcher(
-  dnsRecords: LookupAddress[],
-  rejectUnauthorized: boolean,
-): Agent | null {
-  const firstRecord = dnsRecords[0];
-  if (!firstRecord) return null;
-
-  return new Agent({
-    connect: {
-      keepAlive: false,
-      rejectUnauthorized,
-      lookup(_hostname, options, callback) {
-        // Node's net.connect uses autoSelectFamily (Happy Eyeballs, default
-        // since Node 20) and calls lookup with { all: true }, expecting an
-        // ARRAY of { address, family } records. Always answering with the
-        // single-address signature made every connection fail with
-        // "Invalid IP address: undefined" -> all image fetches 502'd.
-        if (options.all) {
-          callback(
-            null,
-            dnsRecords.map(({ address, family }) => ({ address, family })),
-          );
-        } else {
-          callback(null, firstRecord.address, firstRecord.family);
-        }
-      },
-    },
-  });
-}
 
 function shouldBypassTlsVerification(candidateUrl: string): boolean {
   try {

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -70,8 +70,20 @@ function buildPinnedDnsDispatcher(
     connect: {
       keepAlive: false,
       rejectUnauthorized,
-      lookup(_hostname, _options, callback) {
-        callback(null, firstRecord.address, firstRecord.family);
+      lookup(_hostname, options, callback) {
+        // Node's net.connect uses autoSelectFamily (Happy Eyeballs, default
+        // since Node 20) and calls lookup with { all: true }, expecting an
+        // ARRAY of { address, family } records. Always answering with the
+        // single-address signature made every connection fail with
+        // "Invalid IP address: undefined" -> all image fetches 502'd.
+        if (options.all) {
+          callback(
+            null,
+            dnsRecords.map(({ address, family }) => ({ address, family })),
+          );
+        } else {
+          callback(null, firstRecord.address, firstRecord.family);
+        }
       },
     },
   });

--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -35,7 +35,7 @@ const RETRY_COOLDOWN_MS = 30_000;
 /** Shared LRU fallback — created once, reused across all requests and cooldown periods. */
 const lruFallbackConfig = { handlers: [createLruHandler()] };
 
-CacheHandler.onCreation(() => {
+CacheHandler.onCreation(({ buildId } = {}) => {
   // If a previous failure occurred, check whether the cooldown has elapsed.
   // If so, clear the fallback config to allow a reconnection attempt below.
   if (globalThis.__cacheHandlerLastFailure) {
@@ -106,9 +106,17 @@ CacheHandler.onCreation(() => {
       return lruFallbackConfig;
     }
 
+    // Scope cache keys by build id so a new deploy never reads prerendered
+    // shells written by a previous build. Without this, Coolify's Redis serves
+    // a stale shell whose React tree no longer matches the new build's resume
+    // ("Expected the resume to render ..."), so SSR falls back to client
+    // rendering and the page ships without its <title>/meta. Vercel/localhost
+    // don't use this handler, which is why only self-hosted builds broke.
+    const cacheKeyPrefix = buildId ? `next:cache:${buildId}:` : "next:cache:";
+
     const redisHandler = createRedisHandler({
       client: redisClient,
-      keyPrefix: "next:cache:",
+      keyPrefix: cacheKeyPrefix,
     });
 
     globalThis.__cacheHandlerConfigPromise = null;

--- a/docs/incidents/2026-06-11-coolify-redis-stale-prerender.md
+++ b/docs/incidents/2026-06-11-coolify-redis-stale-prerender.md
@@ -1,0 +1,50 @@
+# Incident: Coolify Redis Stale Prerender Drops SSR Metadata (Jun 11, 2026)
+
+## Summary
+
+Self-hosted (Coolify) deployments on the `develop` line — `staging.esdeveniments.cat` and every `pr-*.esdeveniments.cat` preview — served pages whose raw server HTML had no `<title>`, no meta description, and no canonical link. Pages returned HTTP 200 and rendered for users (the browser set the title client-side), but crawlers saw a metadata-less document. Runtime logs showed `Expected the resume to render <lk> in this slot but instead it rendered <lN>. The tree doesn't match so React will fallback to client rendering`. localhost and Vercel were unaffected.
+
+This is the same failure *family* as [2026-04-23 Coolify PR Preview Empty HTML](./2026-04-23-coolify-pr-preview-empty-html.md) — SSR content/metadata missing only on self-hosted, invisible to a status-code check — but a different root cause. That earlier report recommended "adding a health check to PR preview CI that verifies `<h1>` tags exist." It was never built, so the pattern recurred.
+
+## Impact
+
+| Env | `<title>` in server HTML | Cause |
+| --- | --- | --- |
+| prod (`www`, main) | present | main had the fix |
+| staging (develop) | **missing** | stale Redis prerender |
+| pr-* previews (develop) | **missing** | stale Redis prerender |
+| localhost / Vercel | present | Redis handler not used |
+
+SEO-critical: any develop→main promotion would have shipped a site with no server-rendered title/description/canonical. No downtime; degraded crawlability on the develop line until fixed.
+
+## Timeline
+
+- **May 2, 2026** — `097e1275 fix(cache): scope Redis entries by build id` lands on **main**. Never back-merged to develop.
+- **May 12, 2026** — PR #300 gates the Redis `cacheHandler` to self-hosted only (`isVercel ? {} : { cacheHandler }`).
+- **Jun 11, 2026** — Missing-image incident investigation surfaces that staging/pr previews render no `<title>`. Diagnosed via Coolify MCP (deployment + runtime logs).
+- **Jun 11, 2026** — Build-id scoping ported to the fix branch; pr-339 redeployed; `<title>` restored.
+
+## Root Cause
+
+`cache-handler.mjs` on develop used a fixed Redis key prefix, `next:cache:`. Redis persists across deploys. With one prefix, a new build read prerendered RSC shells written by the **previous** build. The new build's component tree no longer matched that cached shell, so React's resume failed (`Expected the resume to render ...`), discarded the prerender, and fell back to client rendering — which emits HTML without the server-rendered `<head>` metadata.
+
+Why only self-hosted: PR #300 enables the Redis `cacheHandler` only off-Vercel. localhost dev and Vercel never use it (in-memory LRU / no handler), so they have no cross-build persistence to go stale.
+
+The deeper cause is process, not code: a fix existed on **main** and was never propagated to **develop**. The cache bug was the thing that fell through that gap.
+
+## Resolution
+
+Port `097e1275` to develop — scope the key prefix by `buildId` (`next:cache:${buildId}:`) so every build gets a fresh namespace and cannot read a prior build's shell. Verified the handler is now byte-identical in logic to main's working version. Redeploying pr-339 restored server-rendered metadata. Old `next:cache:` entries orphan harmlessly and age out.
+
+## Prevention
+
+1. **Branch-drift guard** (`.github/workflows/branch-drift.yml`) — flags when main is ahead of develop on infra-critical files (`cache-handler.mjs`, `next.config.js`, `Dockerfile`, `proxy.ts`). Directly targets the root cause.
+2. **Post-deploy SSR-metadata monitor** (`.github/workflows/uptime.yml`) — asserts `<title>`, meta description, and canonical exist in the raw prod HTML. The only automated layer that runs against persistent Redis across real deploys, so the only one that catches this symptom. This is the check the April incident asked for.
+3. **Pending — move the merge gate onto prod architecture** — build the Docker image in CI with a throwaway Redis and smoke-test it, or gate develop→main on Coolify staging health. Ends the recurring "green on Vercel, broken on Coolify" pattern (this incident, the April empty-HTML incident, the Feb Sharp incident).
+
+## Lessons Learned
+
+1. **A hotfix on main must be back-merged to develop the same day.** Branch divergence on infra files is how a fixed bug re-ships.
+2. **The cache handler is self-hosted-only.** Anything touching it cannot be validated on Vercel or localhost — it needs a real Redis + a production build across two deploys.
+3. **HTTP 200 is not "the page works."** Assert SSR metadata in the raw HTML; a resume fallback returns 200 with an empty head.
+4. **We already knew.** The April incident named this exact prevention and we didn't build it. A prevention item in a post-mortem is not done until it is code in CI.

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -22,6 +22,7 @@ Files are named: `YYYY-MM-DD-short-description.md`
 
 | Date       | Incident                                                                   | Impact                                  | Status                |
 | ---------- | -------------------------------------------------------------------------- | --------------------------------------- | --------------------- |
+| 2026-06-11 | [Coolify Redis Stale Prerender Drops SSR Metadata](./2026-06-11-coolify-redis-stale-prerender.md) | SEO (develop line: no SSR title/canonical) | Resolved              |
 | 2026-04-25 | [Orank Empty Shell Non-Issue](./2026-04-25-orank-empty-shell-non-issue.md) | None — diagnostic only                  | Resolved (Documented) |
 | 2026-04-23 | [Coolify PR Preview Empty HTML](./2026-04-23-coolify-pr-preview-empty-html.md) | SEO testing unreliable on PR previews | Resolved (Documented) |
 | 2026-02-18 | [Sharp Architecture Mismatch](./2026-02-18-sharp-architecture-mismatch.md) | Performance (4 days unoptimized images) | Resolved              |

--- a/e2e/image-proxy.spec.ts
+++ b/e2e/image-proxy.spec.ts
@@ -28,12 +28,26 @@ async function getProxiedImage(
   proxyUrl: string,
   init?: Parameters<APIRequestContext["get"]>[1],
 ): Promise<APIResponse> {
-  let response!: APIResponse;
+  let response: APIResponse | undefined;
+  let lastError: unknown;
   for (let attempt = 0; attempt < PROXY_502_RETRIES; attempt++) {
     // Back off between attempts so a brief upstream hiccup can recover.
     if (attempt > 0) await new Promise((r) => setTimeout(r, 500));
-    response = await request.get(proxyUrl, init);
-    if (response.status() !== 502) break;
+    try {
+      response = await request.get(proxyUrl, init);
+      if (response.status() !== 502) break;
+    } catch (err) {
+      // A network-level failure (timeout, connection reset) is transient too —
+      // retry it instead of failing the test on the first blip.
+      lastError = err;
+    }
+  }
+  if (!response) {
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(
+          `image-proxy fetch failed for ${proxyUrl} after ${PROXY_502_RETRIES} attempts`,
+        );
   }
   expect(
     response.status(),

--- a/e2e/image-proxy.spec.ts
+++ b/e2e/image-proxy.spec.ts
@@ -1,10 +1,45 @@
-import { test, expect, type Page } from "@playwright/test";
+import {
+  test,
+  expect,
+  type Page,
+  type APIRequestContext,
+  type APIResponse,
+} from "@playwright/test";
 
 /**
  * E2E tests for image proxy functionality
  * Verifies that external images are correctly proxied and optimized
  * across different page types and components
  */
+
+const PROXY_502_RETRIES = 3;
+
+/**
+ * GET a proxied image, retrying on 502.
+ *
+ * A single 502 can be a genuinely flaky upstream. A *persistent* 502 means our
+ * proxy itself is broken — e.g. the autoSelectFamily dispatcher regression that
+ * 502'd every image. We retry to absorb upstream blips, but FAIL (never skip)
+ * when every attempt returns 502. Skipping on 502 is exactly what let that
+ * outage ship green: a total proxy failure looked identical to a flaky service.
+ */
+async function getProxiedImage(
+  request: APIRequestContext,
+  proxyUrl: string,
+  init?: Parameters<APIRequestContext["get"]>[1],
+): Promise<APIResponse> {
+  let response!: APIResponse;
+  for (let attempt = 0; attempt < PROXY_502_RETRIES; attempt++) {
+    response = await request.get(proxyUrl, init);
+    if (response.status() !== 502) break;
+  }
+  expect(
+    response.status(),
+    `image-proxy returned 502 on all ${PROXY_502_RETRIES} attempts for ${proxyUrl} — ` +
+      "the proxy is broken, not a flaky upstream",
+  ).not.toBe(502);
+  return response;
+}
 
 test.describe("Image Proxy", () => {
   /**
@@ -134,13 +169,7 @@ test.describe("Image Proxy", () => {
         testImageUrl
       )}&w=200&q=50`;
 
-      const response = await request.get(proxyUrl);
-
-      // picsum.photos may redirect, accept 200 or skip if service is down
-      if (response.status() === 502) {
-        test.skip(true, "Test image service unavailable");
-        return;
-      }
+      const response = await getProxiedImage(request, proxyUrl);
 
       // Should return 200 OK
       expect(response.status()).toBe(200);
@@ -208,14 +237,9 @@ test.describe("Image Proxy", () => {
       )}&w=200&q=50`;
 
       // Request with AVIF preference
-      const avifResponse = await request.get(proxyUrl, {
+      const avifResponse = await getProxiedImage(request, proxyUrl, {
         headers: { Accept: "image/avif,image/webp,image/*" },
       });
-
-      if (avifResponse.status() === 502) {
-        test.skip(true, "Test image service unavailable");
-        return;
-      }
 
       if (avifResponse.status() === 200) {
         const contentType = avifResponse.headers()["content-type"];
@@ -241,14 +265,9 @@ test.describe("Image Proxy", () => {
         testImageUrl
       )}&w=400&q=60`;
 
-      const response = await request.get(proxyUrl, {
+      const response = await getProxiedImage(request, proxyUrl, {
         headers: { Accept: "image/avif,image/webp,image/*" },
       });
-
-      if (response.status() === 502) {
-        test.skip(true, "Test image service unavailable");
-        return;
-      }
 
       if (response.status() === 200) {
         const headers = response.headers();
@@ -290,14 +309,9 @@ test.describe("Image Proxy", () => {
         testImageUrl
       )}&w=400&q=50`;
 
-      const response = await request.get(proxyUrl, {
+      const response = await getProxiedImage(request, proxyUrl, {
         headers: { Accept: "image/webp,image/*" },
       });
-
-      if (response.status() === 502) {
-        test.skip(true, "Test image service unavailable");
-        return;
-      }
 
       expect(response.status()).toBe(200);
 

--- a/e2e/image-proxy.spec.ts
+++ b/e2e/image-proxy.spec.ts
@@ -38,7 +38,9 @@ async function getProxiedImage(
       if (response.status() !== 502) break;
     } catch (err) {
       // A network-level failure (timeout, connection reset) is transient too —
-      // retry it instead of failing the test on the first blip.
+      // retry it instead of failing the test on the first blip. Clear any
+      // stale response so a 502 from an earlier attempt can't mask this error.
+      response = undefined;
       lastError = err;
     }
   }

--- a/e2e/image-proxy.spec.ts
+++ b/e2e/image-proxy.spec.ts
@@ -30,6 +30,8 @@ async function getProxiedImage(
 ): Promise<APIResponse> {
   let response!: APIResponse;
   for (let attempt = 0; attempt < PROXY_502_RETRIES; attempt++) {
+    // Back off between attempts so a brief upstream hiccup can recover.
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 500));
     response = await request.get(proxyUrl, init);
     if (response.status() !== 502) break;
   }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "sharp": "^0.34.5",
     "swr": "^2.2.5",
     "tailwindcss": "3.3.6",
+    "undici": "^7.25.0",
     "web-vitals": "^5.2.0",
     "zod": "3.24.3",
     "zustand": "^5.0.8"

--- a/test/pinned-dns-dispatcher.test.ts
+++ b/test/pinned-dns-dispatcher.test.ts
@@ -2,18 +2,20 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createServer, type Server } from "node:http";
 import { fetch } from "undici";
-import { buildPinnedDnsDispatcher } from "../utils/pinned-dns-dispatcher";
+import { buildPinnedDnsDispatcher } from "@utils/pinned-dns-dispatcher";
 
 let server: Server | undefined;
 
 function startLoopbackServer(): Promise<number> {
-  return new Promise((resolve) => {
-    server = createServer((_req, res) => {
+  return new Promise((resolve, reject) => {
+    const srv = createServer((_req, res) => {
       res.writeHead(200, { "content-type": "text/plain" });
       res.end("ok");
     });
-    server.listen(0, "127.0.0.1", () => {
-      const address = server?.address();
+    server = srv;
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const address = srv.address();
       resolve(typeof address === "object" && address ? address.port : 0);
     });
   });
@@ -23,6 +25,8 @@ afterEach(
   () =>
     new Promise<void>((resolve) => {
       if (!server) return resolve();
+      // Destroy any kept-alive sockets so close() doesn't hang the suite.
+      server.closeAllConnections?.();
       server.close(() => {
         server = undefined;
         resolve();

--- a/test/pinned-dns-dispatcher.test.ts
+++ b/test/pinned-dns-dispatcher.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { fetch } from "undici";
+import { buildPinnedDnsDispatcher } from "../utils/pinned-dns-dispatcher";
+
+let server: Server | undefined;
+
+function startLoopbackServer(): Promise<number> {
+  return new Promise((resolve) => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server?.address();
+      resolve(typeof address === "object" && address ? address.port : 0);
+    });
+  });
+}
+
+afterEach(
+  () =>
+    new Promise<void>((resolve) => {
+      if (!server) return resolve();
+      server.close(() => {
+        server = undefined;
+        resolve();
+      });
+    }),
+);
+
+describe("buildPinnedDnsDispatcher", () => {
+  // Regression guard. Node's autoSelectFamily (Happy Eyeballs, default since
+  // Node 20) calls the connect-time lookup with { all: true } and expects an
+  // ARRAY of records. Answering with the single-address signature made every
+  // connection fail with "Invalid IP address: undefined" and 502'd every
+  // proxied image. Only a real fetch through the dispatcher exercises this
+  // path — a mocked fetch never invokes lookup, which is why nothing caught it.
+  it("connects through a pinned record on { all: true } lookups", async () => {
+    const port = await startLoopbackServer();
+    const dispatcher = buildPinnedDnsDispatcher(
+      [{ address: "127.0.0.1", family: 4 }],
+      false,
+    );
+    expect(dispatcher).not.toBeNull();
+
+    // .invalid never resolves via real DNS, so a 200 proves the pinned lookup
+    // (not ambient resolution) carried the connection.
+    const response = await fetch(`http://pinned.invalid:${port}/`, {
+      dispatcher: dispatcher ?? undefined,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+  });
+
+  it("returns null when there are no records to pin to", () => {
+    expect(buildPinnedDnsDispatcher([], true)).toBeNull();
+  });
+});

--- a/utils/pinned-dns-dispatcher.ts
+++ b/utils/pinned-dns-dispatcher.ts
@@ -26,7 +26,7 @@ export function buildPinnedDnsDispatcher(
         // ARRAY of { address, family } records. Always answering with the
         // single-address signature made every connection fail with
         // "Invalid IP address: undefined" -> all image fetches 502'd.
-        if (options.all) {
+        if (options?.all) {
           callback(
             null,
             dnsRecords.map(({ address, family }) => ({ address, family })),

--- a/utils/pinned-dns-dispatcher.ts
+++ b/utils/pinned-dns-dispatcher.ts
@@ -1,0 +1,40 @@
+import { Agent } from "undici";
+import type { LookupAddress } from "node:dns";
+
+/**
+ * Builds an undici dispatcher whose connections are pinned to a pre-resolved
+ * set of DNS records. We resolve the host once (in getPublicFetchSafety) to run
+ * SSRF checks, then pin the socket to those exact records so the connection
+ * can't be re-pointed at an internal address via DNS rebinding.
+ *
+ * Returns null when there are no records to pin to (caller falls back).
+ */
+export function buildPinnedDnsDispatcher(
+  dnsRecords: LookupAddress[],
+  rejectUnauthorized: boolean,
+): Agent | null {
+  const firstRecord = dnsRecords[0];
+  if (!firstRecord) return null;
+
+  return new Agent({
+    connect: {
+      keepAlive: false,
+      rejectUnauthorized,
+      lookup(_hostname, options, callback) {
+        // Node's net.connect uses autoSelectFamily (Happy Eyeballs, default
+        // since Node 20) and calls lookup with { all: true }, expecting an
+        // ARRAY of { address, family } records. Always answering with the
+        // single-address signature made every connection fail with
+        // "Invalid IP address: undefined" -> all image fetches 502'd.
+        if (options.all) {
+          callback(
+            null,
+            dnsRecords.map(({ address, family }) => ({ address, family })),
+          );
+        } else {
+          callback(null, firstRecord.address, firstRecord.family);
+        }
+      },
+    },
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "yarn prebuild && yarn build"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11857,6 +11857,7 @@ __metadata:
     swr: "npm:^2.2.5"
     tailwindcss: "npm:3.3.6"
     typescript: "npm:5.9.3"
+    undici: "npm:^7.25.0"
     vite-tsconfig-paths: "npm:^4.3.0"
     vitest: "npm:4.1.7"
     web-vitals: "npm:^5.2.0"


### PR DESCRIPTION
## Summary

Started as "no event images on localhost/Vercel," and the investigation uncovered two distinct production-breaking regressions on the `develop` line plus the gaps that let them ship. This PR carries the fixes and the guardrails so they can't recur silently.

Both bugs were invisible on localhost and Vercel and only manifested on self-hosted (Coolify), which is production's architecture.

## Fixes

- **Image proxy 502s** (`56021c1e`) — the pinned-DNS dispatcher answered undici's `{ all: true }` lookups (Node autoSelectFamily / Happy Eyeballs) with the single-address signature, so every connection failed with `Invalid IP address: undefined` and every proxied image 502'd since PR #300. Verified: broken path errors, fixed path returns 200. Also declares `undici` as a direct dependency (it was a direct import resolving only transitively via cheerio/jsdom).
- **SSR metadata missing on self-hosted** (`ff0ddebb`) — develop's Redis `cacheHandler` used a fixed `next:cache:` key prefix, so each Coolify deploy read the previous build's prerendered shell; the resume mismatched (`Expected the resume to render …`), React fell back to client rendering, and pages shipped with no `<title>`/description/canonical. Scopes the key prefix by `buildId`. Ports `097e1275`, already on `main` — without it, merging develop→main would have reverted prod's working fix.
- **Vercel build** (`af3697b8`) — `vercel.json` runs `yarn prebuild && yarn build` so `sw.js`/`robots.txt` are generated (Yarn 4 skips `prebuild`).

## Prevention

- **Dispatcher regression guard** (`ad1a8695`) — fetches through the dispatcher against a loopback server; fails with the exact prod error against the broken signature. Mocked-fetch unit tests can't reach this path.
- **E2E fails instead of skipping** (`49db361e`) — the image-proxy e2e tests skipped on any 502, so a total outage shipped green. Now they retry then fail; a persistent 502 is red.
- **Uptime monitor** (`2cd39115`, `721e3450`) — probes `/api/image-proxy` with a first-party image, and asserts `<title>`/description/canonical exist in the raw prod HTML (the only automated layer running against real persistent Redis).
- **Branch-drift guard** (`721e3450`) — flags when `main` is ahead of `develop` on infra files (`cache-handler.mjs`, `next.config.js`, `Dockerfile`, `proxy.ts`). Targets the root cause: a main hotfix never back-merged.
- **Docs** (`75f86c6b`, `84023033`) — incident post-mortem + `LESSONS.md` entries.
- **AI review fixes** (`f977f995`) — addressed gemini/coderabbit/cubic suggestions, including a real `bash -eo pipefail` bug that defeated the monitor's retry loop.

## Test plan

- `yarn typecheck` ✅ · `yarn lint` ✅ (0 errors) · `yarn test` ✅ (incl. new dispatcher guard)
- pr-339 preview redeployed: `<title>` restored, image-proxy serves `200 image/webp`.
- Prod image-proxy + SSR-metadata monitor URLs verified by hand.

## Follow-ups (not in this PR)

- **Back-merge `main` → `develop`** — required before promoting develop; the drift guard will keep flagging until done.
- **Move the merge gate onto prod architecture** (Docker build + throwaway Redis in CI, or gate develop→main on Coolify staging) — ends the recurring "green on Vercel, broken on Coolify" pattern. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)