### PR TITLE
fix(cache): prerenderable metadata + bounded cache tags

### DIFF
--- a/app/[locale]/e/[eventId]/page.tsx
+++ b/app/[locale]/e/[eventId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense, use } from "react";
 import type { JSX } from "react";
 import EventDetailSkeleton from "@components/ui/common/skeletons/EventDetailSkeleton";
 import { generateJsonData } from "@utils/helpers";
-import { getEventBySlug } from "@lib/api/events";
+import { getEventBySlug, getEventBySlugForMetadata } from "@lib/api/events";
 import { Metadata } from "next";
 import { siteUrl } from "@config/index";
 import { generateEventMetadata } from "@lib/meta";
@@ -57,7 +57,9 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const slug = (await props.params).eventId;
   const locale = (await rootLocale()) as AppLocale;
-  const event = await getEventBySlug(slug);
+  // Use the request-independent reader: reading headers() here would make
+  // metadata dynamic under cacheComponents and mismatch the prerendered shell.
+  const event = await getEventBySlugForMetadata(slug);
   if (!event) return { title: "No event found" };
   // Use canonical derived from the event itself to avoid locking old slugs
   // into metadata; this helps consolidate SEO to the canonical path.

--- a/app/[locale]/noticies/[place]/[article]/page.tsx
+++ b/app/[locale]/noticies/[place]/[article]/page.tsx
@@ -1,7 +1,7 @@
 // No headers/nonce needed with relaxed CSP
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { getNewsBySlug } from "@lib/api/news";
+import { getNewsBySlug, getNewsBySlugForMetadata } from "@lib/api/news";
 import type { NewsDetailResponseDTO } from "types/api/news";
 import { getTranslations } from "next-intl/server";
 import { siteUrl } from "@config/index";
