### PR TITLE
docs(places): document the Places API cost incident and controls

### DIFF
--- a/.github/skills/api-layer-patterns/SKILL.md
+++ b/.github/skills/api-layer-patterns/SKILL.md
@@ -203,6 +203,8 @@ headers: {
 }
 ```
 
+**Per-request-billed upstreams (e.g. Google Places):** CDN headers aren't enough — on Cloudflare's Free plan `/api/*` isn't edge-cached, and the Next fetch cache is wiped every deploy (`cache-handler.mjs` scopes keys by `buildId`). For a paid upstream, read through the **deploy-independent** app Redis cache (`lib/cache/redis-client.ts`) with a coarse key, and cap cost at the provider (GCP quota). See `app/api/places/nearby/route.ts` and [the Places cost incident](../../../docs/incidents/2026-06-26-places-api-cost.md).
+
 ---
 
 ## Layer 3: External Wrappers

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -33,3 +33,17 @@ main and develop diverge. A fix that lands directly on main (a hotfix) does not 
 ## Never lower preview/test-env fidelity to make a test pass
 
 It's tempting to drop a threshold (e.g. `SITEMAP_MIN_EVENTS_FOR_EXPANSION`) or relax gating in non-prod so a flaky test goes green. Don't: that makes the preview behave differently from production, which is the exact parity gap that caused the cache and image-proxy incidents. Fix the mis-layered test, not the environment. Environment parity is the asset.
+
+## Places API cost is controlled in three layers — two of them are NOT in this repo
+
+`/api/places/nearby` (Google `searchNearby`, billed per request) has its cost held down by three controls, and only the first lives in git:
+
+1. **Code** — `lib/cache/redis-client.ts` + `lib/places/nearby-cache-key.ts` cache results in Redis keyed by `~1.1km-snapped` coordinates. This is a **separate Redis layer from `cache-handler.mjs`** on purpose: the Next handler scopes keys by `buildId` and wipes them every deploy, which is wrong for data that should outlive deploys. The app cache is deploy-independent (12h TTL) and fails open.
+2. **Cloudflare WAF** (dashboard, zone `esdeveniments.cat`) — managed-challenge for SG/JP/CN bot traffic + a per-IP rate-limit on the endpoint.
+3. **GCP quota** (`places.googleapis.com/SearchNearbyRequest`, project `esdeveniments-3`) — **50/day** consumer override. This is the hard ceiling. The €10 "budget" is only an alert, never a cap.
+
+So if restaurants suddenly stop showing, or a request 429s, the cause may be the WAF or the quota — not the code. See [docs/incidents/2026-06-26-places-api-cost.md](docs/incidents/2026-06-26-places-api-cost.md).
+
+## Never block DE / Hetzner / datacenter ASNs at the Cloudflare edge — that's the own origin
+
+~40% of Cloudflare traffic shows country **DE** hitting `api.esdeveniments.cat` on SSR data paths (`/api/events`, `/api/places/regions/options`, …). That is **not** a bot — it's the Coolify box on **Hetzner** (ASN 24940, Germany) calling its own backend through Cloudflare on every render. A disabled "block non-ES" WAF rule already exists from a past attempt, and a Cloudflare AI assistant will recommend challenging datacenter ASNs (incl. 24940 / AWS). Applying either takes down SSR. Use *managed challenge* on named bot-source countries (SG/JP/CN), never *block* by geography/ASN, and always verify origin egress before any country/ASN edge rule.

--- a/docs/incidents/2026-06-26-places-api-cost.md
+++ b/docs/incidents/2026-06-26-places-api-cost.md
@@ -1,0 +1,104 @@
+# Incident: Google Places API Cost Climb from Bot Traffic (Jun 26, 2026)
+
+## Summary
+
+Google **Places API (New) "Nearby Search (Enterprise)"** spend climbed month over
+month — €0.16 (June 2025) → €0.49 (Mar) → €1.29 (May) → €5.02 (June 2026) — tracking
+toward the €10 budget. The driver was bot traffic, not real users: headless,
+JS-executing crawlers (mostly Singapore and Japan) scrolled event pages, tripped the
+`IntersectionObserver` gate on the "Where to eat" widget, and triggered
+`GET /api/places/nearby` → one billable `searchNearby` request per cache miss. The
+owner disabled the API by hand to stop the bleed.
+
+The widget's scroll gate genuinely cut calls for humans (that's why May was only
+€1.29), which is why it looked solved. It wasn't: the cache barely helped, and a bot
+wave in June multiplied the misses.
+
+## Impact
+
+| | |
+| --- | --- |
+| Cost | ~€5 in June 2026 (would have passed the €10 budget alert; never a true cap) |
+| Downtime | None |
+| User impact | While the API was manually disabled, the widget showed a red "Failed to fetch places" error box on upcoming-event pages (now fixed to fail soft) |
+
+The blast radius was always bounded: `SearchNearbyRequest` ships with a 100/day
+default quota, so the worst case was ~100 calls/day ≈ €3/day. The €10 "budget" only
+emails an alert — it never stops usage or billing.
+
+## Timeline
+
+- **Through June 2026** — Spend climbs with traffic; a bot wave (GA4: Singapore 13K /
+  Japan 8.9K "users" vs Barcelona 1.6K, 11s avg engagement, 24K new / 400 returning)
+  pushes June to €5.02.
+- **Jun 26** — Owner disables the Places API in Google Cloud to stop the spend.
+- **Jun 26** — Diagnosis: GA4 + Cloudflare edge analytics confirm bot origin;
+  `/api/places/nearby` traffic is ~75% real ES users, ~25% JP bots, but the wider
+  page-crawl is what multiplied misses. Three-layer fix shipped (PR #376) + edge +
+  quota controls applied. API re-enabled behind the new quota cap.
+
+## Root Cause
+
+Two things made nearly every call a cache miss:
+
+1. **The cache key was the exact lat/lng.** Two events ~200m apart never shared an
+   entry, so the per-event widget re-queried Google for each one.
+2. **The Next.js fetch cache is wiped every deploy.** `cache-handler.mjs` scopes keys
+   by `buildId` (correct for prerender shells — see
+   [2026-06-11](./2026-06-11-coolify-redis-stale-prerender.md)), so the Places
+   results it cached were dropped on each deploy. On a frequently-deployed,
+   bot-crawled site, the hit rate was near zero.
+
+On Cloudflare's Free plan `/api/*` isn't edge-cached either, so nothing absorbed the
+misses before they reached Google. `searchNearby` is billed **per request** (not per
+result), so reducing the result limit 3→2 earlier had not reduced cost.
+
+## Resolution
+
+Defense in depth — no single layer is load-bearing:
+
+1. **Origin (the real fix, PR #376)** — Cache the raw upstream result in Redis keyed
+   by `~1.1km-snapped` coordinates, in a **deploy-independent** key (separate from the
+   `buildId`-scoped Next handler). The Google request never depends on the event date
+   (date handling is post-fetch), so one cached call serves a whole area across every
+   date. 12h TTL. Calls now scale with distinct event areas (dozens/day), not traffic.
+   Fail soft (200 + empty) on any upstream error. `lib/cache/redis-client.ts`,
+   `lib/places/nearby-cache-key.ts`.
+2. **Edge (Cloudflare WAF, not in the repo)** — Managed-challenge `www` traffic from
+   SG/JP/CN (verified-bot-exempt via `cf.client.bot`, `www`-scoped so the origin's own
+   API calls are untouched), plus a per-IP rate-limit on `/api/places/nearby`
+   (15 req / 10s on Free).
+3. **Provider (GCP, not in the repo)** — `places.googleapis.com/SearchNearbyRequest`
+   daily quota capped at **50/day** via a Service Usage consumer override (default was
+   100). This is the hard ceiling; a `429` stops calls and billing for the day.
+
+## Prevention
+
+1. **Coordinate-snapped, deploy-independent cache** — the structural fix: cost is now a
+   function of distinct event locations, so a traffic or bot spike can't move it.
+2. **Daily quota cap (50/day)** — a true hard ceiling. The €10 budget is an alert, not
+   a cap; the quota is what bounds a runaway to one day instead of a month.
+3. **Per-IP edge rate-limit** — the only control that catches direct random-coordinate
+   abuse, which caching can't (random coords miss every time).
+4. **Bundle baseline updated** — the redis client adds ~44KB to the `/api/places*`
+   server bundles; `bundle-size-baseline.json` records it (thresholds unchanged).
+
+## Lessons Learned
+
+1. **A GCP "budget" is a smoke alarm, not a circuit breaker.** It emails; it never
+   stops spend. The hard stop is an **API quota limit** (`SearchNearbyRequest`
+   `/d/{project}`). Set the quota, not just the budget.
+2. **Cache cost drivers by a coarse key, and keep that cache off the `buildId`-scoped
+   handler.** Per-exact-coordinate keys + per-deploy eviction = a cache that doesn't
+   cache. For data that should outlive deploys, use the app-level Redis client
+   (`lib/cache/redis-client.ts`), not the Next incremental cache.
+3. **`searchNearby` bills per request, not per result.** Lowering the result count
+   does nothing for cost; lowering the *number of requests* (caching) is the lever.
+4. **Never block DE / Hetzner / datacenter ASNs at the edge — that is the own origin.**
+   ~40% of Cloudflare traffic is country=DE hitting `api.esdeveniments.cat`: the Coolify
+   box on Hetzner (ASN 24940) calling its own backend on SSR. A disabled "block non-ES"
+   WAF rule and a Cloudflare AI assistant both pointed at exactly this; applying it
+   would take down SSR. Use *managed challenge* on named bot-source countries, never
+   *block* by geography/ASN. Verify origin egress before any country/ASN edge rule.
+5. **A widget's data fetch must fail soft.** A non-critical section returned a 500 that
+   surfaced as a red error box to users when the upstream was unavailable. It now hides.

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -22,6 +22,7 @@ Files are named: `YYYY-MM-DD-short-description.md`
 
 | Date       | Incident                                                                   | Impact                                  | Status                |
 | ---------- | -------------------------------------------------------------------------- | --------------------------------------- | --------------------- |
+| 2026-06-26 | [Google Places API Cost Climb from Bot Traffic](./2026-06-26-places-api-cost.md) | Cost (~€5/mo, trending up; bot-driven) | Resolved              |
 | 2026-06-11 | [Coolify Redis Stale Prerender Drops SSR Metadata](./2026-06-11-coolify-redis-stale-prerender.md) | SEO (develop line: no SSR title/canonical) | Resolved              |
 | 2026-04-25 | [Orank Empty Shell Non-Issue](./2026-04-25-orank-empty-shell-non-issue.md) | None — diagnostic only                  | Resolved (Documented) |
 | 2026-04-23 | [Coolify PR Preview Empty HTML](./2026-04-23-coolify-pr-preview-empty-html.md) | SEO testing unreliable on PR previews | Resolved (Documented) |

--- a/docs/restaurant-promotion-implementation.md
+++ b/docs/restaurant-promotion-implementation.md
@@ -6,7 +6,7 @@ This document describes the complete implementation of the restaurant promotion 
 
 The system allows restaurants to promote themselves on event pages through a paid promotion system. It includes:
 
-1. **SSR "Where to eat" section** - Shows top 3 nearby restaurants via Google Places API
+1. **SSR "Where to eat" section** - Shows top 2 nearby restaurants via Google Places API
 2. **Restaurant promotion form** - Allows restaurants to create paid promotions
 3. **Stripe Checkout integration** - Handles payment processing
 4. **Webhook system** - Activates promotions after successful payment
@@ -41,9 +41,12 @@ The system allows restaurants to promote themselves on event pages through a pai
 **File**: `app/api/places/nearby/route.ts`
 
 - Proxies Google Places Nearby Search API
-- Fetches top 3 restaurants near event location
+- Fetches up to 2 restaurants near event location
 - Uses minimal field mask for performance
-- Implements proper caching with Next.js revalidate
+- Caches results in Redis keyed by ~1.1km-snapped coordinates (deploy-independent,
+  12h TTL) so cost scales with distinct event areas, not traffic. See
+  [the cost incident](./incidents/2026-06-26-places-api-cost.md) and `lib/cache/redis-client.ts`
+- Fails soft (200 + empty result) on any upstream error; the section hides
 - Shows required Google attribution
 - Only stores `place_id` indefinitely, `lat/lng` for max 30 days
 


### PR DESCRIPTION
## Why

Follow-up to #376. The Places API cost fix spans three layers, and **two of them live outside this repo** — the Cloudflare WAF rules and the GCP 50/day quota cap. A teammate reading only the code would have no signal those exist, so when restaurants stop showing in some region or a request 429s, they'd debug the wrong layer. There was also a genuine near-miss worth recording: blanket-blocking non-ES (or datacenter ASNs) at Cloudflare would take down SSR, because the origin is on Hetzner (DE) and calls its own backend through Cloudflare.

## What

- **`docs/incidents/2026-06-26-places-api-cost.md`** — post-mortem in the house format: bot-traffic root cause, the per-exact-coord + buildId-wiped cache that made it expensive, the three-layer fix, and the lessons (a GCP budget is an alert not a cap; `searchNearby` bills per request; never block DE/Hetzner = own origin; widgets must fail soft).
- **`LESSONS.md`** — two entries: the three-layer control (two not in git) and the never-block-DE/Hetzner rule.
- **`docs/restaurant-promotion-implementation.md`** — fixed stale claims: "top 3" → 2 nearby restaurants; "Next.js revalidate" caching → deploy-independent Redis snapped-coord cache; noted fail-soft.
- **`.github/skills/api-layer-patterns/SKILL.md`** — pointer to the Redis read-through pattern for per-request-billed upstreams (CDN headers alone aren't enough on Free).
- **`docs/incidents/README.md`** — indexed the new entry.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs the Places API cost incident and the three-layer cost controls to prevent overspend (deploy‑independent Redis caching, Cloudflare WAF/rate‑limit, and a 50/day GCP quota). Also updates LESSONS and restaurant implementation docs (2 results, fail‑soft), adds a Redis pattern pointer in `api-layer-patterns`, and indexes the incident.

<sup>Written for commit 18e6ba247fa5440540c99164c40c56ec1a446169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for nearby restaurant recommendations and map-related search behavior.
  * Clarified that the “Where to eat” section now shows fewer results for a more focused experience.
  * Added incident documentation and operational notes covering cost spikes, traffic controls, and safer handling of external service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->