### PR TITLE
perf(sitemap): parallelize news hub/detail fetches (fix build timeout)

### DIFF
--- a/app/server-google-news-sitemap.xml/route.ts
+++ b/app/server-google-news-sitemap.xml/route.ts
@@ -57,33 +57,47 @@ export async function GET() {
     publicationDate: string;
   }[] = [];
 
-  for (const hub of NEWS_HUBS) {
-    try {
-      const res = await fetchNews({ page: 0, size: 20, place: hub.slug });
-      const items = Array.isArray(res.content) ? res.content : [];
-      for (const item of items) {
-        // Fetch detail to get accurate publication datetime
-        const detail = await fetchNewsBySlug(item.slug);
-        if (!detail || !detail.createdAt) continue;
-        const pubMs = Date.parse(detail.createdAt);
-        if (isNaN(pubMs) || now - pubMs > cutoffMs) continue;
-        const basePath = `/noticies/${hub.slug}/${item.slug}`;
-        const localizedUrls = buildLocalizedUrls(basePath);
-
-        SUPPORTED_LOCALES.forEach((locale) => {
-          const loc = localizedUrls[locale] ?? `${siteUrl}${basePath}`;
-          candidates.push({
-            loc,
-            publicationName: "Esdeveniments.cat",
-            language: localeToHrefLang[locale as AppLocale] ?? locale,
-            title: detail.title,
-            publicationDate: new Date(pubMs).toISOString(),
-          });
-        });
+  // Fetch hubs and their per-article details IN PARALLEL. The previous nested
+  // sequential awaits (hubs x ~20 detail fetches) blew past the 60s build-export
+  // limit when the API was slow. NEWS_HUBS is small, so an unbounded Promise.all
+  // is fine — add a concurrency cap if it ever grows large.
+  const perHub = await Promise.all(
+    NEWS_HUBS.map(async (hub) => {
+      try {
+        const res = await fetchNews({ page: 0, size: 20, place: hub.slug });
+        const items = Array.isArray(res.content) ? res.content : [];
+        return await Promise.all(
+          items.map(async (item) => ({
+            hub,
+            item,
+            // Detail fetch gives the accurate publication datetime
+            detail: await fetchNewsBySlug(item.slug),
+          }))
+        );
+      } catch (e) {
+        console.error("google-news-sitemap: error fetching hub", hub.slug, e);
+        return [];
       }
-    } catch (e) {
-      console.error("google-news-sitemap: error fetching hub", hub.slug, e);
-    }
+    })
+  );
+
+  for (const { hub, item, detail } of perHub.flat()) {
+    if (!detail || !detail.createdAt) continue;
+    const pubMs = Date.parse(detail.createdAt);
+    if (isNaN(pubMs) || now - pubMs > cutoffMs) continue;
+    const basePath = `/noticies/${hub.slug}/${item.slug}`;
+    const localizedUrls = buildLocalizedUrls(basePath);
+
+    SUPPORTED_LOCALES.forEach((locale) => {
+      const loc = localizedUrls[locale] ?? `${siteUrl}${basePath}`;
+      candidates.push({
+        loc,
+        publicationName: "Esdeveniments.cat",
+        language: localeToHrefLang[locale as AppLocale] ?? locale,
+        title: detail.title,
+        publicationDate: new Date(pubMs).toISOString(),
+      });
+    });
   }
 
   // Google News sitemaps must contain at least one URL

--- a/app/server-google-news-sitemap.xml/route.ts
+++ b/app/server-google-news-sitemap.xml/route.ts
@@ -57,23 +57,35 @@ export async function GET() {
     publicationDate: string;
   }[] = [];
 
-  // Fetch hubs and their per-article details IN PARALLEL. The previous nested
-  // sequential awaits (hubs x ~20 detail fetches) blew past the 60s build-export
-  // limit when the API was slow. NEWS_HUBS is small, so an unbounded Promise.all
-  // is fine — add a concurrency cap if it ever grows large.
+  // Fetch hubs IN PARALLEL, but cap each hub's per-article detail fetches at
+  // DETAIL_CONCURRENCY so we never hit the API with hubs x ~20 requests at once
+  // (socket exhaustion / 429). Sequential awaits blew past the 60s build-export
+  // limit; ~5 per hub keeps it fast (well under 60s) and gentle (≤20 in flight).
+  const DETAIL_CONCURRENCY = 5;
   const perHub = await Promise.all(
     NEWS_HUBS.map(async (hub) => {
       try {
         const res = await fetchNews({ page: 0, size: 20, place: hub.slug });
         const items = Array.isArray(res.content) ? res.content : [];
-        return await Promise.all(
-          items.map(async (item) => ({
-            hub,
-            item,
-            // Detail fetch gives the accurate publication datetime
-            detail: await fetchNewsBySlug(item.slug),
-          }))
-        );
+        const resolved: {
+          hub: (typeof NEWS_HUBS)[number];
+          item: (typeof items)[number];
+          detail: Awaited<ReturnType<typeof fetchNewsBySlug>>;
+        }[] = [];
+        for (let i = 0; i < items.length; i += DETAIL_CONCURRENCY) {
+          const chunk = items.slice(i, i + DETAIL_CONCURRENCY);
+          resolved.push(
+            ...(await Promise.all(
+              chunk.map(async (item) => ({
+                hub,
+                item,
+                // Detail fetch gives the accurate publication datetime
+                detail: await fetchNewsBySlug(item.slug),
+              }))
+            ))
+          );
+        }
+        return resolved;
       } catch (e) {
         console.error("google-news-sitemap: error fetching hub", hub.slug, e);
         return [];

--- a/app/server-news-sitemap.xml/route.ts
+++ b/app/server-news-sitemap.xml/route.ts
@@ -20,31 +20,40 @@ export async function GET() {
 
   const articleEntries: SitemapField[] = [];
 
-  // Fetch a limited number of recent articles per hub to avoid oversized sitemap
-  for (const hub of NEWS_HUBS) {
-    try {
-      const res = await fetchNews({ page: 0, size: 20, place: hub.slug });
-      const items = Array.isArray(res.content) ? res.content : [];
-      for (const item of items) {
-        const lastDate = item.endDate || item.startDate;
-        if (!item.slug || !lastDate) continue;
-        const loc = `${siteUrl}/noticies/${hub.slug}/${item.slug}`;
-        articleEntries.push({
-          loc,
-          lastmod: new Date(lastDate).toISOString(),
-          changefreq: "daily",
-          priority: 0.7,
-          alternates: buildAlternateLinks(loc),
-        });
+  // Fetch recent articles per hub IN PARALLEL. Sequential awaits blew past the
+  // 60s build-export limit when the API was slow. NEWS_HUBS is small, so an
+  // unbounded Promise.all is fine — add a concurrency cap if it ever grows.
+  const perHub = await Promise.all(
+    NEWS_HUBS.map(async (hub) => {
+      try {
+        const res = await fetchNews({ page: 0, size: 20, place: hub.slug });
+        return (Array.isArray(res.content) ? res.content : []).map((item) => ({
+          hub,
+          item,
+        }));
+      } catch (e) {
+        // Continue gracefully on a hub failure
+        console.error(
+          "server-news-sitemap: error fetching news for hub",
+          hub.slug,
+          e
+        );
+        return [];
       }
-    } catch (e) {
-      // Continue gracefully on a hub failure
-      console.error(
-        "server-news-sitemap: error fetching news for hub",
-        hub.slug,
-        e
-      );
-    }
+    })
+  );
+
+  for (const { hub, item } of perHub.flat()) {
+    const lastDate = item.endDate || item.startDate;
+    if (!item.slug || !lastDate) continue;
+    const loc = `${siteUrl}/noticies/${hub.slug}/${item.slug}`;
+    articleEntries.push({
+      loc,
+      lastmod: new Date(lastDate).toISOString(),
+      changefreq: "daily",
+      priority: 0.7,
+      alternates: buildAlternateLinks(loc),
+    });
   }
 
   const xml = buildSitemap([...listEntries, ...articleEntries], {});


### PR DESCRIPTION
## Why

The **Lighthouse CI** build failed intermittently (e.g. develop run [27606990031](https://github.com/Esdeveniments/esdeveniments-frontend/actions/runs/27606990031)):

```
Failed to build /server-news-sitemap.xml/route ... took more than 60 seconds (attempt 3 of 3)
Export encountered an error on /server-news-sitemap.xml/route, exiting the build.
```

The same commit **passed on main's CI** — so it's a flaky timeout, not a deterministic bug. Cause: both news sitemap routes fetched data **sequentially**:
- `server-news-sitemap.xml`: one `fetchNews` per hub, sequentially.
- `server-google-news-sitemap.xml`: per hub, then **`fetchNewsBySlug` per article** → ~`NEWS_HUBS × 20` sequential round-trips. At build these hit the live API; when it's slow, the export blows past Next's 60s limit.

## Fix

Parallelize with `Promise.all` (hubs, and the per-article detail fetches). `NEWS_HUBS` is small (4), so unbounded is fine — noted a concurrency cap as the upgrade path if it grows. No output/semantics change — same entries, same detail-based publication dates.

## Verified
- `yarn typecheck` clean.
- `next build` clean, exit 0, **no export timeout** on either sitemap route.

Not related to the PPR/metadata work — pre-existing sequential fetching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized news sitemap fetches and capped Google News detail fetch concurrency to prevent Next export timeouts and avoid API overload. No sitemap output changes; builds for `server-news-sitemap.xml` and `server-google-news-sitemap.xml` are faster and more reliable.

- **Bug Fixes**
  - Fetch hubs in parallel; in Google News, fetch per-article details in chunks of 5 per hub to avoid 429s/socket exhaustion.
  - Keeps entries identical (same URLs and publication dates); hub-level errors are logged and skipped.
  - Stays well under the 60s export limit while keeping parallelism modest.

<sup>Written for commit b33eddacc769bca75dc19734e0b4ad5da1f962fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized news sitemap generation to fetch hub listings and article details in parallel instead of sequentially, improving performance.

* **Bug Fixes**
  * Enhanced error handling to isolate failures at the hub level, preventing one hub error from affecting others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->