@@ -53,7 +53,9 @@ export async function generateMetadata({
   const { place, article } = await params;
   let detail: NewsDetailResponseDTO | null = null;
   try {
-    detail = await getNewsBySlug(article);
+    // Request-independent reader: headers() here would make metadata dynamic
+    // under cacheComponents and mismatch the prerendered shell.
+    detail = await getNewsBySlugForMetadata(article);
   } catch (error) {
     reportNewsDetailError("generateMetadata", error, { place, article });
   }

--- a/docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
+++ b/docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
@@ -1,0 +1,108 @@
+# cacheComponents Metadata Resume Mismatch + Oversized Cache Tag
+
+## Summary
+
+Two errors were flooding the self-hosted (Coolify) production logs, found while
+investigating frontend memory/restart behaviour:
+
+1. A constant PPR resume error: `Expected the resume to render <div> in this slot
+   but instead it rendered <__next_metadata_boundary__>. The tree doesn't match so
+   React will fallback to client rendering.` (digest `2239402817`).
+2. A recurring warning: a cache tag exceeded Next.js's 256-character limit, so
+   tagging silently failed for affected events.
+
+## Impact
+
+- **SEO / correctness:** every request hitting the resume mismatch bailed from
+  server rendering to client rendering, so the server shipped an incomplete tree.
+  It fired hardest on bot user-agents (matched by `htmlLimitedBots`, which forces
+  a blocking render), exactly the traffic where server HTML matters most.
+- **Cache correctness:** events whose id produced an oversized tag were never
+  tagged, so targeted `updateTag`/`revalidateTag` invalidation didn't reach them.
+- No downtime, no cost spike. Degraded SSR + log noise.
+
+## Timeline
+
+- Ongoing in production (last deploy 2026-05-18). Surfaced 2026-06-13 while
+  reading container logs via the Coolify MCP during a memory investigation.
+
+## Root Cause
+
+### 1. Dynamic metadata under cacheComponents
+
+`generateMetadata` on the event (`app/[locale]/e/[eventId]/page.tsx`) and news
+article (`app/[locale]/noticies/[place]/[article]/page.tsx`) pages fetched the
+entity through `getInternalApiUrl` (`utils/api-helpers.ts`), which reads
+`headers().get("host")` to resolve the request origin.
+
+With `cacheComponents: true`, reading `headers()` makes the render runtime-dynamic.
+Because metadata is rendered behind the `__next_metadata_boundary__`, making it
+dynamic moves that boundary into the dynamic **resume** tree, while the static PPR
+**prerender** produced a plain `<div>` at the same slot. On resume the positions
+disagree, React reports the tree mismatch, and falls back to client rendering.
+This is the app-code branch of Next's
+[`next-prerender-dynamic-metadata`](https://nextjs.org/docs/messages/next-prerender-dynamic-metadata)
+rule: _Document Metadata must not depend on uncached/runtime data_. The dynamic
+dependency was pulled in transitively and silently — nothing in `generateMetadata`
+looked dynamic at a glance.
+
+The page **content** was already explicitly dynamic (`await connection()` in
+`EventPageContent`), so the fix is to keep metadata static, not to make it match
+the dynamic content.
+
+### 2. Oversized cache tag
+
+A malformed event id — a whole RSS `link` + `description` collapsed into the slug
+by the backend feed parser — was interpolated directly into an `event:${slug}`
+tag, pushing it past Next's 256-char limit. The tag was built inline at the fetch
+site, with no length guard.
+
+## Resolution
+
+1. **Metadata:** added request-independent readers `getEventBySlugForMetadata`
+   (`lib/api/events.ts`) and `getNewsBySlugForMetadata` (`lib/api/news.ts`) that
+   resolve the API origin from configuration (`INTERNAL_SITE_URL`/
+   `NEXT_PUBLIC_SITE_URL`) instead of `headers()`, via a new `preferConfiguredOrigin`
+   option on `getInternalApiUrl`. `generateMetadata` uses these; page content keeps
+   using the header-aware reader. Verified with `next build`: `/[locale]/e/[eventId]`
+   is now classified `◐` (Partial Prerender) with no dynamic-metadata errors.
+2. **Tag:** added `boundedTag()` in `lib/cache/tags.ts`. Oversized values are
+   truncated with a stable djb2 hash suffix so the tag stays ≤256 chars, unique,
+   and identical across set (`fetch`) and invalidate (`updateTag`/`revalidateTag`).
+   All slug-based builders (`eventTag`, `placeTag`, `newsPlaceTag`, `newsSlugTag`)
+   route through it; `lib/api/events.ts` uses the helper instead of inline tags.
+
+## Prevention
+
+- **Convention:** any `generateMetadata` that needs entity data MUST use a
+  `*ForMetadata` reader (request-independent), never a `headers()`-bound fetch.
+  Listing pages already use cached readers, so only the two detail pages were
+  affected.
+- **Lint guard:** `eslint.config.mjs` flags calls to the header-aware readers
+  (`getEventBySlug`/`getNewsBySlug`/`getInternalApiUrl`) inside a `generateMetadata`
+  function, pointing at the `*ForMetadata` alternative.
+- **Tags:** never interpolate a slug into a tag inline — always go through the
+  `lib/cache/tags.ts` builders, which enforce the 256-char limit. Covered by
+  `test/cache-tags.test.ts`.
+- **Build check:** `next build` reports per-route prerender mode; detail routes
+  should stay `◐` (Partial Prerender). A route flipping to `ƒ` (Dynamic) after a
+  metadata change is the signal this regressed.
+
+## Performance impact
+
+- Metadata is prerendered into the static shell again, so the shell (including
+  `<head>`) flushes immediately and PPR resume succeeds instead of discarding the
+  server tree and re-rendering on the client. Bots get complete server HTML with
+  no JS execution. Removes the constant error allocation + client-render churn.
+- Correct cache tagging restores targeted revalidation for previously-untagged
+  events, avoiding stale content and unnecessary full refetches.
+
+## Lessons Learned
+
+- Under `cacheComponents`, a single transitive `headers()`/`cookies()` call deep in
+  a shared helper can silently make `generateMetadata` dynamic and break PPR. The
+  blast radius of "read the request host" is larger than it looks.
+- Metadata and page content have independent dynamism. Making content dynamic does
+  not require (or excuse) making metadata dynamic.
+- Read production logs early. This was visible for weeks; a memory investigation
+  surfaced it only because we finally pulled container logs.

--- a/docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
+++ b/docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
@@ -78,9 +78,10 @@ site, with no length guard.
   `*ForMetadata` reader (request-independent), never a `headers()`-bound fetch.
   Listing pages already use cached readers, so only the two detail pages were
   affected.
-- **Lint guard:** `eslint.config.mjs` flags calls to the header-aware readers
-  (`getEventBySlug`/`getNewsBySlug`/`getInternalApiUrl`) inside a `generateMetadata`
-  function, pointing at the `*ForMetadata` alternative.
+- **Lint guard:** `eslint.config.mjs` flags calls to the header-aware event/news
+  readers (`getEventBySlug`, `getNewsBySlug`, `fetchEventBySlug`,
+  `fetchEventBySlugWithStatus`, `fetchNewsBySlug`, `fetchNews`, `fetchNewsCities`)
+  inside a `generateMetadata` function, pointing at the `*ForMetadata` alternative.
 - **Tags:** never interpolate a slug into a tag inline — always go through the
   `lib/cache/tags.ts` builders, which enforce the 256-char limit. Covered by
   `test/cache-tags.test.ts`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,9 +108,9 @@ export default [
           // boundary into the resume tree and breaks PPR. Covers declaration and
           // arrow/expression forms. See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
           selector:
-            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug)$/]",
+            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEventBySlug|fetchNewsBySlug)$/]",
           message:
