### PR TITLE
docs(ci-migration): address Gemini review feedback on #371

### DIFF
--- a/docs/ci-build-push-migration.md
+++ b/docs/ci-build-push-migration.md
@@ -28,24 +28,14 @@ Most are already repo-level secrets. Add the gaps:
 - `NEXT_PUBLIC_VAPID_PUBLIC_KEY` = copy from the Coolify staging app env
 - Any other `NEXT_PUBLIC_*` that differs from prod for staging.
 
-**Clear the prod tracking IDs on staging (important).** A GitHub *environment*
-secret falls back to the repo-level secret when unset. The repo-level values are
-**prod**, so if the `staging` environment doesn't override the analytics keys,
-the staging image inlines prod tracking and staging traffic pollutes prod
-analytics. Today staging's Coolify app simply omits these (builds empty), so
-this is a regression the migration would introduce. Set them to empty strings in
-the `staging` environment:
-
-```bash
-gh secret set NEXT_PUBLIC_GOOGLE_ANALYTICS        --env staging --body ""
-gh secret set NEXT_PUBLIC_GOOGLE_ADS              --env staging --body ""
-gh secret set NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION --env staging --body ""
-gh secret set NEXT_PUBLIC_TIKTOK_CLIENT_KEY       --env staging --body ""
-gh secret set NEXT_PUBLIC_TIKTOK_REDIRECT_URI     --env staging --body ""
-```
-
-Then re-trigger a `develop` build so the `:develop` image is rebuilt without the
-prod IDs **before** flipping Coolify staging to the prebuilt image.
+**Analytics on non-prod:** a GitHub *environment* secret falls back to the
+repo-level (prod) secret when unset, so the staging image inlines the prod
+analytics IDs. That no longer pollutes prod analytics, because GA and Auto Ads
+are gated to the production host at runtime (see `app/GoogleScripts.tsx`, PR
+#374): they only fire on `www.esdeveniments.cat`, never on staging or previews.
+So you do not need to clear those IDs in the staging environment. (Setting a
+GitHub secret to an empty string isn't even possible — the API rejects it with
+HTTP 422.)
 
 `NEXT_PUBLIC_CONTACT_EMAIL` is not set anywhere today (builds empty); add it if
 you want it inlined.

--- a/docs/ci-build-push-migration.md
+++ b/docs/ci-build-push-migration.md
@@ -28,6 +28,25 @@ Most are already repo-level secrets. Add the gaps:
 - `NEXT_PUBLIC_VAPID_PUBLIC_KEY` = copy from the Coolify staging app env
 - Any other `NEXT_PUBLIC_*` that differs from prod for staging.
 
+**Clear the prod tracking IDs on staging (important).** A GitHub *environment*
+secret falls back to the repo-level secret when unset. The repo-level values are
+**prod**, so if the `staging` environment doesn't override the analytics keys,
+the staging image inlines prod tracking and staging traffic pollutes prod
+analytics. Today staging's Coolify app simply omits these (builds empty), so
+this is a regression the migration would introduce. Set them to empty strings in
+the `staging` environment:
+
+```bash
+gh secret set NEXT_PUBLIC_GOOGLE_ANALYTICS        --env staging --body ""
+gh secret set NEXT_PUBLIC_GOOGLE_ADS              --env staging --body ""
+gh secret set NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION --env staging --body ""
+gh secret set NEXT_PUBLIC_TIKTOK_CLIENT_KEY       --env staging --body ""
+gh secret set NEXT_PUBLIC_TIKTOK_REDIRECT_URI     --env staging --body ""
+```
+
+Then re-trigger a `develop` build so the `:develop` image is rebuilt without the
+prod IDs **before** flipping Coolify staging to the prebuilt image.
+
 `NEXT_PUBLIC_CONTACT_EMAIL` is not set anywhere today (builds empty); add it if
 you want it inlined.
 
@@ -52,8 +71,14 @@ For each frontend app (prod `ohrtinmo1t8sz798wrq1gav3`, staging
 3. **Remove `BUILD_VERSION` from the app's runtime env vars.** The image bakes
    `BUILD_VERSION=<git sha>` at build time, and a runtime override would shadow
    it, breaking the `/api/health` version gate the deploy workflow waits on.
-4. Keep the existing deploy webhook. It now triggers a pull-and-redeploy of the
-   new tag instead of an on-host build.
+4. Deploy trigger: a **Docker Image** app does not auto-deploy from git pushes
+   the way a Dockerfile/GitHub app does, so confirm the workflow's
+   `COOLIFY_WEBHOOK_URL` is this app's **Deploy Webhook** (Coolify → app →
+   Webhooks). The deploy job POSTs it explicitly, which makes Coolify re-pull
+   the moving tag (`:main` / `:develop`) and swap the container. After the first
+   prebuilt deploy, verify `/api/health` reports the new commit — if the tag
+   didn't re-pull, enable "force pull" / check the webhook points at the right
+   app.
 
 ## How it flows after migration
 


### PR DESCRIPTION
Follow-up to #371 (merged without the review loop — my miss). Addresses both unresolved Gemini threads, both on `docs/ci-build-push-migration.md`:

1. **Staging analytics pollution (real regression).** GitHub environment secrets fall back to repo-level (prod) secrets when unset. Staging only has API_URL/SITE_URL/VAPID set, so the `:develop` image inlines **prod** GA/Ads/TikTok IDs. Staging fires no analytics today, so this is a regression the migration introduces. Doc now instructs clearing those IDs (empty) in the `staging` environment before flipping Coolify staging.
2. **Coolify Docker Image webhook.** Clarified that a Docker Image app needs the explicit Deploy Webhook to re-pull the moving tag, with a post-deploy `/api/health` verification.

Doc-only. No workflow/code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `docs/ci-build-push-migration.md` to remove the staging “clear analytics IDs” step (GA/Ads are now host-gated) and to clarify Deploy Webhook behavior for Coolify Docker Image apps with a `/api/health` verification.

- **Migration**
  - Analytics: environment secrets fall back to repo-level prod values, but GA/Auto Ads are gated to the production host (from #374), so staging won’t pollute prod; GitHub also rejects empty secrets (HTTP 422).
  - Coolify: ensure the workflow’s `COOLIFY_WEBHOOK_URL` is the app’s Deploy Webhook so moving tags (`:main`/`:develop`) re-pull; confirm via `/api/health`, and if the tag didn’t refresh, enable force pull or fix the webhook target.

<sup>Written for commit 55cdfae5f2e2219867df2d31843585795a86dab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

