### PR TITLE
fix(places): cache nearby results by snapped coords to cap Places API cost

### DIFF
--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -429,8 +429,15 @@ export async function GET(request: NextRequest) {
 
         const data: GooglePlacesSearchNearbyRawResponse =
           await response.json();
-        places = Array.isArray(data.places) ? data.places : [];
-        // Cache even an empty array: a barren area shouldn't be re-queried per hit.
+        // A 200 carrying an `error` body (or a null/invalid parse) is a soft
+        // failure — fail soft without caching, so it isn't suppressed for the
+        // 12h TTL after the upstream recovers. A genuinely empty area omits
+        // `places` with no error, and we DO cache that as [] (don't re-query).
+        if (data?.error) {
+          console.error("Google Places API soft error:", data.error);
+          return failSoftEmpty();
+        }
+        places = Array.isArray(data?.places) ? data.places : [];
         await cacheSetJson(cacheKey, places, NEARBY_TTL_SECONDS);
       } catch (fetchError) {
         console.error("Google Places API fetch/parse error:", fetchError);

--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -13,7 +13,7 @@ import {
 import { handleApiError } from "@utils/api-error-handler";
 import {
   buildNearbyCacheKey,
-  snapCoordinate,
+  nearbySearchCenter,
 } from "@lib/places/nearby-cache-key";
 import { cacheGetJson, cacheSetJson } from "@lib/cache/redis-client";
 
@@ -369,17 +369,18 @@ export async function GET(request: NextRequest) {
       const url = new URL(
         "https://places.googleapis.com/v1/places:searchNearby"
       );
-      const requestedCount = Math.min(Math.max(limit * 3, 12), 20);
+      // Always request the max: searchNearby is billed per request, not per
+      // result, and the cache key omits `limit`, so caching the largest set
+      // lets one entry serve any limit without underfilling after filtering.
+      const requestedCount = 20;
 
+      const center = nearbySearchCenter(lat, lng, radius);
       const requestBody: GooglePlacesNearbyRequest = {
         includedTypes: ["restaurant"],
         maxResultCount: requestedCount,
         locationRestriction: {
           circle: {
-            center: {
-              latitude: snapCoordinate(lat),
-              longitude: snapCoordinate(lng),
-            },
+            center: { latitude: center.lat, longitude: center.lng },
             radius,
           },
         },
@@ -387,34 +388,44 @@ export async function GET(request: NextRequest) {
         languageCode: "ca",
       };
 
-      // We cache the result ourselves, so opt the fetch out of Next's
-      // buildId-scoped data cache to avoid storing the same payload twice.
-      const response = await fetch(url.toString(), {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Goog-Api-Key": apiKey,
-          "X-Goog-FieldMask": fields,
-        },
-        body: JSON.stringify(requestBody),
-        cache: "no-store",
-      });
-
-      const data: GooglePlacesSearchNearbyRawResponse = await response.json();
-
-      if (!response.ok) {
-        console.error("Google Places API error:", response.status, data);
-        // Fail soft: this is a non-critical widget. Return an empty result so
-        // the section just hides instead of erroring, and don't cache failures.
-        return NextResponse.json(
+      // Fail soft: this is a non-critical widget. Any upstream failure — non-OK
+      // status, non-JSON body, or a network/DNS error — returns an empty result
+      // so the section just hides (never a 500 to the user) and we don't cache
+      // the failure. We cache the result ourselves, so the fetch opts out of
+      // Next's buildId-scoped data cache to avoid storing the payload twice.
+      const failSoftEmpty = () =>
+        NextResponse.json(
           { results: [], status: "OK", attribution: "Powered by Google" },
           { status: 200, headers: { "Cache-Control": "no-store" } }
         );
-      }
 
-      places = Array.isArray(data.places) ? data.places : [];
-      // Cache even an empty array: a barren area shouldn't be re-queried per hit.
-      await cacheSetJson(cacheKey, places, NEARBY_TTL_SECONDS);
+      try {
+        const response = await fetch(url.toString(), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Goog-Api-Key": apiKey,
+            "X-Goog-FieldMask": fields,
+          },
+          body: JSON.stringify(requestBody),
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          const errText = await response.text().catch(() => "");
+          console.error("Google Places API error:", response.status, errText);
+          return failSoftEmpty();
+        }
+
+        const data: GooglePlacesSearchNearbyRawResponse =
+          await response.json();
+        places = Array.isArray(data.places) ? data.places : [];
+        // Cache even an empty array: a barren area shouldn't be re-queried per hit.
+        await cacheSetJson(cacheKey, places, NEARBY_TTL_SECONDS);
+      } catch (fetchError) {
+        console.error("Google Places API fetch/parse error:", fetchError);
+        return failSoftEmpty();
+      }
     }
 
     const filtered = places.filter((place: GooglePlaceResponse) => {

--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -345,7 +345,12 @@ export async function GET(request: NextRequest) {
   const NEARBY_TTL_SECONDS = 60 * 60 * 12; // 12h — opening hours rarely change
 
   try {
-    let places = await cacheGetJson<GooglePlaceResponse[]>(cacheKey);
+    // Treat a corrupted / non-array cached value as a miss (re-fetch) so a
+    // poisoned entry can't make `.filter` throw and turn into a 500.
+    const cached = await cacheGetJson<GooglePlaceResponse[]>(cacheKey);
+    let places: GooglePlaceResponse[] | null = Array.isArray(cached)
+      ? cached
+      : null;
 
     if (places === null) {
       const fields = [

--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -416,6 +416,9 @@ export async function GET(request: NextRequest) {
           },
           body: JSON.stringify(requestBody),
           cache: "no-store",
+          // Bound the upstream call so a hung Google request can't tie up the
+          // worker; on timeout the fetch throws and we fail soft below.
+          signal: AbortSignal.timeout(5000),
         });
 
         if (!response.ok) {

--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -11,6 +11,11 @@ import {
   OpeningSegment,
 } from "types/api/restaurant";
 import { handleApiError } from "@utils/api-error-handler";
+import {
+  buildNearbyCacheKey,
+  snapCoordinate,
+} from "@lib/places/nearby-cache-key";
+import { cacheGetJson, cacheSetJson } from "@lib/cache/redis-client";
 
 export async function GET(request: NextRequest) {
   const t = await getTranslations("Api.PlacesNearby");
@@ -327,74 +332,90 @@ export async function GET(request: NextRequest) {
     return { info: { open_status: "unknown" }, weekdayText };
   }
 
-  // --- Main fetch + transform ---
+  // --- Cached fetch + transform ---
+  // Snap the search centre to a ~1.1km grid so every event in the same area
+  // shares one cache entry, and cache the raw upstream result in Redis under a
+  // build-independent key (unlike Next's fetch cache, which cache-handler.mjs
+  // scopes by buildId and wipes on every deploy). The Google request never
+  // depends on the event date — date handling is post-fetch — so one cached
+  // call serves the whole neighbourhood across every date. searchNearby is
+  // billed per request, so this is what bounds the Places bill by distinct
+  // locations instead of by traffic.
+  const cacheKey = buildNearbyCacheKey(lat, lng, radius);
+  const NEARBY_TTL_SECONDS = 60 * 60 * 12; // 12h — opening hours rarely change
+
   try {
-    const fields = [
-      "places.name",
-      "places.displayName",
-      "places.formattedAddress",
-      "places.rating",
-      "places.priceLevel",
-      "places.location",
-      "places.photos",
-      "places.businessStatus",
-      "places.currentOpeningHours",
-      "places.regularOpeningHours",
-      "places.utcOffsetMinutes",
-      "places.postalAddress.addressLines",
-      "places.postalAddress.locality",
-      "places.postalAddress.administrativeArea",
-      "places.postalAddress.postalCode",
-    ].join(",");
+    let places = await cacheGetJson<GooglePlaceResponse[]>(cacheKey);
 
-    const url = new URL("https://places.googleapis.com/v1/places:searchNearby");
-    const requestedCount = Math.min(Math.max(limit * 3, 12), 20);
+    if (places === null) {
+      const fields = [
+        "places.name",
+        "places.displayName",
+        "places.formattedAddress",
+        "places.rating",
+        "places.priceLevel",
+        "places.location",
+        "places.photos",
+        "places.businessStatus",
+        "places.currentOpeningHours",
+        "places.regularOpeningHours",
+        "places.utcOffsetMinutes",
+        "places.postalAddress.addressLines",
+        "places.postalAddress.locality",
+        "places.postalAddress.administrativeArea",
+        "places.postalAddress.postalCode",
+      ].join(",");
 
-    const requestBody: GooglePlacesNearbyRequest = {
-      includedTypes: ["restaurant"],
-      maxResultCount: requestedCount,
-      locationRestriction: {
-        circle: {
-          center: { latitude: lat, longitude: lng },
-          radius,
-        },
-      },
-      rankPreference: "DISTANCE",
-      languageCode: "ca",
-    };
-
-    const response = await fetch(url.toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Goog-Api-Key": apiKey,
-        "X-Goog-FieldMask": fields,
-      },
-      body: JSON.stringify(requestBody),
-      next: {
-        revalidate: 3600,
-        tags: [
-          "places",
-          `places:${lat}:${lng}`,
-          eventDateISO ? `places:date:${eventDateISO}` : "places:date:none",
-        ],
-      },
-    });
-
-    const data: GooglePlacesSearchNearbyRawResponse = await response.json();
-
-    if (!response.ok) {
-      console.error("Google Places API error:", response.status, data);
-      return NextResponse.json(
-        { error: "Places API error", status: response.status, details: data },
-        {
-          status: 500,
-          headers: { "Cache-Control": "no-store" },
-        }
+      const url = new URL(
+        "https://places.googleapis.com/v1/places:searchNearby"
       );
-    }
+      const requestedCount = Math.min(Math.max(limit * 3, 12), 20);
 
-    const places = Array.isArray(data.places) ? data.places : [];
+      const requestBody: GooglePlacesNearbyRequest = {
+        includedTypes: ["restaurant"],
+        maxResultCount: requestedCount,
+        locationRestriction: {
+          circle: {
+            center: {
+              latitude: snapCoordinate(lat),
+              longitude: snapCoordinate(lng),
+            },
+            radius,
+          },
+        },
+        rankPreference: "DISTANCE",
+        languageCode: "ca",
+      };
+
+      // We cache the result ourselves, so opt the fetch out of Next's
+      // buildId-scoped data cache to avoid storing the same payload twice.
+      const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Goog-Api-Key": apiKey,
+          "X-Goog-FieldMask": fields,
+        },
+        body: JSON.stringify(requestBody),
+        cache: "no-store",
+      });
+
+      const data: GooglePlacesSearchNearbyRawResponse = await response.json();
+
+      if (!response.ok) {
+        console.error("Google Places API error:", response.status, data);
+        // Fail soft: this is a non-critical widget. Return an empty result so
+        // the section just hides instead of erroring, and don't cache failures.
+        return NextResponse.json(
+          { results: [], status: "OK", attribution: "Powered by Google" },
+          { status: 200, headers: { "Cache-Control": "no-store" } }
+        );
+      }
+
+      places = Array.isArray(data.places) ? data.places : [];
+      // Cache even an empty array: a barren area shouldn't be re-queried per hit.
+      await cacheSetJson(cacheKey, places, NEARBY_TTL_SECONDS);
+    }
 
     const filtered = places.filter((place: GooglePlaceResponse) => {
       if (!isOperational(place)) return false;

--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -345,12 +345,14 @@ export async function GET(request: NextRequest) {
   const NEARBY_TTL_SECONDS = 60 * 60 * 12; // 12h — opening hours rarely change
 
   try {
-    // Treat a corrupted / non-array cached value as a miss (re-fetch) so a
-    // poisoned entry can't make `.filter` throw and turn into a 500.
+    // Treat a corrupted cached value (not an array, or with null/non-object
+    // elements from a partial write) as a miss (re-fetch) so it can't make
+    // `.filter` throw and turn into a 500.
     const cached = await cacheGetJson<GooglePlaceResponse[]>(cacheKey);
-    let places: GooglePlaceResponse[] | null = Array.isArray(cached)
-      ? cached
-      : null;
+    let places: GooglePlaceResponse[] | null =
+      Array.isArray(cached) && cached.every((p) => p && typeof p === "object")
+        ? cached
+        : null;
 
     if (places === null) {
       const fields = [

--- a/bundle-size-baseline.json
+++ b/bundle-size-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "lastUpdated": "2026-04-21T18:45:00+00:00",
+  "lastUpdated": "2026-06-26T00:00:00+00:00",
   "clientTotalBytes": 2283119,
   "thresholds": {
     "warning": {
@@ -118,7 +118,7 @@
       "fileCount": 8
     },
     "/api/places": {
-      "serverBytes": 95812,
+      "serverBytes": 142830,
       "fileCount": 24
     },
     "/api/events": {
@@ -170,7 +170,7 @@
       "fileCount": 6
     },
     "/api/places/nearby": {
-      "serverBytes": 24413,
+      "serverBytes": 70288,
       "fileCount": 6
     },
     "/api/news/[slug]": {

--- a/components/ui/restaurantPromotion/RestaurantPromotionSection.tsx
+++ b/components/ui/restaurantPromotion/RestaurantPromotionSection.tsx
@@ -40,7 +40,6 @@ export default function RestaurantPromotionSection({
   // All hooks must be called at the top level before any conditional returns
   const [placesResp, setPlacesResp] = useState<PlacesResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [openPromoInfo, setOpenPromoInfo] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const isVisible = useOnScreen(sectionRef as React.RefObject<Element>, {
@@ -112,7 +111,6 @@ export default function RestaurantPromotionSection({
 
     const fetchPlaces = async () => {
       setIsLoading(true);
-      setError(null);
 
       try {
         let dateParam = "";
@@ -128,12 +126,11 @@ export default function RestaurantPromotionSection({
         if (res.ok) {
           const data = await res.json();
           setPlacesResp(data);
-        } else {
-          setError("Failed to fetch places");
         }
+        // On failure, leave the section hidden — it's a non-critical widget,
+        // not worth showing the user an error.
       } catch (err) {
         console.error("Error fetching places", err);
-        setError("Error fetching places");
       } finally {
         setIsLoading(false);
       }
@@ -170,13 +167,6 @@ export default function RestaurantPromotionSection({
             setOpenPromoInfo(true);
           }}
         />
-      )}
-
-      {/* Error State */}
-      {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <p className="body-small text-error">{error}</p>
-        </div>
       )}
 
       {/* Active Promotion (if any) */}

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -60,8 +60,9 @@ async function getClient(): Promise<ReturnType<typeof createClient> | null> {
   const isTls = url.startsWith("rediss://");
 
   globalForRedis.__appRedis = (async () => {
+    let client: ReturnType<typeof createClient> | null = null;
     try {
-      const client = createClient({
+      client = createClient({
         url,
         pingInterval: 10_000,
         // Fail fast instead of queueing commands while disconnected, so a Redis
@@ -82,7 +83,13 @@ async function getClient(): Promise<ReturnType<typeof createClient> | null> {
       });
       await client.connect();
       return client;
-    } catch {
+    } catch (error) {
+      // Disconnect the failed client so it doesn't keep retrying in the
+      // background — without this, each cooldown cycle during a prolonged
+      // outage would orphan a new client. Log so a silent connect failure
+      // (= running uncached, more paid Places calls) is noticeable.
+      client?.disconnect().catch(() => {});
+      console.warn("[redis-cache] connect failed:", error);
       globalForRedis.__appRedis = undefined;
       globalForRedis.__appRedisFailedAt = Date.now();
       return null;

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createClient } from "redis";
 
 /**

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -1,0 +1,110 @@
+import { createClient } from "redis";
+
+/**
+ * App-level Redis cache, deliberately separate from the Next.js incremental
+ * cache handler (cache-handler.mjs). That handler namespaces every key by
+ * buildId, so its entries are dropped on each deploy — correct for prerender
+ * shells, wrong for data we want to outlive deploys (e.g. Google Places
+ * results). This client uses stable, unprefixed keys.
+ *
+ * Fails open: any connection or command error resolves to null / no-op so the
+ * caller falls back to the origin. It never throws into the request path.
+ */
+
+/** Back off this long after a failure so a Redis outage can't trigger a connect attempt on every request. */
+const FAILURE_COOLDOWN_MS = 30_000;
+
+const globalForRedis = globalThis as unknown as {
+  __appRedis?: Promise<ReturnType<typeof createClient> | null>;
+  __appRedisFailedAt?: number;
+};
+
+/** Mirrors cache-handler.mjs so both layers resolve Redis the same way. */
+function getRedisUrl(): string | null {
+  if (process.env.REDIS_URL?.trim()) return process.env.REDIS_URL;
+
+  const host = process.env.REDIS_HOST;
+  if (!host) return null;
+
+  const port = process.env.REDIS_PORT || "6379";
+  const password = process.env.REDIS_PASSWORD;
+  const username = process.env.REDIS_USERNAME;
+  const auth = password
+    ? `${username ? encodeURIComponent(username) : ""}:${encodeURIComponent(
+        password
+      )}@`
+    : username
+      ? `${encodeURIComponent(username)}@`
+      : "";
+
+  return `redis://${auth}${host}:${port}`;
+}
+
+async function getClient(): Promise<ReturnType<typeof createClient> | null> {
+  if (globalForRedis.__appRedis) return globalForRedis.__appRedis;
+
+  if (
+    globalForRedis.__appRedisFailedAt &&
+    Date.now() - globalForRedis.__appRedisFailedAt < FAILURE_COOLDOWN_MS
+  ) {
+    return null;
+  }
+
+  const url = getRedisUrl();
+  if (!url) return null;
+
+  const isTls = url.startsWith("rediss://");
+
+  globalForRedis.__appRedis = (async () => {
+    try {
+      const client = createClient({
+        url,
+        pingInterval: 10_000,
+        socket: isTls
+          ? { tls: true, rejectUnauthorized: false, connectTimeout: 2_000 }
+          : { connectTimeout: 2_000 },
+      });
+      // node-redis needs a persistent error listener or it throws on errors.
+      // node-redis reconnects on its own; we just record the last failure so
+      // getClient() can back off if the connection never recovers.
+      client.on("error", () => {
+        globalForRedis.__appRedisFailedAt = Date.now();
+      });
+      await client.connect();
+      return client;
+    } catch {
+      globalForRedis.__appRedis = undefined;
+      globalForRedis.__appRedisFailedAt = Date.now();
+      return null;
+    }
+  })();
+
+  return globalForRedis.__appRedis;
+}
+
+export async function cacheGetJson<T>(key: string): Promise<T | null> {
+  try {
+    const client = await getClient();
+    if (!client) return null;
+    const raw = await client.get(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheSetJson(
+  key: string,
+  value: unknown,
+  ttlSeconds: number
+): Promise<void> {
+  try {
+    const client = await getClient();
+    if (!client) return;
+    // SETEX (dedicated helper) avoids the deprecated { EX } option and is
+    // stable across redis v5/v6.
+    await client.setEx(key, ttlSeconds, JSON.stringify(value));
+  } catch {
+    // best-effort: a failed cache write must never fail the request
+  }
+}

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -71,10 +71,13 @@ async function getClient(): Promise<ReturnType<typeof createClient> | null> {
           : { connectTimeout: 2_000 },
       });
       // node-redis needs a persistent error listener or it throws on errors.
-      // node-redis reconnects on its own; we just record the last failure so
-      // getClient() can back off if the connection never recovers.
+      // Drop the client on error (matching cache-handler.mjs) so that once the
+      // cooldown elapses getClient() builds a fresh one, instead of handing
+      // back a permanently-broken connection that can never recover.
       client.on("error", () => {
         globalForRedis.__appRedisFailedAt = Date.now();
+        client.disconnect().catch(() => {});
+        globalForRedis.__appRedis = undefined;
       });
       await client.connect();
       return client;
@@ -110,7 +113,9 @@ export async function cacheSetJson(
     // SETEX (dedicated helper) avoids the deprecated { EX } option and is
     // stable across redis v5/v6.
     await client.setEx(key, ttlSeconds, JSON.stringify(value));
-  } catch {
-    // best-effort: a failed cache write must never fail the request
+  } catch (error) {
+    // best-effort: a failed cache write must never fail the request, but log
+    // it so write failures aren't silently swallowed.
+    console.warn("[redis-cache] set failed:", error);
   }
 }

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -71,13 +71,13 @@ async function getClient(): Promise<ReturnType<typeof createClient> | null> {
           : { connectTimeout: 2_000 },
       });
       // node-redis needs a persistent error listener or it throws on errors.
-      // Drop the client on error (matching cache-handler.mjs) so that once the
-      // cooldown elapses getClient() builds a fresh one, instead of handing
-      // back a permanently-broken connection that can never recover.
-      client.on("error", () => {
+      // It reconnects on its own, so we don't disconnect/recreate here — doing
+      // that risked a late error from an old client wiping a newer one's
+      // promise. We just stamp the failure (the cooldown check above uses it to
+      // fail open) and log it so errors aren't silently swallowed.
+      client.on("error", (err) => {
         globalForRedis.__appRedisFailedAt = Date.now();
-        client.disconnect().catch(() => {});
-        globalForRedis.__appRedis = undefined;
+        console.warn("[redis-cache] client error:", err?.message ?? err);
       });
       await client.connect();
       return client;

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -41,14 +41,17 @@ function getRedisUrl(): string | null {
 }
 
 async function getClient(): Promise<ReturnType<typeof createClient> | null> {
-  if (globalForRedis.__appRedis) return globalForRedis.__appRedis;
-
+  // Fail open during the cooldown after any failure — checked before reusing a
+  // cached client, so a client that errored *after* connecting is skipped too
+  // (otherwise the cached promise would always short-circuit this check).
   if (
     globalForRedis.__appRedisFailedAt &&
     Date.now() - globalForRedis.__appRedisFailedAt < FAILURE_COOLDOWN_MS
   ) {
     return null;
   }
+
+  if (globalForRedis.__appRedis) return globalForRedis.__appRedis;
 
   const url = getRedisUrl();
   if (!url) return null;
@@ -60,6 +63,9 @@ async function getClient(): Promise<ReturnType<typeof createClient> | null> {
       const client = createClient({
         url,
         pingInterval: 10_000,
+        // Fail fast instead of queueing commands while disconnected, so a Redis
+        // outage falls through to the origin immediately rather than hanging.
+        disableOfflineQueue: true,
         socket: isTls
           ? { tls: true, rejectUnauthorized: false, connectTimeout: 2_000 }
           : { connectTimeout: 2_000 },

--- a/lib/places/nearby-cache-key.ts
+++ b/lib/places/nearby-cache-key.ts
@@ -11,11 +11,29 @@
  * function of distinct locations, not of traffic.
  */
 
-/** 2 decimal places ≈ 1.1 km — far inside the 5 km search radius, so snapping the centre this much doesn't change which restaurants come back. */
+/** 2 decimal places ≈ 1.1 km. */
 export const NEARBY_GRID = 100;
+
+/**
+ * Below this radius, snapping (which can move the centre up to ~700m) could
+ * push the search area off the caller's point and return wrong results, so
+ * exact coordinates are used instead. The app always searches at 5km, so it
+ * always snaps; only small-radius direct callers fall back to exact.
+ */
+export const SNAP_MIN_RADIUS_M = 2000;
 
 export function snapCoordinate(value: number): number {
   return Math.round(value * NEARBY_GRID) / NEARBY_GRID;
+}
+
+/** The centre to actually search/cache with: snapped for wide radii, exact for narrow ones. */
+export function nearbySearchCenter(
+  lat: number,
+  lng: number,
+  radiusMeters: number
+): { lat: number; lng: number } {
+  if (radiusMeters < SNAP_MIN_RADIUS_M) return { lat, lng };
+  return { lat: snapCoordinate(lat), lng: snapCoordinate(lng) };
 }
 
 export function buildNearbyCacheKey(
@@ -23,7 +41,6 @@ export function buildNearbyCacheKey(
   lng: number,
   radiusMeters: number
 ): string {
-  return `places:nearby:v1:${snapCoordinate(lat)}:${snapCoordinate(
-    lng
-  )}:r${radiusMeters}`;
+  const center = nearbySearchCenter(lat, lng, radiusMeters);
+  return `places:nearby:v1:${center.lat}:${center.lng}:r${radiusMeters}`;
 }

--- a/lib/places/nearby-cache-key.ts
+++ b/lib/places/nearby-cache-key.ts
@@ -11,7 +11,7 @@
  * function of distinct locations, not of traffic.
  */
 
-/** 2 decimal places ≈ 1.1 km. */
+/** 2 decimal places: about 1.1 km of latitude (~0.8 km of longitude at Catalan latitudes), both well inside the 5 km search radius. */
 export const NEARBY_GRID = 100;
 
 /**

--- a/lib/places/nearby-cache-key.ts
+++ b/lib/places/nearby-cache-key.ts
@@ -1,0 +1,29 @@
+/**
+ * Cache-key helpers for Places "search nearby" results.
+ *
+ * Snapping coordinates to a coarse grid collapses many distinct event
+ * locations within the same area onto one key, so a single Google call serves
+ * the whole neighbourhood. The key intentionally excludes the event date: the
+ * upstream request doesn't depend on it (date handling happens after the
+ * fetch), so one cached result also serves every date in that cell.
+ *
+ * searchNearby is billed per request, so this is what keeps the Places bill a
+ * function of distinct locations, not of traffic.
+ */
+
+/** 2 decimal places ≈ 1.1 km — far inside the 5 km search radius, so snapping the centre this much doesn't change which restaurants come back. */
+export const NEARBY_GRID = 100;
+
+export function snapCoordinate(value: number): number {
+  return Math.round(value * NEARBY_GRID) / NEARBY_GRID;
+}
+
+export function buildNearbyCacheKey(
+  lat: number,
+  lng: number,
+  radiusMeters: number
+): string {
+  return `places:nearby:v1:${snapCoordinate(lat)}:${snapCoordinate(
+    lng
+  )}:r${radiusMeters}`;
+}

--- a/test/nearby-cache-key.test.ts
+++ b/test/nearby-cache-key.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   snapCoordinate,
+  nearbySearchCenter,
   buildNearbyCacheKey,
+  SNAP_MIN_RADIUS_M,
 } from "@lib/places/nearby-cache-key";
 
 describe("nearby cache key", () => {
@@ -10,7 +12,7 @@ describe("nearby cache key", () => {
     expect(snapCoordinate(2.169912)).toBe(2.17);
   });
 
-  it("maps two locations ~700m apart onto the same key (one Google call serves both)", () => {
+  it("at the app's 5km radius, two points ~700m apart share a key (one Google call serves both)", () => {
     const a = buildNearbyCacheKey(41.3851, 2.1734, 5000);
     const b = buildNearbyCacheKey(41.3879, 2.1699, 5000);
     expect(a).toBe(b);
@@ -32,5 +34,25 @@ describe("nearby cache key", () => {
     expect(buildNearbyCacheKey(41.39, 2.17, 5000)).not.toBe(
       buildNearbyCacheKey(41.39, 2.17, 1000)
     );
+  });
+
+  it("does NOT snap below the minimum radius, so a small search stays on the caller's point", () => {
+    const narrow = 500;
+    expect(narrow).toBeLessThan(SNAP_MIN_RADIUS_M);
+    expect(nearbySearchCenter(41.3851, 2.1734, narrow)).toEqual({
+      lat: 41.3851,
+      lng: 2.1734,
+    });
+    // exact coords preserved, so two nearby points must NOT collide
+    expect(buildNearbyCacheKey(41.3851, 2.1734, narrow)).not.toBe(
+      buildNearbyCacheKey(41.3879, 2.1699, narrow)
+    );
+  });
+
+  it("snaps at or above the minimum radius", () => {
+    expect(nearbySearchCenter(41.3851, 2.1734, SNAP_MIN_RADIUS_M)).toEqual({
+      lat: 41.39,
+      lng: 2.17,
+    });
   });
 });

--- a/test/nearby-cache-key.test.ts
+++ b/test/nearby-cache-key.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  snapCoordinate,
+  buildNearbyCacheKey,
+} from "@lib/places/nearby-cache-key";
+
+describe("nearby cache key", () => {
+  it("snaps coordinates to a ~1.1km grid", () => {
+    expect(snapCoordinate(41.387654)).toBe(41.39);
+    expect(snapCoordinate(2.169912)).toBe(2.17);
+  });
+
+  it("maps two locations ~700m apart onto the same key (one Google call serves both)", () => {
+    const a = buildNearbyCacheKey(41.3851, 2.1734, 5000);
+    const b = buildNearbyCacheKey(41.3879, 2.1699, 5000);
+    expect(a).toBe(b);
+  });
+
+  it("keeps distant locations on separate keys", () => {
+    const bcn = buildNearbyCacheKey(41.3851, 2.1734, 5000);
+    const girona = buildNearbyCacheKey(41.9794, 2.8214, 5000);
+    expect(bcn).not.toBe(girona);
+  });
+
+  it("does not depend on the event date — same coords/radius always yield the same key", () => {
+    expect(buildNearbyCacheKey(41.39, 2.17, 5000)).toBe(
+      "places:nearby:v1:41.39:2.17:r5000"
+    );
+  });
+
+  it("separates keys by radius", () => {
+    expect(buildNearbyCacheKey(41.39, 2.17, 5000)).not.toBe(
+      buildNearbyCacheKey(41.39, 2.17, 1000)
+    );
+  });
+});


### PR DESCRIPTION
## Why

Google **Places API "Nearby Search (Enterprise)"** cost climbed month over month (€0.16 → €5.02 in June, heading for the €10 budget). The `where-to-eat` widget calls `/api/places/nearby` when it scrolls into view, and each cache miss is one billable `searchNearby` request.

Two things made nearly every hit a miss:
- The result was cached on the **exact** lat/lng, so two events ~200m apart never shared an entry.
- `cache-handler.mjs` scopes keys by `buildId`, so **every deploy wiped** the cache.

On top of that, a wave of JS-executing bots (Singapore/Japan — confirmed in GA4 *and* Cloudflare edge logs) crawl event pages, scroll, and trigger the fetch, multiplying the calls.

## What this PR changes (origin layer)

- **Snap the search centre to a ~1.1km grid** (`lib/places/nearby-cache-key.ts`) so every event in an area shares one cache entry. Negligible against the 5km search radius.
- **Cache the raw upstream result in Redis** under a build-independent key, 12h TTL (`lib/cache/redis-client.ts`). The Google request never depends on the event date (date handling is post-fetch), so **one cached call serves a whole area across every date — and survives deploys**. Billable calls now scale with distinct event locations, not traffic.
  - Separate from the Next incremental cache handler on purpose (that one is `buildId`-scoped). Fails open: any Redis error → normal fetch, never a failed request.
- **Fail soft** on upstream errors: return an empty result (200) so the non-critical widget just hides, instead of the old red "Failed to fetch places" box. This also fixes the error box users currently see while the API is disabled.

## Done out-of-band (not in this diff)

- **Cloudflare WAF** (Free plan): managed-challenge `www` traffic from SG/JP/CN (verified-bot-exempt, scoped to `www` so the Hetzner origin's calls to `api.esdeveniments.cat` are untouched), plus a per-IP rate-limit on `/api/places/nearby` (15 req/10s, verified firing). These are the demand-side backstop; the cache is the real fix.
- **Pending before re-enabling the API:** set a **daily quota cap** on the Places API in Google Cloud as a hard ceiling (the API is currently disabled).

## Verification

- `yarn typecheck` clean, `yarn lint` clean on changed files.
- `test/nearby-cache-key.test.ts`: proves two points ~700m apart share a key, distant ones don't, and the date is not part of the key. 19 tests green (incl. existing `restaurant-promotion-section`).
- Rate-limit confirmed live (429 after 15 hits/10s).

> Note: the Redis cache only engages on the self-hosted (Coolify) path — `cacheHandler`/Redis are off on Vercel/localhost, where it falls back to a normal per-request fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache Google Places Nearby results by snapping coords to a ~1.1 km grid and storing raw responses in `redis` under build-independent keys to cut API calls and keep cache across deploys. The widget now fails soft with a 5s upstream timeout; the cache fails open with a cooldown when `redis` is down.

- **Bug Fixes**
  - Snap the search center for wide radii; keep exact coords for small searches; always request 20 results; bound the upstream call with a 5s timeout.
  - Cache upstream results in `redis` (12h TTL) with stable, date-agnostic keys; use no-store fetch; cache empty arrays; treat non-arrays or arrays with null/non-object elements as a miss; do not cache 200 responses that include an `error` body (fail soft and retry later).
  - Harden fail-open/soft behavior: disable offline queue, add a short failure cooldown and disconnect on connect failure, add `server-only` import, and wrap fetch + JSON parse so any upstream failure returns 200 with empty results; remove the client error UI so the section hides on failure.

- **Dependencies**
  - Rebaselined server bundle sizes for Places routes due to the server-only `redis` client import (`/api/places` 95.8 KB → 142.8 KB; `/api/places/nearby` 24.4 KB → 70.3 KB); thresholds unchanged.

<sup>Written for commit 7e50414d1aa846abf51661d44b50c34ead495948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nearby place searches are now faster and more reliable thanks to improved caching.
  * Promotion content loads more smoothly, with the info panel loaded only when needed.

* **Bug Fixes**
  * Search results now fail gracefully when an upstream service is unavailable, returning an empty list instead of an error.
  * Corrupted cached nearby-search data is automatically ignored and refreshed.
  * Hidden promotion widgets no longer show error messages when loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->