### PR TITLE
fix(analytics): load GA + Auto Ads only on the production host

### DIFF
--- a/app/GoogleScripts.tsx
+++ b/app/GoogleScripts.tsx
@@ -10,6 +10,14 @@ import { scheduleIdleCallback } from "@utils/browser";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
 const ADS_CLIENT = process.env.NEXT_PUBLIC_GOOGLE_ADS;
+// ponytail: canonical prod host. GA (pageviews + consent) and Auto Ads fire
+// ONLY on real production. Vercel previews, staging, and the app embedded in the
+// Coolify dashboard all inline the same prod measurement ID and would otherwise
+// pollute prod analytics. Checked at runtime (window.location), so it holds no
+// matter which build inlined the ID. The CMP/consent banner is intentionally
+// NOT gated (it must keep its beforeInteractive ordering on prod, and it sends
+// nothing to GA on its own). Add hosts here if production ever serves more.
+const PROD_HOST = "www.esdeveniments.cat";
 // FundingChoices URL uses the ads client ID (without 'ca-' prefix if present)
 const FUNDING_CHOICES_PUB_ID = ADS_CLIENT?.replace(/^ca-/, "") ?? "";
 const FUNDING_CHOICES_SRC = FUNDING_CHOICES_PUB_ID
@@ -114,6 +122,14 @@ function GoogleAnalyticsPageview({ adsAllowed }: { adsAllowed: boolean }) {
 export default function GoogleScripts() {
   const { adsAllowed } = useAdContext();
 
+  // Gate all Google scripts to the production host. Resolved after mount so the
+  // first client render matches SSR (both render nothing) — no hydration
+  // mismatch — then GA loads only when actually served from prod.
+  const [isProdHost, setIsProdHost] = useState(false);
+  useEffect(() => {
+    setIsProdHost(window.location.hostname === PROD_HOST);
+  }, []);
+
   const [HeavyComponent, setHeavyComponent] = useState<
     React.ComponentType<{ adsAllowed: boolean }> | null
   >(null);
@@ -126,7 +142,7 @@ export default function GoogleScripts() {
   // because our TCF implementation (AdContext) provides a unified consent model.
   // This is intentional and aligns with our CMP's consent structure.
   useEffect(() => {
-    if (!GA_MEASUREMENT_ID || isE2ETestMode) return;
+    if (!GA_MEASUREMENT_ID || isE2ETestMode || !isProdHost) return;
     const win = ensureGtag();
     if (!win) return;
 
@@ -161,13 +177,14 @@ export default function GoogleScripts() {
     );
 
     return cleanup;
-  }, [adsAllowed]);
+  }, [adsAllowed, isProdHost]);
 
   // Load heavy tracking + Auto Ads only after hydration.
   // This prevents server/client HTML mismatches caused by client-only boundaries.
   useEffect(() => {
     if (!adsAllowed) return;
     if (isE2ETestMode) return;
+    if (!isProdHost) return;
     let cancelled = false;
 
     import("./GoogleScriptsHeavy")
@@ -182,12 +199,12 @@ export default function GoogleScripts() {
     return () => {
       cancelled = true;
     };
-  }, [adsAllowed]);
+  }, [adsAllowed, isProdHost]);
 
   return (
     <>
       {/* Google Analytics - Consent Mode v2 (defaults set inline to avoid race conditions) */}
-      {GA_MEASUREMENT_ID && !isE2ETestMode && (
+      {GA_MEASUREMENT_ID && !isE2ETestMode && isProdHost && (
         <>
           <Script id="google-analytics-consent" strategy="lazyOnload">
             {`
@@ -287,14 +304,14 @@ export default function GoogleScripts() {
       )}
 
       {/* Pageview tracking - wrapped in Suspense for useSearchParams */}
-      {GA_MEASUREMENT_ID && !isE2ETestMode && (
+      {GA_MEASUREMENT_ID && !isE2ETestMode && isProdHost && (
         <Suspense fallback={null}>
           <GoogleAnalyticsPageview adsAllowed={adsAllowed} />
         </Suspense>
       )}
 
       {/* Heavy tracking + Auto Ads: only load after consent */}
-      {!isE2ETestMode && adsAllowed && HeavyComponent && (
+      {!isE2ETestMode && isProdHost && adsAllowed && HeavyComponent && (
         <HeavyComponent adsAllowed={adsAllowed} />
       )}
     </>

--- a/app/GoogleScripts.tsx
+++ b/app/GoogleScripts.tsx
@@ -6,18 +6,11 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useAdContext } from "@lib/context/AdContext";
 import type { WindowWithGtag } from "types/common";
 import { isE2ETestMode } from "@utils/env";
+import { isProductionHost } from "@utils/production-host";
 import { scheduleIdleCallback } from "@utils/browser";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
 const ADS_CLIENT = process.env.NEXT_PUBLIC_GOOGLE_ADS;
-// ponytail: canonical prod host. GA (pageviews + consent) and Auto Ads fire
-// ONLY on real production. Vercel previews, staging, and the app embedded in the
-// Coolify dashboard all inline the same prod measurement ID and would otherwise
-// pollute prod analytics. Checked at runtime (window.location), so it holds no
-// matter which build inlined the ID. The CMP/consent banner is intentionally
-// NOT gated (it must keep its beforeInteractive ordering on prod, and it sends
-// nothing to GA on its own). Add hosts here if production ever serves more.
-const PROD_HOST = "www.esdeveniments.cat";
 // FundingChoices URL uses the ads client ID (without 'ca-' prefix if present)
 const FUNDING_CHOICES_PUB_ID = ADS_CLIENT?.replace(/^ca-/, "") ?? "";
 const FUNDING_CHOICES_SRC = FUNDING_CHOICES_PUB_ID
@@ -122,12 +115,16 @@ function GoogleAnalyticsPageview({ adsAllowed }: { adsAllowed: boolean }) {
 export default function GoogleScripts() {
   const { adsAllowed } = useAdContext();
 
-  // Gate all Google scripts to the production host. Resolved after mount so the
-  // first client render matches SSR (both render nothing) — no hydration
-  // mismatch — then GA loads only when actually served from prod.
+  // Gate GA (pageviews + consent) and Auto Ads to the production host so they
+  // never fire on Vercel previews, staging, or the app embedded in the Coolify
+  // dashboard, all of which inline the same prod measurement ID. Reuses the
+  // existing prod-host allowlist (covers www + apex). Resolved after mount so
+  // the first client render matches SSR (both render nothing) — no hydration
+  // mismatch. The CMP/consent banner is intentionally NOT gated (it keeps its
+  // beforeInteractive ordering and sends nothing to GA on its own).
   const [isProdHost, setIsProdHost] = useState(false);
   useEffect(() => {
-    setIsProdHost(window.location.hostname === PROD_HOST);
+    setIsProdHost(isProductionHost(window.location.hostname));
   }, []);
 
   const [HeavyComponent, setHeavyComponent] = useState<


### PR DESCRIPTION
## Why

Prod GA showed a `page_view` titled `…Configuration | Coolify` — the prod GA tag executed in a non-prod context. Root cause: `GoogleScripts.tsx` loads GA whenever the prod `NEXT_PUBLIC_GOOGLE_ANALYTICS` is present, with **no environment/host guard**. So every surface that inlines the prod ID fires prod GA: Vercel previews, staging (after the build-in-CI migration), and the app embedded/opened via the Coolify dashboard.

## Fix

Gate GA (pageview + consent) and Auto Ads on the runtime host: `window.location.hostname === "www.esdeveniments.cat"`, resolved after mount so the first client render matches SSR (no hydration mismatch). Non-prod hosts (`*.vercel.app`, `staging.esdeveniments.cat`, `coolify.esdeveniments.cat`) no longer load GA/ads. Runtime check, so it holds regardless of which build inlined the ID — strictly more complete than per-environment empty secrets.

**Deliberately not gated:** the CMP/Funding Choices consent banner. It uses a `beforeInteractive` script for ordering and is a compliance surface; it sends nothing to GA on its own, so gating it would add risk for no analytics benefit.

## Verify after deploy to prod
- `www.esdeveniments.cat`: GA still fires (Realtime shows pageviews), consent banner unchanged.
- A Vercel preview / staging: no GA hits, no Auto Ads.

`yarn typecheck` + `yarn lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Google Analytics and Auto Ads to production hosts only so prod GA never fires on previews, staging, or when embedded via the Coolify dashboard.

- **Bug Fixes**
  - Use `isProductionHost()` allowlist (covers `www` and apex) in `app/GoogleScripts.tsx`, resolved after mount to avoid hydration mismatch; gates GA consent/pageview and Auto Ads.
  - Keep the Funding Choices/CMP banner ungated (`beforeInteractive`); non‑prod hosts ignore the prod `NEXT_PUBLIC_GOOGLE_ANALYTICS` and do not load GA or ads.

<sup>Written for commit beba90bd2da32b2ac93c92e5082e8a283358a199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

