### PR TITLE
fix(cache): use 'use cache' for metadata readers (PPR static shell)

### DIFF
--- a/app/[locale]/e/[eventId]/page.tsx
+++ b/app/[locale]/e/[eventId]/page.tsx
@@ -59,14 +59,10 @@ export async function generateMetadata(props: {
   const locale = (await rootLocale()) as AppLocale;
   // Use the request-independent reader: reading headers() here would make
   // metadata dynamic under cacheComponents and mismatch the prerendered shell.
-  // It throws on transient errors (so they aren't cached) — fall back to a
-  // minimal title for this request; the next request retries.
-  let event: Awaited<ReturnType<typeof getEventBySlugForMetadata>>;
-  try {
-    event = await getEventBySlugForMetadata(slug);
-  } catch {
-    return { title: "No event found" };
-  }
+  // It throws on transient errors — let that bubble so Next does NOT cache a
+  // broken render (SWR keeps the previous good page); only a genuine 404
+  // returns null below.
+  const event = await getEventBySlugForMetadata(slug);
   if (!event) return { title: "No event found" };
   // Use canonical derived from the event itself to avoid locking old slugs
   // into metadata; this helps consolidate SEO to the canonical path.

--- a/app/[locale]/e/[eventId]/page.tsx
+++ b/app/[locale]/e/[eventId]/page.tsx
@@ -59,7 +59,14 @@ export async function generateMetadata(props: {
   const locale = (await rootLocale()) as AppLocale;
   // Use the request-independent reader: reading headers() here would make
   // metadata dynamic under cacheComponents and mismatch the prerendered shell.
-  const event = await getEventBySlugForMetadata(slug);
+  // It throws on transient errors (so they aren't cached) — fall back to a
+  // minimal title for this request; the next request retries.
+  let event: Awaited<ReturnType<typeof getEventBySlugForMetadata>>;
+  try {
+    event = await getEventBySlugForMetadata(slug);
+  } catch {
+    return { title: "No event found" };
+  }
   if (!event) return { title: "No event found" };
   // Use canonical derived from the event itself to avoid locking old slugs
   // into metadata; this helps consolidate SEO to the canonical path.

--- a/app/[locale]/noticies/[place]/[article]/page.tsx
+++ b/app/[locale]/noticies/[place]/[article]/page.tsx
@@ -53,9 +53,16 @@ export async function generateMetadata({
   const { place, article } = await params;
   // Request-independent reader: headers() here would make metadata dynamic
   // under cacheComponents and mismatch the prerendered shell. It throws on
-  // transient errors — let that bubble so Next does NOT cache a broken render
-  // (SWR keeps the previous good page); a genuine 404 returns null below.
-  const detail = await getNewsBySlugForMetadata(article);
+  // transient errors — report with context, then re-throw so Next does NOT
+  // cache a broken render (SWR keeps the previous good page); a genuine 404
+  // returns null below.
+  let detail: NewsDetailResponseDTO | null = null;
+  try {
+    detail = await getNewsBySlugForMetadata(article);
+  } catch (error) {
+    reportNewsDetailError("generateMetadata", error, { place, article });
+    throw error;
+  }
   const canonicalPlace = getCanonicalPlaceSlugFromDetail(detail, place);
   const placeType = await getPlaceTypeAndLabelCached(place);
   const locale = (await rootLocale()) as AppLocale;

--- a/app/[locale]/noticies/[place]/[article]/page.tsx
+++ b/app/[locale]/noticies/[place]/[article]/page.tsx
@@ -51,14 +51,11 @@ export async function generateMetadata({
   params: Promise<{ place: string; article: string }>;
 }): Promise<Metadata> {
   const { place, article } = await params;
-  let detail: NewsDetailResponseDTO | null = null;
-  try {
-    // Request-independent reader: headers() here would make metadata dynamic
-    // under cacheComponents and mismatch the prerendered shell.
-    detail = await getNewsBySlugForMetadata(article);
-  } catch (error) {
-    reportNewsDetailError("generateMetadata", error, { place, article });
-  }
+  // Request-independent reader: headers() here would make metadata dynamic
+  // under cacheComponents and mismatch the prerendered shell. It throws on
+  // transient errors — let that bubble so Next does NOT cache a broken render
+  // (SWR keeps the previous good page); a genuine 404 returns null below.
+  const detail = await getNewsBySlugForMetadata(article);
   const canonicalPlace = getCanonicalPlaceSlugFromDetail(detail, place);
   const placeType = await getPlaceTypeAndLabelCached(place);
   const locale = (await rootLocale()) as AppLocale;

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -12,6 +12,7 @@ import {
 import { slugifySegment } from "@utils/string-helpers";
 import { eventsTag, eventTag } from "@lib/cache/tags";
 import type { InternalOriginOptions } from "types/api/internal";
+import { cacheLife, cacheTag } from "next/cache";
 import {
   parseEventDetail,
   parsePagedEvents,
@@ -257,10 +258,18 @@ export const getEventBySlug = cache(fetchEventBySlug);
 // cacheComponents. Reading headers() there would make the metadata boundary
 // dynamic and mismatch the static shell ("Expected the resume to render <div>
 // ... but instead it rendered <__next_metadata_boundary__>").
-export const getEventBySlugForMetadata = cache(
-  (slug: string): Promise<EventDetailResponseDTO | null> =>
-    fetchEventBySlug(slug, { preferConfiguredOrigin: true }),
-);
+export async function getEventBySlugForMetadata(
+  slug: string,
+): Promise<EventDetailResponseDTO | null> {
+  "use cache";
+  // cacheComponents: metadata must read CACHED data to be prerenderable. React
+  // cache() is only request memoization, so a revalidated fetch under it still
+  // counts as runtime I/O → no static shell → PPR resume mismatch. "use cache"
+  // marks it cached; preferConfiguredOrigin keeps headers() out (forbidden here).
+  cacheLife("hours");
+  cacheTag(eventsTag, eventTag(slug));
+  return fetchEventBySlug(slug, { preferConfiguredOrigin: true });
+}
 
 export async function updateEventById(
   uuid: string,

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -203,6 +203,11 @@ export async function fetchEventBySlug(
       `Error fetching event by slug (internal) for ${fullSlug}:`,
       errorMessage,
     );
+    // Transient failure: re-throw for cached metadata readers so the error is
+    // not cached as a null (a real 404 returned above, which is fine to cache).
+    if (options.throwOnError) {
+      throw error instanceof Error ? error : new Error(errorMessage);
+    }
     return null;
   }
 }
@@ -268,7 +273,10 @@ export async function getEventBySlugForMetadata(
   // marks it cached; preferConfiguredOrigin keeps headers() out (forbidden here).
   cacheLife("hours");
   cacheTag(eventsTag, eventTag(slug));
-  return fetchEventBySlug(slug, { preferConfiguredOrigin: true });
+  return fetchEventBySlug(slug, {
+    preferConfiguredOrigin: true,
+    throwOnError: true,
+  });
 }
 
 export async function updateEventById(

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -271,12 +271,20 @@ export async function getEventBySlugForMetadata(
   // cache() is only request memoization, so a revalidated fetch under it still
   // counts as runtime I/O → no static shell → PPR resume mismatch. "use cache"
   // marks it cached; preferConfiguredOrigin keeps headers() out (forbidden here).
-  cacheLife("hours");
   cacheTag(eventsTag, eventTag(slug));
-  return fetchEventBySlug(slug, {
+  const event = await fetchEventBySlug(slug, {
     preferConfiguredOrigin: true,
     throwOnError: true,
   });
+  if (!event) {
+    // Genuine 404: cache briefly so a newly-created event isn't stuck on
+    // "not found" metadata for hours. "minutes" not "seconds" — seconds is a
+    // PPR dynamic hole and would re-break the static shell.
+    cacheLife("minutes");
+    return null;
+  }
+  cacheLife("hours");
+  return event;
 }
 
 export async function updateEventById(

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -79,6 +79,11 @@ export async function fetchNewsBySlug(
     return addCacheKeyToNewsDetail(data);
   } catch (e) {
     console.error("Error fetching news by slug:", e);
+    // Transient failure: re-throw for cached metadata readers so the error is
+    // not cached as a null (a real 404 returned above, which is fine to cache).
+    if (options.throwOnError) {
+      throw e instanceof Error ? e : new Error(String(e));
+    }
     return null;
   }
 }
@@ -136,5 +141,8 @@ export async function getNewsBySlugForMetadata(
   // metadata prerenderable under cacheComponents.
   cacheLife("hours");
   cacheTag(newsTag, newsSlugTag(slug));
-  return fetchNewsBySlug(slug, { preferConfiguredOrigin: true });
+  return fetchNewsBySlug(slug, {
+    preferConfiguredOrigin: true,
+    throwOnError: true,
+  });
 }

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -16,6 +16,7 @@ import { newsTag, newsPlaceTag, newsSlugTag } from "../cache/tags";
 import type { CacheTag } from "types/cache";
 import { addCacheKeyToNewsList, addCacheKeyToNewsDetail } from "@utils/news-cache";
 import type { InternalOriginOptions } from "types/api/internal";
+import { cacheLife, cacheTag } from "next/cache";
 
 // Re-export for backward compatibility
 export type { FetchNewsParams } from "types/api/news";
@@ -127,7 +128,13 @@ export const getNewsBySlug = cache(fetchNewsBySlug);
 // request headers(), so generateMetadata stays prerenderable under
 // cacheComponents (reading headers() would make the metadata boundary dynamic
 // and mismatch the static shell). Mirrors getEventBySlugForMetadata.
-export const getNewsBySlugForMetadata = cache(
-  (slug: string): Promise<NewsDetailResponseDTO | null> =>
-    fetchNewsBySlug(slug, { preferConfiguredOrigin: true }),
-);
+export async function getNewsBySlugForMetadata(
+  slug: string,
+): Promise<NewsDetailResponseDTO | null> {
+  "use cache";
+  // See getEventBySlugForMetadata: "use cache" (not React cache) is what makes
+  // metadata prerenderable under cacheComponents.
+  cacheLife("hours");
+  cacheTag(newsTag, newsSlugTag(slug));
+  return fetchNewsBySlug(slug, { preferConfiguredOrigin: true });
+}

--- a/lib/api/news.ts
+++ b/lib/api/news.ts
@@ -139,10 +139,18 @@ export async function getNewsBySlugForMetadata(
   "use cache";
   // See getEventBySlugForMetadata: "use cache" (not React cache) is what makes
   // metadata prerenderable under cacheComponents.
-  cacheLife("hours");
   cacheTag(newsTag, newsSlugTag(slug));
-  return fetchNewsBySlug(slug, {
+  const detail = await fetchNewsBySlug(slug, {
     preferConfiguredOrigin: true,
     throwOnError: true,
   });
+  if (!detail) {
+    // Genuine 404: cache briefly so a newly-published article isn't stuck on
+    // "not found" metadata for hours. "minutes" not "seconds" — seconds is a
+    // PPR dynamic hole and would re-break the static shell.
+    cacheLife("minutes");
+    return null;
+  }
+  cacheLife("hours");
+  return detail;
 }

--- a/types/api/internal.ts
+++ b/types/api/internal.ts
@@ -8,4 +8,11 @@
  */
 export interface InternalOriginOptions {
   preferConfiguredOrigin?: boolean;
+  /**
+   * Re-throw on transient fetch failures (network error / non-404 HTTP error)
+   * instead of returning `null`. Set by cached metadata readers so a transient
+   * error is never cached as a missing-metadata `null` for the cacheLife window
+   * (a genuine 404 still returns `null`, which is safe to cache).
+   */
+  throwOnError?: boolean;
 }


### PR DESCRIPTION
Follow-up to #346. The PPR resume error (`digest: 2239402817`) was **still firing in production** after #346 merged — verified by cache-busting the Cloudflare origin and reading the live logs:

```
Route "/[locale]/e/[eventId]" did not produce a static shell ... NEXT_STATIC_GEN_BAILOUT
⨯ Error: Expected the resume to render <div> ... <__next_metadata_boundary__> ... digest: '2239402817'
```

## Why #346 was insufficient

#346 made `generateMetadata` fetch via a request-independent reader wrapped in **React `cache()`**. But under `cacheComponents`, React `cache()` is only request memoization — a `fetch` with `next:{revalidate}` under it still counts as **runtime I/O at prerender**, so the route produces no static shell and the metadata boundary lands in the dynamic resume tree → mismatch. Per the [Cache Components docs](https://nextjs.org/docs/app/getting-started/cache-components), prerenderable data must use the **`use cache`** directive.

## Fix

`getEventBySlugForMetadata` / `getNewsBySlugForMetadata` are now `"use cache"` functions with `cacheLife("hours")` + `cacheTag(...)`. `preferConfiguredOrigin` keeps `headers()` out of the call path (which `use cache` forbids).

## Verified on staging (`staging.esdeveniments.cat`, runs `develop` + Redis = same cacheComponents+Redis condition as prod)

Deployed `e94a441b` to staging, then ran the **same** cache-busted-origin + Googlebot protocol that reproduces the error on prod:
- **Staging logs: zero resume errors, zero `NEXT_STATIC_GEN_BAILOUT`** after 8 origin requests.
- Event pages render correct event-specific metadata (`<title>Recollida d'andròmines | Sant Martí d'Albars | Osona</title>`, real og:title, full 464 KB body) — not a fallback shell.
- `yarn typecheck` + `eslint` + `next build` clean.

> Local `next build` cannot reproduce this — it's a runtime PPR-resume error, and prod sits behind Cloudflare (plain requests hit cache, not origin). Hence staging + cache-bust is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persistent PPR resume errors by switching metadata readers to the "use cache" directive so prerendering produces a static shell under cacheComponents. Also prevents caching broken metadata and adds error reporting for news metadata while still letting errors bubble.

- **Bug Fixes**
  - Switched `getEventBySlugForMetadata` and `getNewsBySlugForMetadata` to "use cache" with `cacheTag(...)` and conditional `cacheLife`: "minutes" for 404, "hours" when found; kept `preferConfiguredOrigin` to avoid `headers()` in the call path.
  - Added `throwOnError` to slug fetchers; metadata readers set it so transient failures re-throw and are not cached. Event `generateMetadata` lets errors bubble; news `generateMetadata` now catches only to call `reportNewsDetailError(...)`, then re-throws.
  - Outcome: eliminates `NEXT_STATIC_GEN_BAILOUT` and digest mismatches in production and reduces 404 stickiness.

<sup>Written for commit f21e2c65350f821fb58c4a5b461c72dec725d735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated caching implementation for event and news content metadata retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->