### PR TITLE
ci: build prod image in CI, deploy prebuilt to Coolify

### DIFF
--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -208,19 +208,93 @@ jobs:
           if-no-files-found: ignore
 
   # -----------------------------------------------------------------
+  # Build the production image on a GitHub runner and push it to GHCR.
+  # The heavy Next.js build used to run on the shared Coolify host and
+  # starved prod of CPU during deploys; building here keeps it off-box.
+  # Coolify then deploys this prebuilt image (Docker Image source).
+  # -----------------------------------------------------------------
+  build-and-push:
+    name: Build & push image
+    needs: [quality, unit-tests, e2e-tests]
+    # Build only when the CI jobs that ran passed (mirrors the deploy gate).
+    if: >-
+      always() &&
+      !(github.event_name == 'workflow_dispatch' && inputs.skip_ci) &&
+      (needs.quality.result == 'success' || needs.quality.result == 'skipped') &&
+      (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    # Environment-scoped secrets let the develop (staging) build inline its own
+    # NEXT_PUBLIC_* values, overriding the repo-level prod defaults.
+    environment:
+      name: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Compute lowercase image name
+        id: meta
+        run: echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ github.ref_name }}
+            ${{ steps.meta.outputs.image }}:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # NEXT_PUBLIC_* are inlined into the client bundle (public by design).
+          # HMAC_SECRET / SENTRY_AUTH_TOKEN are used only in the builder stage and
+          # do not persist in the final runner image (multi-stage Dockerfile).
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+            NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_GOOGLE_ANALYTICS=${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS }}
+            NEXT_PUBLIC_GOOGLE_ADS=${{ secrets.NEXT_PUBLIC_GOOGLE_ADS }}
+            NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=${{ secrets.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }}
+            NEXT_PUBLIC_GOOGLE_MAPS=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS }}
+            NEXT_PUBLIC_TIKTOK_CLIENT_KEY=${{ secrets.NEXT_PUBLIC_TIKTOK_CLIENT_KEY }}
+            NEXT_PUBLIC_TIKTOK_REDIRECT_URI=${{ secrets.NEXT_PUBLIC_TIKTOK_REDIRECT_URI }}
+            NEXT_PUBLIC_VAPID_PUBLIC_KEY=${{ secrets.NEXT_PUBLIC_VAPID_PUBLIC_KEY }}
+            HMAC_SECRET=${{ secrets.HMAC_SECRET }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+
+  # -----------------------------------------------------------------
   # Deploy to Coolify (waits for whichever CI jobs actually ran)
   # -----------------------------------------------------------------
   deploy:
     name: Deploy to Coolify
     runs-on: ubuntu-latest
-    needs: [quality, unit-tests, e2e-tests]
+    needs: [quality, unit-tests, e2e-tests, build-and-push]
     # Run deploy if all non-skipped jobs succeeded.
     # `always()` lets us proceed when skipped jobs report as skipped (not failed).
     if: >-
       always() &&
       (needs.quality.result == 'success' || needs.quality.result == 'skipped') &&
       (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&
-      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
+      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped')
     # 20 min = 15 min MAX_WAIT for Coolify build (prod Next.js + Docker rebuilds
     # run ~12 min) + ~5 min for webhook trigger, smoke tests, and runner overhead.
     timeout-minutes: 20

--- a/docs/ci-build-push-migration.md
+++ b/docs/ci-build-push-migration.md
@@ -1,0 +1,80 @@
+# Build in CI, deploy prebuilt image (Coolify)
+
+The Next.js build used to run on the Coolify host (`build_pack: dockerfile`,
+no dedicated build server). That host also runs prod + staging + the backends +
+databases on 4 vCPUs, so every on-server build starved prod of CPU and caused
+timeouts/500s during deploys.
+
+This change moves the build to a GitHub runner. `deploy-coolify.yml` now builds
+the image and pushes it to GHCR (`build-and-push` job); Coolify deploys that
+prebuilt image instead of building on the host. The Dockerfile and
+`output: "standalone"` are unchanged.
+
+## One-time setup (do these before merging the workflow)
+
+### 1. GitHub secrets for the build
+
+The build inlines `NEXT_PUBLIC_*` at build time, so they must exist in GitHub.
+Most are already repo-level secrets. Add the gaps:
+
+**Repo-level** (`Settings → Secrets → Actions`):
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY` — copy from the Coolify prod app env. Without it
+  the push CTA is missing in the image.
+
+**`staging` environment** (these override the repo-level prod values on the
+`develop` build, since `NEXT_PUBLIC_*` are baked per environment):
+- `NEXT_PUBLIC_API_URL` = `https://api-preproduction.esdeveniments.cat`
+- `NEXT_PUBLIC_SITE_URL` = `https://staging.esdeveniments.cat`
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY` = copy from the Coolify staging app env
+- Any other `NEXT_PUBLIC_*` that differs from prod for staging.
+
+`NEXT_PUBLIC_CONTACT_EMAIL` is not set anywhere today (builds empty); add it if
+you want it inlined.
+
+Runtime-only vars (Redis, Turso, Stripe webhooks, VAPID private key, Cloudflare,
+Places, revalidate secret) stay in Coolify as container env. The prebuilt image
+does not bake them, so nothing to copy.
+
+### 2. GHCR package visibility
+
+The image is `ghcr.io/esdeveniments/esdeveniments-frontend`. Keep it **private**
+and add a read-only pull credential in Coolify, or make the package public to
+skip pull auth. Private is recommended.
+
+### 3. Coolify app reconfiguration (prod and staging frontend apps)
+
+For each frontend app (prod `ohrtinmo1t8sz798wrq1gav3`, staging
+`nykpqplcbakwtuzezzuet80d`):
+1. Change the source from **Dockerfile / GitHub** to **Docker Image**:
+   - prod → `ghcr.io/esdeveniments/esdeveniments-frontend:main`
+   - staging → `ghcr.io/esdeveniments/esdeveniments-frontend:develop`
+2. Add the GHCR pull credential (if the package is private).
+3. **Remove `BUILD_VERSION` from the app's runtime env vars.** The image bakes
+   `BUILD_VERSION=<git sha>` at build time, and a runtime override would shadow
+   it, breaking the `/api/health` version gate the deploy workflow waits on.
+4. Keep the existing deploy webhook. It now triggers a pull-and-redeploy of the
+   new tag instead of an on-host build.
+
+## How it flows after migration
+
+1. Push to `main`/`develop` → CI runs quality, unit, e2e (main).
+2. `build-and-push` builds the image on the runner and pushes
+   `:<branch>` + `:sha-<commit>` to GHCR.
+3. `deploy` hits the Coolify webhook → Coolify pulls the new `:<branch>` image
+   and swaps the container. No build on the host.
+4. The deploy job's health gate confirms `/api/health` reports the new commit,
+   then purges Cloudflare and runs smoke tests (unchanged).
+
+## Rollback
+
+If a prebuilt deploy misbehaves, switch the Coolify app source back to
+Dockerfile/GitHub in the dashboard (one toggle). Revert the workflow change via
+git. No data is touched; this is all build/deploy plumbing.
+
+## Not covered here (follow-ups)
+
+- The **backend** (`esdeveniments-back-pro`) also builds on the host and is the
+  app that actually fell over on 2026-06-26. It needs the same treatment in its
+  own repo.
+- Right-size the frontend container memory (currently 1.5 GB, OOM-prone) and
+  consider moving staging + pre environments off the prod box.


### PR DESCRIPTION
## Why

Builds ran on the Coolify host (`build_pack: dockerfile`, no build server) on a shared 4-vCPU box that also runs prod + staging + backends + DBs. On-host builds starved prod of CPU during deploys, contributing to the 2026-06-26 timeout/500s. This moves the Next.js build to a GitHub runner and has Coolify deploy a prebuilt image. Official Coolify best practice ([docs](https://coolify.io/docs/applications/ci-cd/github/actions)).

> [!IMPORTANT]
> **Draft on purpose. Do NOT merge until the Coolify apps are switched to Docker Image source + the secrets below are added.** Merging earlier would build in CI *and* still build on-host (worse). Full checklist: `docs/ci-build-push-migration.md`.

## What changes

- New `build-and-push` job: builds on the runner, pushes `ghcr.io/esdeveniments/esdeveniments-frontend:<branch>` + `:sha-<commit>`. Per-env `NEXT_PUBLIC_*` via environment-scoped secrets.
- `deploy` job now depends on `build-and-push`; webhook + health gate + smoke + Cloudflare purge unchanged.
- Dockerfile and `output: "standalone"` unchanged.

## Before merge (you, with Coolify access)

1. Add GitHub secrets — repo: `NEXT_PUBLIC_VAPID_PUBLIC_KEY`; `staging` env: `NEXT_PUBLIC_API_URL` (`https://api-preproduction.esdeveniments.cat`), `NEXT_PUBLIC_SITE_URL` (`https://staging.esdeveniments.cat`), `NEXT_PUBLIC_VAPID_PUBLIC_KEY`.
2. Flip prod + staging frontend apps to **Docker Image** source (`:main` / `:develop`), add GHCR pull cred.
3. **Remove `BUILD_VERSION` from the Coolify runtime env** (the image bakes it; a runtime override breaks the `/api/health` version gate).

## Rollback

Switch the Coolify source back to Dockerfile/GitHub (one toggle); revert this PR. No data touched.

## Scope / follow-ups

This is the frontend slice. The **backend** also builds on-host and is what actually crashed on 2026-06-26 (`restart_count: 9`) — needs the same fix in its repo. Also right-size the frontend memory (1.5 GB, OOM-prone) and consider moving staging/pre off the prod box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the Next.js image in CI and push it to `ghcr.io`, then have Coolify deploy the prebuilt image. This keeps builds off the shared host and avoids CPU starvation during deploys while keeping the webhook/health checks unchanged.

- **Refactors**
  - Added `build-and-push` job to build on GitHub runners and push `:<branch>` and `:sha-<commit>` tags to `ghcr.io/esdeveniments/esdeveniments-frontend`.
  - Made `deploy` depend on `build-and-push`; existing webhook, health gate, smoke tests, and Cloudflare purge stay the same.
  - Inlined per-env `NEXT_PUBLIC_*` via environment-scoped secrets; Dockerfile and `output: "standalone"` unchanged.

- **Migration**
  - Add GitHub secrets: repo `NEXT_PUBLIC_VAPID_PUBLIC_KEY`; staging overrides for `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_VAPID_PUBLIC_KEY`.
  - Switch Coolify frontend apps to Docker Image source using `:main` (prod) / `:develop` (staging); add GHCR pull cred if the package is private.
  - Remove `BUILD_VERSION` from Coolify runtime env to keep the health/version gate working.

<sup>Written for commit 870322805c424c992a7d159f78713b79f34981c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new deployment flow that builds production images in CI and publishes them to a container registry for release use.
  * Updated deployments to pull prebuilt images for both production and staging.
* **Documentation**
  * Added a migration guide covering setup, rollout, rollback, and environment configuration for the new build-and-deploy process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->