### PR TITLE
test(e2e): de-flake event-data-dependent deploy gate tests

### DIFF
--- a/e2e/add-to-calendar.spec.ts
+++ b/e2e/add-to-calendar.spec.ts
@@ -1,18 +1,10 @@
-import { test, expect, type Page } from "@playwright/test";
-
-async function getFirstEventSlug(page: Page): Promise<string | undefined> {
-  // Use internal API so HMAC is handled server-side
-  const res = await page.request.get(`/api/events?size=1`);
-  const data = (await res.json()) as { content?: Array<{ slug?: string }> };
-  const slug = data?.content?.[0]?.slug;
-  return slug ?? undefined;
-}
+import { test, expect } from "@playwright/test";
+import { gotoFirstResolvableEvent } from "./helpers/events";
 
 test.describe("Add to calendar menu", () => {
   test("opens menu and shows calendar links", async ({ page }) => {
-    const slug = await getFirstEventSlug(page);
-    if (!slug) test.skip(true, "No events returned from API");
-    await page.goto(`/e/${slug}`, { waitUntil: "domcontentloaded", timeout: 60000 });
+    const slug = await gotoFirstResolvableEvent(page);
+    test.skip(slug === null, "No resolvable event returned from API");
 
     // Auto-waiting assertion - no need for manual waits
     const button = page.getByRole("button", { name: /Afegir al calendari/i });

--- a/e2e/favorites.flow.spec.ts
+++ b/e2e/favorites.flow.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForFavoritesReady } from "./helpers/events";
 
 function decodeCookieValue(raw: string): string {
   try {
@@ -59,6 +60,7 @@ test.describe("Favorites flow", () => {
   test("add favorite, see it on /preferits, persists after reload", async ({
     page,
   }) => {
+    const favoritesReady = waitForFavoritesReady(page);
     await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
 
     const firstEventLink = page
@@ -87,6 +89,9 @@ test.describe("Favorites flow", () => {
     });
     await expect(favButton).toHaveAttribute("aria-pressed", "false");
 
+    // Ensure the button has hydrated and SWR has settled before toggling, so
+    // the click isn't dropped and a late GET can't reset the optimistic state.
+    await favoritesReady;
     await favButton.click();
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
@@ -131,6 +136,7 @@ test.describe("Favorites flow", () => {
   test("remove favorite, /preferits becomes empty state after reload", async ({
     page,
   }) => {
+    const favoritesReady = waitForFavoritesReady(page);
     await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
 
     const firstEventLink = page
@@ -157,6 +163,8 @@ test.describe("Favorites flow", () => {
       timeout: process.env.CI ? 60000 : 30000,
     });
 
+    // Ensure hydration + SWR settle before toggling (see the add-favorite test).
+    await favoritesReady;
     // Toggle ON
     await favButton.click();
     await expect(favButton).toHaveAttribute("aria-pressed", "true");

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -1,0 +1,60 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Fetch candidate event slugs from the internal API proxy (HMAC is signed
+ * server-side). Returns an empty array if the API is unreachable or empty.
+ */
+export async function fetchEventSlugs(page: Page, size = 5): Promise<string[]> {
+  const res = await page.request.get(`/api/events?size=${size}`);
+  if (!res.ok()) return [];
+  const data = (await res.json()) as { content?: Array<{ slug?: string }> };
+  return (data?.content ?? [])
+    .map((event) => event?.slug)
+    .filter((slug): slug is string => typeof slug === "string" && slug.length > 0);
+}
+
+/**
+ * Navigate to the detail page of the first event whose `/e/[slug]` actually
+ * resolves, returning the slug used (or `null` if none of the candidates do).
+ *
+ * The event detail page renders the calendar button and Event JSON-LD
+ * unconditionally, so the only way they go missing is a `notFound()` (a
+ * CANCELLED event, or a transient cold-build SSR fetch miss). The list API can
+ * surface such a slug, which made tests that blindly used `content[0].slug`
+ * flaky. Trying the next candidate when a page 404s removes that dependency on
+ * which event happens to be first.
+ */
+export async function gotoFirstResolvableEvent(
+  page: Page,
+  { localePrefix = "" }: { localePrefix?: string } = {}
+): Promise<string | null> {
+  const slugs = await fetchEventSlugs(page);
+  for (const slug of slugs) {
+    const response = await page.goto(`${localePrefix}/e/${slug}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 90000,
+    });
+    if (response?.ok()) return slug;
+  }
+  return null;
+}
+
+/**
+ * Wait for the `useSWR` GET `/api/favorites` that every favorite button fires
+ * on mount. Resolving this response means the button has hydrated (so a click
+ * won't be dropped before React attaches its handler) and SWR has settled (so a
+ * late GET won't overwrite the optimistic `aria-pressed` state after a click).
+ *
+ * Must be called as a promise set up *before* `page.goto`, then awaited after
+ * navigation — otherwise the request may fire before the listener is attached.
+ * Tolerates the request having already resolved (e.g. on a retry).
+ */
+export function waitForFavoritesReady(page: Page): Promise<unknown> {
+  return page
+    .waitForResponse(
+      (r) =>
+        r.url().includes("/api/favorites") && r.request().method() === "GET",
+      { timeout: 30000 }
+    )
+    .catch(() => null);
+}

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -21,8 +21,12 @@ export async function fetchEventSlugs(page: Page, size = 5): Promise<string[]> {
  * unconditionally, so the only way they go missing is a `notFound()` (a
  * CANCELLED event, or a transient cold-build SSR fetch miss). The list API can
  * surface such a slug, which made tests that blindly used `content[0].slug`
- * flaky. Trying the next candidate when a page 404s removes that dependency on
- * which event happens to be first.
+ * flaky. Trying the next candidate when a page resolves to "not found" removes
+ * that dependency on which event happens to be first.
+ *
+ * Note: the page returns HTTP 200 even for a missing event (PPR streams a shell,
+ * then the not-found boundary), so the response status can't distinguish them.
+ * `NoEventFound` renders `data-testid="no-event-found"`; a real event never does.
  */
 export async function gotoFirstResolvableEvent(
   page: Page,
@@ -30,11 +34,16 @@ export async function gotoFirstResolvableEvent(
 ): Promise<string | null> {
   const slugs = await fetchEventSlugs(page);
   for (const slug of slugs) {
-    const response = await page.goto(`${localePrefix}/e/${slug}`, {
+    await page.goto(`${localePrefix}/e/${slug}`, {
       waitUntil: "domcontentloaded",
       timeout: 90000,
     });
-    if (response?.ok()) return slug;
+    const isNotFound = await page
+      .getByTestId("no-event-found")
+      .waitFor({ state: "visible", timeout: 10000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!isNotFound) return slug;
   }
   return null;
 }

--- a/e2e/hreflang-and-jsonld-locale.spec.ts
+++ b/e2e/hreflang-and-jsonld-locale.spec.ts
@@ -1,20 +1,10 @@
-import { test, expect, type Page } from "@playwright/test";
-
-async function fetchAnyEventSlug(page: Page): Promise<string | undefined> {
-  const res = await page.request.get(`/api/events?size=1`);
-  const data = (await res.json()) as { content?: Array<{ slug?: string }> };
-  return data?.content?.[0]?.slug ?? undefined;
-}
+import { test, expect } from "@playwright/test";
+import { gotoFirstResolvableEvent } from "./helpers/events";
 
 test.describe("Localized SEO (hreflang + JSON-LD)", () => {
   test("/es/e/:slug has correct alternates and inLanguage", async ({ page }) => {
-    const slug = await fetchAnyEventSlug(page);
-    if (!slug) test.skip(true, "No events returned from API");
-
-    await page.goto(`/es/e/${slug}`, {
-      waitUntil: "domcontentloaded",
-      timeout: 90000,
-    });
+    const slug = await gotoFirstResolvableEvent(page, { localePrefix: "/es" });
+    test.skip(slug === null, "No resolvable event returned from API");
 
     // With PPR/cacheComponents, async generateMetadata delivers alternate links
     // via RSC flight data into the body (React 19 doesn't auto-hoist link[rel=alternate]

--- a/e2e/jsonld-list-and-detail.spec.ts
+++ b/e2e/jsonld-list-and-detail.spec.ts
@@ -1,12 +1,5 @@
-import { test, expect, type Page } from "@playwright/test";
-
-async function fetchAnyEventSlug(page: Page): Promise<string | undefined> {
-  // Go through internal API proxy so server signs with HMAC
-  const res = await page.request.get(`/api/events?size=1`);
-  const data = (await res.json()) as { content?: Array<{ slug?: string }> };
-  const slug = data?.content?.[0]?.slug;
-  return slug ?? undefined;
-}
+import { test, expect } from "@playwright/test";
+import { gotoFirstResolvableEvent } from "./helpers/events";
 
 test.describe("JSON-LD presence", () => {
   test("List page exposes JSON-LD (ItemList or Event)", async ({ page }) => {
@@ -58,12 +51,8 @@ test.describe("JSON-LD presence", () => {
   });
 
   test("Event detail page exposes Event JSON-LD", async ({ page }) => {
-    const slug = await fetchAnyEventSlug(page);
-    if (!slug) test.skip(true, "No events returned from API");
-    await page.goto(`/e/${slug}`, {
-      waitUntil: "domcontentloaded",
-      timeout: 90000,
-    });
+    const slug = await gotoFirstResolvableEvent(page);
+    test.skip(slug === null, "No resolvable event returned from API");
     // Use auto-waiting assertion instead of waitForSelector (longer timeout for remote URLs)
     await expect(
       page.locator('script[type="application/ld+json"]').first()


### PR DESCRIPTION
## Why

The Coolify deploy E2E gate (`deploy-coolify.yml` → "Build & E2E tests") intermittently fails on 4 tests that depend on live event data and SSR timing. They passed on PR previews (warm ISR cache) but failed on the cold prod-build deploy run, blocking the prod deploy on #364.

## Root causes

**3 detail-page tests** (`add-to-calendar`, Event JSON-LD in `jsonld-list-and-detail`, `hreflang-and-jsonld-locale`): each grabbed `content[0].slug` from `/api/events?size=1` and assumed its detail page resolves. The calendar button and Event JSON-LD render **unconditionally** — they only vanish when `/e/[slug]` hits `notFound()` (a `CANCELLED` event, or a transient cold-build SSR fetch miss). So an unlucky first event = failure.

**Favorites** (`favorites.flow`): the test asserts `aria-pressed` flips on click, but that state is optimistic and a `useSWR` GET `/api/favorites` reconciles it (`favoriteButton/index.tsx:65-69`). A click before hydration was dropped, or a late GET overwrote the optimistic value.

## Fix

New `e2e/helpers/events.ts`:
- `gotoFirstResolvableEvent()` — tries candidate slugs, navigates to the first whose `/e/[slug]` responds `ok()`; skips only if none resolve. Removes the dependency on which event is first.
- `waitForFavoritesReady()` — awaits the on-mount `/api/favorites` GET (a hydration signal **and** SWR-settle barrier) before the toggle.

Consolidates the three duplicated slug-fetch helpers into the new file.

## Not masking regressions

A real outage still fails the build: the `/catalunya` list JSON-LD test and the homepage event-card assertions don't skip.

`yarn typecheck` and `yarn lint` pass (0 errors). Can't run the suite locally (needs the live backend + HMAC), so the deploy gate is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky E2E tests that rely on live event data and hydration, preventing deploy gate failures by navigating to a truly resolvable event page and waiting for favorites to settle before toggling.

- **Bug Fixes**
  - Added `gotoFirstResolvableEvent()` to try candidate slugs from `/api/events` and detect not-found by `data-testid="no-event-found"` (not HTTP status); used in add-to-calendar, Event JSON-LD, and hreflang tests.
  - Added `waitForFavoritesReady()` to await the initial `GET /api/favorites` (hydration + SWR settle) before clicking the favorite button, avoiding dropped or overwritten state.
  - Real regressions still surface (e.g., list JSON-LD and homepage card tests).

- **Refactors**
  - Consolidated duplicated slug-fetch logic into `e2e/helpers/events.ts` and updated affected specs.

<sup>Written for commit 8074d10ca40e1acb444f2c9827fc69dbe674d042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end reliability for favorites by waiting for the page to fully settle before clicking, reducing missed or overwritten favorite actions.
  * Made calendar and language-related page checks more resilient by only running tests on pages that actually load correctly.
  * Updated event-detail validation to use a more consistent page-loading approach, helping prevent flaky failures in localized and structured-data checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->