-            "Do not call getEventBySlug/getNewsBySlug inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
+            "Do not call getEventBySlug/getNewsBySlug/fetchEventBySlug/fetchNewsBySlug inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -101,6 +101,17 @@ export default [
           message:
             "Do not declare interfaces outside of the /types directory. Centralize all interfaces in /types.",
         },
+        {
+          // Prevent dynamic metadata under cacheComponents (PPR): generateMetadata
+          // must not call request-bound readers (getEventBySlug/getNewsBySlug read
+          // headers()), which makes metadata runtime-dynamic, pushes the metadata
+          // boundary into the resume tree and breaks PPR. Covers declaration and
+          // arrow/expression forms. See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
+          selector:
+            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug)$/]",
+          message:
+            "Do not call getEventBySlug/getNewsBySlug inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
+        },
       ],
     },
   },
@@ -250,27 +261,6 @@ export default [
                 "Prefer importing Link from '@i18n/routing' for automatic locale handling. Use next/link only for external URLs or in primitives with manual locale handling.",
             },
           ],
-        },
-      ],
-    },
-  },
-  // Prevent dynamic metadata under cacheComponents (PPR).
-  // generateMetadata must not fetch via request-bound readers: getEventBySlug /
-  // getNewsBySlug resolve the origin from headers(), which makes metadata
-  // runtime-dynamic, pushes the metadata boundary into the resume tree and
-  // breaks PPR ("Expected the resume to render <div> ... <__next_metadata_boundary__>").
-  // Use the request-independent *ForMetadata readers instead.
-  // See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
-  {
-    files: ["app/**/e/**/page.tsx", "app/**/noticies/**/page.tsx"],
-    rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "FunctionDeclaration[id.name='generateMetadata'] CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug)$/]",
-          message:
-            "Do not call getEventBySlug/getNewsBySlug inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -254,4 +254,25 @@ export default [
       ],
     },
   },
+  // Prevent dynamic metadata under cacheComponents (PPR).
+  // generateMetadata must not fetch via request-bound readers: getEventBySlug /
+  // getNewsBySlug resolve the origin from headers(), which makes metadata
+  // runtime-dynamic, pushes the metadata boundary into the resume tree and
+  // breaks PPR ("Expected the resume to render <div> ... <__next_metadata_boundary__>").
+  // Use the request-independent *ForMetadata readers instead.
+  // See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
+  {
+    files: ["app/**/e/**/page.tsx", "app/**/noticies/**/page.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "FunctionDeclaration[id.name='generateMetadata'] CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug)$/]",
+          message:
+            "Do not call getEventBySlug/getNewsBySlug inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
+        },
+      ],
+    },
+  },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,9 +108,9 @@ export default [
           // boundary into the resume tree and breaks PPR. Covers declaration and
           // arrow/expression forms. See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
           selector:
-            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEventBySlug|fetchNewsBySlug|fetchEventBySlugWithStatus)$/]",
+            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEvents|fetchEventBySlug|fetchEventBySlugWithStatus|fetchNews|fetchNewsBySlug|fetchNewsCities)$/]",
           message:
-            "Do not call event/news slug readers (getEventBySlug, getNewsBySlug, fetchEventBySlug, fetchNewsBySlug, fetchEventBySlugWithStatus) inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
+            "Do not call event/news data readers inside generateMetadata — they read request data (headers()/connection()) and make metadata dynamic under cacheComponents, breaking PPR. Use the request-independent getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -210,15 +210,18 @@ export default [
   // CRITICAL: Prevent searchParams in listing pages to avoid cache explosion
   // Reading searchParams makes pages dynamic, creating a separate cache entry per unique URL+query
   // See: Dec 28, 2025 incident - 200M cache writes = $307 cost
