### PR TITLE
fix(image-proxy): use undici's fetch with the undici dispatcher

### DIFF
--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -7,7 +7,7 @@
  */
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 import {
   normalizeExternalImageUrl,
   isLegacyFileHandler,
@@ -120,7 +120,16 @@ async function fetchWithTimeout(
       init.dispatcher = pinnedDnsDispatcher ?? insecureTlsDispatcher;
     }
 
-    const response = await fetch(url, init as RequestInit);
+    // Use undici's own fetch (not the global one) so the response-body
+    // plumbing comes from the SAME undici copy as the dispatcher Agent above.
+    // Feeding a standalone-undici Agent into Node's global fetch (bundled
+    // undici) mismatches internal symbols and throws
+    // "controller[kState].transformAlgorithm is not a function" when decoding
+    // compressed upstream responses.
+    const response = (await undiciFetch(
+      url,
+      init as Parameters<typeof undiciFetch>[1],
+    )) as unknown as Response;
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");
       await response.body?.cancel();

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -111,7 +111,8 @@ async function fetchWithTimeout(
     const pinnedDnsDispatcher = targetSafety.dnsRecords
       ? buildPinnedDnsDispatcher(targetSafety.dnsRecords, !bypassTls)
       : null;
-    const init: RequestInit & { dispatcher?: unknown } = {
+    // Typed as undici's own request init so `dispatcher` is properly typed.
+    const init: NonNullable<Parameters<typeof undiciFetch>[1]> = {
       signal: controller.signal,
       redirect: "manual",
     };
@@ -126,10 +127,7 @@ async function fetchWithTimeout(
     // undici) mismatches internal symbols and throws
     // "controller[kState].transformAlgorithm is not a function" when decoding
     // compressed upstream responses.
-    const response = (await undiciFetch(
-      url,
-      init as Parameters<typeof undiciFetch>[1],
-    )) as unknown as Response;
+    const response = (await undiciFetch(url, init)) as unknown as Response;
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");
       await response.body?.cancel();

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -93,7 +93,7 @@ async function fetchWithTimeout(
   url: string,
   redirectsRemaining = MAX_REDIRECTS,
   deadline = Date.now() + TIMEOUT_MS,
-): Promise<Response> {
+): Promise<Awaited<ReturnType<typeof undiciFetch>>> {
   const targetSafety = await getPublicFetchSafety(url);
   if (!targetSafety.isSafe) {
     throw new Error("Blocked unsafe image upstream");
@@ -127,7 +127,7 @@ async function fetchWithTimeout(
     // undici) mismatches internal symbols and throws
     // "controller[kState].transformAlgorithm is not a function" when decoding
     // compressed upstream responses.
-    const response = (await undiciFetch(url, init)) as unknown as Response;
+    const response = await undiciFetch(url, init);
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");
       await response.body?.cancel();


### PR DESCRIPTION
## Problem

Prod logs show a recurring `TypeError: controller[kState].transformAlgorithm is not a function` (undici web-streams), which started after the undici 7.25→7.28 bump.

## Root cause

`app/api/image-proxy/route.ts` builds a pinned-DNS dispatcher using the **standalone** `undici` package's `Agent`, then passes it to Node's **global** `fetch` (which uses Node 22's *bundled* undici). The two undici copies use different internal stream symbols (`kState`), so decoding a compressed upstream response throws, and the proxy falls back to the 1×1 placeholder.

The existing `test/pinned-dns-dispatcher.test.ts` passes precisely because it imports `fetch` from `"undici"` — so the test exercises the consistent path while prod used the mismatched one.

## Fix

Use undici's own `fetch` for the upstream image fetch so the `Agent` and the response-body plumbing come from one undici copy. Two-line change plus a comment so it isn't reverted to global `fetch`. The consumed Response surface (`.status`, `.ok`, `.headers.get`, `.body.getReader/.cancel`, `redirect: "manual"`) is identical.

`yarn typecheck` + `yarn lint` pass. The `e2e/image-proxy.spec.ts` flow covers the route end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the image proxy to use `undici`’s own `fetch` with its `Agent` to stop stream errors that caused 1×1 placeholders. Aligns request and response types with `undici` for safer typing.

- **Bug Fixes**
  - Avoids mixing Node’s global `fetch` (bundled `undici`) with the standalone `undici` `Agent`, which caused `TypeError: controller[kState].transformAlgorithm is not a function` on compressed responses. Now both dispatcher and fetch come from `undici`.
  - Types the request init as `undici`’s so `dispatcher` is correctly typed and drops the call-site cast.
  - Returns `undici`’s `Response` type from `fetchWithTimeout`, removing the previous cast and keeping types consistent end to end.

<sup>Written for commit 92dc9a22d911656f0e9f7696f4663a960386a04d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image loading reliability when fetching upstream images.
  - Reduced the chance of runtime errors and broken image responses, especially for compressed content.
  - Better support for secure and specialized network routing during image requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->