### PR TITLE
ci(deploy): bump Coolify wait timeout to match real build time

### DIFF
--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -221,9 +221,9 @@ jobs:
       (needs.quality.result == 'success' || needs.quality.result == 'skipped') &&
       (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&
       (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
-    # 15 min = 10 min MAX_WAIT for Coolify build (realistic for Next.js + Docker)
-    # + ~5 min for webhook trigger, smoke tests, and GitHub runner overhead.
-    timeout-minutes: 15
+    # 20 min = 15 min MAX_WAIT for Coolify build (prod Next.js + Docker rebuilds
+    # run ~12 min) + ~5 min for webhook trigger, smoke tests, and runner overhead.
+    timeout-minutes: 20
     # GitHub Environment enables protection rules, required reviewers, and environment-specific secrets
     environment:
       name: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
@@ -298,10 +298,10 @@ jobs:
           # Coolify dashboard → Application → Environment so /api/health
           # exposes the running commit SHA.
           #
-          # Next.js + Docker builds routinely take 5-8 minutes on Coolify.
-          # A short MAX_WAIT produced silent false-positive "successes" when
-          # the workflow exited before the container actually swapped.
-          MAX_WAIT=600  # 10 minutes — realistic upper bound for full rebuild
+          # Prod Next.js + Docker rebuilds on Coolify run ~12 minutes. Too-short
+          # a MAX_WAIT fails the step (and skips the CDN purge + smoke tests)
+          # even though the deploy then succeeds — a false negative.
+          MAX_WAIT=900  # 15 minutes — covers the ~12 min full rebuild with margin
           INTERVAL=10
           ELAPSED=0
           DEPLOY_CONFIRMED=0


### PR DESCRIPTION
## Why

Run [27570658174](https://github.com/Esdeveniments/esdeveniments-frontend/actions/runs/27570658174) showed a red ❌ on **Deploy to Coolify** even though the deploy succeeded and prod is healthy.

Root cause: the "Wait for Coolify deployment to complete" step uses `MAX_WAIT=600` (10 min), but the prod Next.js + Docker rebuild ran **12m4s** (19:27:50 → 19:39:54). The step timed out 2 min early (`Container did NOT swap within 600s`) while the deploy finished right after — a **false negative**.

Worse, because the wait step "failed," the two steps after it were **skipped**:
- **Purge Cloudflare CDN cache** → the edge kept serving stale (pre-fix) pages until TTL expiry (~30 min).
- **Post-deploy smoke tests** → didn't run.

## Change

- `MAX_WAIT` 600 → **900** (15 min) — covers the ~12-min build with margin.
- Job `timeout-minutes` 15 → **20** (15 min wait + ~5 min for trigger/smoke/runner).
- Fixed the stale comments that claimed 5–8 min builds.

No logic change — just the timeout values, so the next deploy confirms green and actually runs the CDN purge + smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the Coolify deploy wait window to match real Next.js + Docker build time, preventing false failures and ensuring CDN purge and smoke tests run. Wait is now 15 minutes; job timeout is 20 minutes.

- **Bug Fixes**
  - Increased `MAX_WAIT` to 900s (15m) for the Coolify deployment check.
  - Raised job `timeout-minutes` to 20 to cover wait plus overhead.

<sup>Written for commit dd8484ad9f984929157d4f962ea10fec6cc81e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