+  // NOTE: glob targets the locale-nested route (app/[locale]/[place]/**). The
+  // previous `app/[place]/**` glob matched no files after the next-intl [locale]
+  // segment was added, silently disabling this guard.
   {
-    files: ["app/\\[place\\]/**/*.tsx", "app/\\[place\\]/**/*.ts"],
+    files: ["app/\\[locale\\]/\\[place\\]/**/*.tsx", "app/\\[locale\\]/\\[place\\]/**/*.ts"],
     rules: {
       "no-restricted-syntax": [
         "error",
         {
           selector: "Identifier[name='searchParams']",
           message:
-            "⚠️ COST ALERT: Do NOT use searchParams in app/[place]/* pages! This makes pages dynamic and creates millions of cache entries ($300+ cost spike on Dec 28, 2025). Handle query params in middleware (proxy.ts) or client-side (SWR) instead.",
+            "⚠️ COST ALERT: Do NOT use searchParams in app/[locale]/[place]/* pages! This makes pages dynamic and creates millions of cache entries ($300+ cost spike on Dec 28, 2025). Handle query params in middleware (proxy.ts) or client-side (SWR) instead.",
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,9 +108,9 @@ export default [
           // boundary into the resume tree and breaks PPR. Covers declaration and
           // arrow/expression forms. See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
           selector:
-            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEventBySlug|fetchNewsBySlug)$/]",
+            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEventBySlug|fetchNewsBySlug|fetchEventBySlugWithStatus)$/]",
           message:
-            "Do not call getEventBySlug/getNewsBySlug/fetchEventBySlug/fetchNewsBySlug inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
+            "Do not call event/news slug readers (getEventBySlug, getNewsBySlug, fetchEventBySlug, fetchNewsBySlug, fetchEventBySlugWithStatus) inside generateMetadata — they read headers() and make metadata dynamic under cacheComponents, breaking PPR. Use getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
         },
       ],
     },

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -19,7 +19,6 @@ import {
 import {
   fetchCategorizedEventsExternal,
   fetchEventsExternal,
-  fetchEventBySlug as fetchEventBySlugExternal,
 } from "./events-external";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 import {
@@ -169,14 +168,6 @@ export async function fetchEventBySlug(
 ): Promise<EventDetailResponseDTO | null> {
   if (isE2ETestMode && e2eEventsStore?.has(fullSlug)) {
     return e2eEventsStore.get(fullSlug) ?? null;
-  }
-  // During build/SSG the internal /api/* routes aren't served, so read the
-  // backend directly (matches the list fetchers' isBuildPhase behavior; also
-  // no-store, avoiding the build-time fetch-cache explosion). Relevant if a
-  // future generateStaticParams prerenders event slugs — generateMetadata uses
-  // this path via getEventBySlugForMetadata.
-  if (isBuildPhase) {
-    return fetchEventBySlugExternal(fullSlug);
   }
   try {
     // Read via internal API route (stable cache, HMAC stays server-side)

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -19,6 +19,7 @@ import {
 import {
   fetchCategorizedEventsExternal,
   fetchEventsExternal,
+  fetchEventBySlug as fetchEventBySlugExternal,
 } from "./events-external";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 import {
@@ -168,6 +169,14 @@ export async function fetchEventBySlug(
 ): Promise<EventDetailResponseDTO | null> {
   if (isE2ETestMode && e2eEventsStore?.has(fullSlug)) {
     return e2eEventsStore.get(fullSlug) ?? null;
+  }
+  // During build/SSG the internal /api/* routes aren't served, so read the
+  // backend directly (matches the list fetchers' isBuildPhase behavior; also
+  // no-store, avoiding the build-time fetch-cache explosion). Relevant if a
+  // future generateStaticParams prerenders event slugs — generateMetadata uses
+  // this path via getEventBySlugForMetadata.
+  if (isBuildPhase) {
+    return fetchEventBySlugExternal(fullSlug);
   }
   try {
     // Read via internal API route (stable cache, HMAC stays server-side)

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -10,6 +10,7 @@ import {
   isApiUrlConfigured,
 } from "@utils/api-helpers";
 import { slugifySegment } from "@utils/string-helpers";
+import { eventsTag, eventTag } from "@lib/cache/tags";
 import {
   parseEventDetail,
   parsePagedEvents,
@@ -163,6 +164,7 @@ export const fetchEvents = cache(fetchEventsInternal);
 
 export async function fetchEventBySlug(
   fullSlug: string,
+  options: { preferConfiguredOrigin?: boolean } = {},
 ): Promise<EventDetailResponseDTO | null> {
   if (isE2ETestMode && e2eEventsStore?.has(fullSlug)) {
     return e2eEventsStore.get(fullSlug) ?? null;
@@ -170,11 +172,13 @@ export async function fetchEventBySlug(
   try {
     // Read via internal API route (stable cache, HMAC stays server-side)
     // Use getInternalApiUrl which resolves the correct internal origin
-    const internalApiUrl = await getInternalApiUrl(`/api/events/${fullSlug}`);
+    const internalApiUrl = await getInternalApiUrl(`/api/events/${fullSlug}`, {
+      preferConfiguredOrigin: options.preferConfiguredOrigin,
+    });
 
     const res = await fetch(internalApiUrl, {
       headers: getVercelProtectionBypassHeaders(),
-      next: { revalidate: 1800, tags: ["events", `event:${fullSlug}`] },
+      next: { revalidate: 1800, tags: [eventsTag, eventTag(fullSlug)] },
     });
 
     if (res.status === 404) {
@@ -214,7 +218,7 @@ export async function fetchEventBySlugWithStatus(fullSlug: string): Promise<{
 
     const res = await fetch(internalApiUrl, {
       headers: getVercelProtectionBypassHeaders(),
-      next: { revalidate: 1800, tags: ["events", `event:${fullSlug}`] },
+      next: { revalidate: 1800, tags: [eventsTag, eventTag(fullSlug)] },
     });
 
     if (res.status === 404) {
@@ -243,9 +247,19 @@ export async function fetchEventBySlugWithStatus(fullSlug: string): Promise<{
   }
 }
 
-// Cached wrapper to deduplicate event fetches within the same request
-// Used by both generateMetadata and the page component
+// Cached wrapper to deduplicate event fetches within the same request.
+// Used by the page component (which is explicitly dynamic via connection()).
 export const getEventBySlug = cache(fetchEventBySlug);
+
+// Metadata-only reader: resolves the API origin from configuration instead of
+// request headers(), so generateMetadata stays prerenderable under
+// cacheComponents. Reading headers() there would make the metadata boundary
+// dynamic and mismatch the static shell ("Expected the resume to render <div>
+// ... but instead it rendered <__next_metadata_boundary__>").
+export const getEventBySlugForMetadata = cache(
+  (slug: string): Promise<EventDetailResponseDTO | null> =>
+    fetchEventBySlug(slug, { preferConfiguredOrigin: true }),
+);
 
 export async function updateEventById(
   uuid: string,

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -11,6 +11,7 @@ import {
 } from "@utils/api-helpers";
 import { slugifySegment } from "@utils/string-helpers";
 import { eventsTag, eventTag } from "@lib/cache/tags";
+import type { InternalOriginOptions } from "types/api/internal";
 import {
   parseEventDetail,
   parsePagedEvents,
@@ -164,7 +165,7 @@ export const fetchEvents = cache(fetchEventsInternal);
 
 export async function fetchEventBySlug(
   fullSlug: string,
-  options: { preferConfiguredOrigin?: boolean } = {},
+  options: InternalOriginOptions = {},
 ): Promise<EventDetailResponseDTO | null> {
   if (isE2ETestMode && e2eEventsStore?.has(fullSlug)) {
     return e2eEventsStore.get(fullSlug) ?? null;

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -15,6 +15,7 @@ import {
 import { newsTag, newsPlaceTag, newsSlugTag } from "../cache/tags";
 import type { CacheTag } from "types/cache";
 import { addCacheKeyToNewsList, addCacheKeyToNewsDetail } from "@utils/news-cache";
+import type { InternalOriginOptions } from "types/api/internal";
 
 // Re-export for backward compatibility
 export type { FetchNewsParams } from "types/api/news";
@@ -60,7 +61,7 @@ export async function fetchNews(
 
 export async function fetchNewsBySlug(
   slug: string,
-  options: { preferConfiguredOrigin?: boolean } = {}
+  options: InternalOriginOptions = {}
 ): Promise<NewsDetailResponseDTO | null> {
   // Internal route
   try {

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -15,8 +15,6 @@ import {
 import { newsTag, newsPlaceTag, newsSlugTag } from "../cache/tags";
 import type { CacheTag } from "types/cache";
 import { addCacheKeyToNewsList, addCacheKeyToNewsDetail } from "@utils/news-cache";
-import { isBuildPhase } from "@utils/constants";
-import { fetchNewsBySlugExternal } from "./news-external";
 
 // Re-export for backward compatibility
 export type { FetchNewsParams } from "types/api/news";
@@ -64,13 +62,6 @@ export async function fetchNewsBySlug(
   slug: string,
   options: { preferConfiguredOrigin?: boolean } = {}
 ): Promise<NewsDetailResponseDTO | null> {
-  // During build/SSG the internal /api/* routes aren't served — read the
-  // backend directly (no-store, avoiding the build-time fetch-cache explosion).
-  // Relevant if a future generateStaticParams prerenders slugs;
-  // generateMetadata uses this path via getNewsBySlugForMetadata.
-  if (isBuildPhase) {
-    return fetchNewsBySlugExternal(slug);
-  }
   // Internal route
   try {
     const url = await getInternalApiUrl(`/api/news/${slug}`, {

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -15,6 +15,8 @@ import {
 import { newsTag, newsPlaceTag, newsSlugTag } from "../cache/tags";
 import type { CacheTag } from "types/cache";
 import { addCacheKeyToNewsList, addCacheKeyToNewsDetail } from "@utils/news-cache";
+import { isBuildPhase } from "@utils/constants";
+import { fetchNewsBySlugExternal } from "./news-external";
 
 // Re-export for backward compatibility
 export type { FetchNewsParams } from "types/api/news";
@@ -62,6 +64,13 @@ export async function fetchNewsBySlug(
   slug: string,
   options: { preferConfiguredOrigin?: boolean } = {}
 ): Promise<NewsDetailResponseDTO | null> {
+  // During build/SSG the internal /api/* routes aren't served — read the
+  // backend directly (no-store, avoiding the build-time fetch-cache explosion).
+  // Relevant if a future generateStaticParams prerenders slugs;
+  // generateMetadata uses this path via getNewsBySlugForMetadata.
+  if (isBuildPhase) {
+    return fetchNewsBySlugExternal(slug);
+  }
   // Internal route
   try {
     const url = await getInternalApiUrl(`/api/news/${slug}`, {

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -59,11 +59,14 @@ export async function fetchNews(
 }
 
 export async function fetchNewsBySlug(
-  slug: string
+  slug: string,
+  options: { preferConfiguredOrigin?: boolean } = {}
 ): Promise<NewsDetailResponseDTO | null> {
   // Internal route
   try {
-    const url = await getInternalApiUrl(`/api/news/${slug}`);
+    const url = await getInternalApiUrl(`/api/news/${slug}`, {
+      preferConfiguredOrigin: options.preferConfiguredOrigin,
+    });
     const response = await fetch(url, {
       headers: getVercelProtectionBypassHeaders(),
       next: { revalidate: 3600, tags: [newsTag, newsSlugTag(slug)] },
@@ -115,6 +118,15 @@ export async function fetchNewsCities(params?: {
   }
 }
 
-// Cached wrapper to deduplicate news fetches within the same request
-// Used by both generateMetadata and the page component
+// Cached wrapper to deduplicate news fetches within the same request.
+// Used by the page component (explicitly dynamic).
 export const getNewsBySlug = cache(fetchNewsBySlug);
+
+// Metadata-only reader: resolves the API origin from configuration instead of
+// request headers(), so generateMetadata stays prerenderable under
+// cacheComponents (reading headers() would make the metadata boundary dynamic
+// and mismatch the static shell). Mirrors getEventBySlugForMetadata.
+export const getNewsBySlugForMetadata = cache(
+  (slug: string): Promise<NewsDetailResponseDTO | null> =>
+    fetchNewsBySlug(slug, { preferConfiguredOrigin: true }),
+);

--- a/lib/cache/tags.ts
+++ b/lib/cache/tags.ts
@@ -4,16 +4,47 @@
  */
 import type { CacheTag } from "types/cache";
 
+/** Next.js rejects cache tags longer than 256 characters. */
+const MAX_TAG_LENGTH = 256;
+
+/** Stable, non-cryptographic short hash (djb2) used to shorten oversized tags. */
+function shortTagHash(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * Build a `<prefix>:<value>` tag that always fits Next.js's 256-char limit.
+ * Oversized values (e.g. a malformed event id that carries a whole URL +
+ * description from a bad RSS parse) are truncated with a stable hash suffix, so
+ * the tag stays unique and identical across the fetch (set) and the
+ * updateTag/revalidateTag (invalidate) paths. Short values pass through verbatim.
+ */
+function boundedTag<Prefix extends string>(
+  prefix: Prefix,
+  value: string,
+): `${Prefix}:${string}` {
+  const tag = `${prefix}:${value}`;
+  if (tag.length <= MAX_TAG_LENGTH) return tag as `${Prefix}:${string}`;
+  const hash = shortTagHash(value);
+  // Reserve room for the ":" separator and the "-<hash>" suffix.
+  const keep = MAX_TAG_LENGTH - prefix.length - 2 - hash.length;
+  return `${prefix}:${value.slice(0, Math.max(0, keep))}-${hash}` as `${Prefix}:${string}`;
+}
+
 // Event tags
 export const eventsTag = "events" as const satisfies CacheTag;
 export const eventsCategorizedTag = "events:categorized" as const satisfies CacheTag;
 export const eventTag = (slug: string): `event:${string}` =>
-  `event:${slug}` as const;
+  boundedTag("event", slug);
 
 // Place tags
 export const placesTag = "places" as const satisfies CacheTag;
 export const placeTag = (slug: string): `place:${string}` =>
-  `place:${slug}` as const;
+  boundedTag("place", slug);
 
 // City tags
 export const citiesTag = "cities" as const satisfies CacheTag;
@@ -37,7 +68,7 @@ export const promotionsTag = "promotions" as const satisfies CacheTag;
 // News tags
 export const newsTag = "news" as const satisfies CacheTag;
 export const newsPlaceTag = (slug: string): `news:place:${string}` =>
-  `news:place:${slug}` as const;
+  boundedTag("news:place", slug);
 export const newsSlugTag = (slug: string): `news:${string}` =>
-  `news:${slug}` as const;
+  boundedTag("news", slug);
 

--- a/test/cache-tags.test.ts
+++ b/test/cache-tags.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  eventTag,
+  placeTag,
+  newsPlaceTag,
+  newsSlugTag,
+} from "@lib/cache/tags";
+
+// The malformed event id seen in production logs (a whole RSS link + description
+// collapsed into the slug) — this is what blew past Next's 256-char tag limit.
+const MALFORMED_SLUG =
+  "bibliobustitle-linkhttpswwwsantcugatsesgarriguescatactualitatagenda4010-bibliobushtmllink-descriptioncdata-4010-mon-17-nov-2025-112258-0100-2026-07-24-153000-2026-07-24-183000-c-rasa-de-lamell-24-de-juliol-del-2026-af53a4ee-e521-4ecb-b26a-11a7e95729b7";
+
+describe("cache tag builders", () => {
+  it("passes short slugs through verbatim", () => {
+    expect(eventTag("concert-major-2026")).toBe("event:concert-major-2026");
+    expect(placeTag("barcelona")).toBe("place:barcelona");
+  });
+
+  it("keeps oversized tags within Next.js's 256-char limit", () => {
+    const tag = eventTag(MALFORMED_SLUG);
+    expect(tag.length).toBeLessThanOrEqual(256);
+    expect(tag.startsWith("event:")).toBe(true);
+  });
+
+  it("is deterministic for the same slug (set and revalidate must match)", () => {
+    expect(eventTag(MALFORMED_SLUG)).toBe(eventTag(MALFORMED_SLUG));
+  });
+
+  it("distinguishes two oversized slugs that share a long prefix", () => {
+    const a = `${MALFORMED_SLUG}-aaaaaaaa`;
+    const b = `${MALFORMED_SLUG}-bbbbbbbb`;
+    expect(eventTag(a)).not.toBe(eventTag(b));
+  });
+
+  it("bounds every slug-based builder", () => {
+    for (const tag of [
+      eventTag(MALFORMED_SLUG),
+      placeTag(MALFORMED_SLUG),
+      newsPlaceTag(MALFORMED_SLUG),
+      newsSlugTag(MALFORMED_SLUG),
+    ]) {
+      expect(tag.length).toBeLessThanOrEqual(256);
+    }
+  });
+});

--- a/types/api/internal.ts
+++ b/types/api/internal.ts
@@ -1,0 +1,11 @@
+/**
+ * Options for internal API readers that can resolve the API origin from
+ * configuration instead of the request `headers()`.
+ *
+ * Set `preferConfiguredOrigin: true` in request-independent contexts (e.g.
+ * `generateMetadata`) so the read stays prerenderable under `cacheComponents` —
+ * reading `headers()` there makes metadata dynamic and breaks PPR.
+ */
+export interface InternalOriginOptions {
+  preferConfiguredOrigin?: boolean;
+}

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -9,6 +9,7 @@ import type { FetchEventsParams } from "types/event";
 import { distanceToRadius } from "types/event";
 import type { FetchNewsParams } from "@lib/api/news";
 import type { HeadersFn } from "types/utils";
+import type { InternalOriginOptions } from "types/api/internal";
 
 /** Default API URL used as fallback when NEXT_PUBLIC_API_URL is not set. */
 const DEFAULT_API_URL = apiDefaults.apiUrl;
@@ -98,7 +99,7 @@ export function getVercelProtectionBypassHeaders(): Record<string, string> {
  */
 export async function getInternalApiUrl(
   path: string,
-  options: { preferConfiguredOrigin?: boolean } = {},
+  options: InternalOriginOptions = {},
 ): Promise<string> {
   const normalized = path.startsWith("/") ? path : `/${path}`;
 

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -96,12 +96,19 @@ export function getVercelProtectionBypassHeaders(): Record<string, string> {
  * In Vercel preview deployments, this function will use the request host header
  * when available to ensure the correct preview URL is used.
  */
-export async function getInternalApiUrl(path: string): Promise<string> {
+export async function getInternalApiUrl(
+  path: string,
+  options: { preferConfiguredOrigin?: boolean } = {},
+): Promise<string> {
   const normalized = path.startsWith("/") ? path : `/${path}`;
 
   // Priority 1: Try to get host from request headers (works in server components)
-  // This ensures Vercel preview URLs are correctly resolved
-  if (headersFn) {
+  // This ensures Vercel preview URLs are correctly resolved.
+  // Skipped when preferConfiguredOrigin is set: reading headers() makes the
+  // caller dynamic, which under cacheComponents must be avoided in
+  // generateMetadata (otherwise the metadata boundary lands in the resume tree
+  // and mismatches the static shell). Metadata uses the configured origin below.
+  if (headersFn && !options.preferConfiguredOrigin) {
     try {
       const headersList = await headersFn();
       const host = headersList.get("host");


### PR DESCRIPTION
Fixes two production runtime errors found in the live Coolify logs (separate from the memory PR #345 — no file overlap).

## 1. PPR resume mismatch (the log flood) 🔴

```
⨯ Error: Expected the resume to render <div> in this slot but instead it rendered
  <__next_metadata_boundary__>. The tree doesn't match so React will fallback to
  client rendering.  { digest: '2239402817' }
```

**Root cause:** `generateMetadata` on the **event** (`/[locale]/e/[eventId]`) and **news article** (`/[locale]/noticies/[place]/[article]`) detail pages fetched the entity via `getInternalApiUrl`, which reads `headers().get("host")`. Under `cacheComponents` that makes metadata **runtime-dynamic**, so the `__next_metadata_boundary__` lands in the dynamic resume tree and no longer matches the prerendered shell's `<div>`. SSR bails to client rendering — losing server HTML (bad for SEO/bots). It floods logs because `htmlLimitedBots` forces a blocking render for bot UAs, where this path is hit hardest.

**Fix** (per Next's [`next-prerender-dynamic-metadata`](https://nextjs.org/docs/messages/next-prerender-dynamic-metadata)): give metadata a request-independent reader — `getEventBySlugForMetadata` / `getNewsBySlugForMetadata` — that resolves the API origin from configuration instead of `headers()`, via a new `preferConfiguredOrigin` option on `getInternalApiUrl`. Metadata becomes prerenderable; page content stays dynamic through its own `connection()`. Listing pages already use cached readers in metadata, so they're unaffected — scoped to the two detail pages.

**Verified:** `next build` succeeds with `cacheComponents` on; `/[locale]/e/[eventId]` is classified **◐ Partial Prerender**, no dynamic-metadata/resume errors. Final confirmation is watching prod logs for digest `2239402817` to stop after deploy (the error is runtime-resume-specific).

## 2. Cache tag exceeding 256 chars

```
Warning: invalid tags passed to fetch .../api/events/bibliobustitle-linkhttps...
tag: "event:bibliobustitle-linkhttps..." exceeded max length of 256
```

A malformed event id (a whole RSS `link`+`description` collapsed into the slug, from the backend feed parser) produced an `event:<…>` tag past Next's 256-char limit, so tagging silently failed. Added `boundedTag()` in `lib/cache/tags.ts`: oversized values are truncated with a stable djb2 hash suffix so the tag stays unique and **identical across set (`fetch`) and invalidate (`updateTag`/`revalidateTag`)**. Routed `lib/api/events.ts` through the helper. The malformed id itself is a backend (`esdeveniments-backend`) data issue worth fixing upstream.

## Verification
- `yarn typecheck` ✅ clean
- `next build` ✅ exit 0, event route ◐ PPR, no metadata/prerender errors
- New `test/cache-tags.test.ts` ✅ 5 passing (256-char cap, determinism, prefix-collision distinctness, all slug builders)

> Local `eslint` is a stale install (v10 vs pinned v9) that breaks the pre-commit/pre-push hooks independent of this change; CI lints with eslint 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PPR resume mismatch by making event/news detail metadata prerenderable and bounds cache tags to keep invalidation reliable; also restores the `searchParams` lint guard on place pages to prevent cache blowups.

- **Bug Fixes**
  - Metadata: added request-independent readers `getEventBySlugForMetadata`/`getNewsBySlugForMetadata`; introduced `getInternalApiUrl({ preferConfiguredOrigin: true })` and `InternalOriginOptions`; switched detail pages to use the new readers; `ESLint` now forbids `getEventBySlug`/`getNewsBySlug`, raw `fetchEventBySlug`/`fetchEventBySlugWithStatus`/`fetchNewsBySlug`, and list readers `fetchEvents`/`fetchNews`/`fetchNewsCities` inside any `generateMetadata`.
  - Cache tags: added `boundedTag()` with a stable hash and applied it to `eventTag`, `placeTag`, `newsPlaceTag`, and `newsSlugTag`; fetchers now use `eventsTag`/`eventTag`; tests cover the 256-char cap and determinism.
  - Lint guard: fixed the glob to `app/[locale]/[place]/**` to re-enable the `searchParams` cost guard on place listings.

<sup>Written for commit 8bec34df2e4c2ab2580dbaa77c5bb5119ba2814c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Reliability**
  * Made metadata generation request-independent to prevent dynamic behavior and improve caching/stability for event and news pages.
  * Bounded/truncated cache tags to avoid failures with oversized slugs.

* **Tests**
  * Added tests validating cache tag length, determinism, and distinctness for large/malformed slugs.

* **Documentation**
  * Added an incident report describing causes, impact, and resolutions for metadata/caching issues.

* **Chores**
  * Added linting guidance to discourage unsafe metadata readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->