### PR TITLE
release: deploy to production (2026-06-26) — Places API cost fix

### DIFF
--- a/.github/skills/api-layer-patterns/SKILL.md
+++ b/.github/skills/api-layer-patterns/SKILL.md
@@ -203,6 +203,8 @@ headers: {
 }
 ```
 
+**Per-request-billed upstreams (e.g. Google Places):** CDN headers aren't enough — on Cloudflare's Free plan `/api/*` isn't edge-cached, and the Next fetch cache is wiped every deploy (`cache-handler.mjs` scopes keys by `buildId`). For a paid upstream, read through the **deploy-independent** app Redis cache (`lib/cache/redis-client.ts`) with a coarse key, and cap cost at the provider (GCP quota). See `app/api/places/nearby/route.ts` and [the Places cost incident](../../../docs/incidents/2026-06-26-places-api-cost.md).
+
 ---
 
 ## Layer 3: External Wrappers

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -208,19 +208,93 @@ jobs:
           if-no-files-found: ignore
 
   # -----------------------------------------------------------------
+  # Build the production image on a GitHub runner and push it to GHCR.
+  # The heavy Next.js build used to run on the shared Coolify host and
+  # starved prod of CPU during deploys; building here keeps it off-box.
+  # Coolify then deploys this prebuilt image (Docker Image source).
+  # -----------------------------------------------------------------
+  build-and-push:
+    name: Build & push image
+    needs: [quality, unit-tests, e2e-tests]
+    # Build only when the CI jobs that ran passed (mirrors the deploy gate).
+    if: >-
+      always() &&
+      !(github.event_name == 'workflow_dispatch' && inputs.skip_ci) &&
+      (needs.quality.result == 'success' || needs.quality.result == 'skipped') &&
+      (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    # Environment-scoped secrets let the develop (staging) build inline its own
+    # NEXT_PUBLIC_* values, overriding the repo-level prod defaults.
+    environment:
+      name: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Compute lowercase image name
+        id: meta
+        run: echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ github.ref_name }}
+            ${{ steps.meta.outputs.image }}:sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # NEXT_PUBLIC_* are inlined into the client bundle (public by design).
+          # HMAC_SECRET / SENTRY_AUTH_TOKEN are used only in the builder stage and
+          # do not persist in the final runner image (multi-stage Dockerfile).
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+            NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_GOOGLE_ANALYTICS=${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS }}
+            NEXT_PUBLIC_GOOGLE_ADS=${{ secrets.NEXT_PUBLIC_GOOGLE_ADS }}
+            NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=${{ secrets.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }}
+            NEXT_PUBLIC_GOOGLE_MAPS=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS }}
+            NEXT_PUBLIC_TIKTOK_CLIENT_KEY=${{ secrets.NEXT_PUBLIC_TIKTOK_CLIENT_KEY }}
+            NEXT_PUBLIC_TIKTOK_REDIRECT_URI=${{ secrets.NEXT_PUBLIC_TIKTOK_REDIRECT_URI }}
+            NEXT_PUBLIC_VAPID_PUBLIC_KEY=${{ secrets.NEXT_PUBLIC_VAPID_PUBLIC_KEY }}
+            HMAC_SECRET=${{ secrets.HMAC_SECRET }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+
+  # -----------------------------------------------------------------
   # Deploy to Coolify (waits for whichever CI jobs actually ran)
   # -----------------------------------------------------------------
   deploy:
     name: Deploy to Coolify
     runs-on: ubuntu-latest
-    needs: [quality, unit-tests, e2e-tests]
+    needs: [quality, unit-tests, e2e-tests, build-and-push]
     # Run deploy if all non-skipped jobs succeeded.
     # `always()` lets us proceed when skipped jobs report as skipped (not failed).
     if: >-
       always() &&
       (needs.quality.result == 'success' || needs.quality.result == 'skipped') &&
       (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped') &&
-      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped')
+      (needs.e2e-tests.result == 'success' || needs.e2e-tests.result == 'skipped') &&
+      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped')
     # 20 min = 15 min MAX_WAIT for Coolify build (prod Next.js + Docker rebuilds
     # run ~12 min) + ~5 min for webhook trigger, smoke tests, and runner overhead.
     timeout-minutes: 20

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -33,3 +33,17 @@ main and develop diverge. A fix that lands directly on main (a hotfix) does not 
 ## Never lower preview/test-env fidelity to make a test pass
 
 It's tempting to drop a threshold (e.g. `SITEMAP_MIN_EVENTS_FOR_EXPANSION`) or relax gating in non-prod so a flaky test goes green. Don't: that makes the preview behave differently from production, which is the exact parity gap that caused the cache and image-proxy incidents. Fix the mis-layered test, not the environment. Environment parity is the asset.
+
+## Places API cost is controlled in three layers — two of them are NOT in this repo
+
+`/api/places/nearby` (Google `searchNearby`, billed per request) has its cost held down by three controls, and only the first lives in git:
+
+1. **Code** — `lib/cache/redis-client.ts` + `lib/places/nearby-cache-key.ts` cache results in Redis keyed by `~1.1km-snapped` coordinates. This is a **separate Redis layer from `cache-handler.mjs`** on purpose: the Next handler scopes keys by `buildId` and wipes them every deploy, which is wrong for data that should outlive deploys. The app cache is deploy-independent (12h TTL) and fails open.
+2. **Cloudflare WAF** (dashboard, zone `esdeveniments.cat`) — managed-challenge for SG/JP/CN bot traffic + a per-IP rate-limit on the endpoint.
+3. **GCP quota** (`places.googleapis.com/SearchNearbyRequest`, project `esdeveniments-3`) — **50/day** consumer override. This is the hard ceiling. The €10 "budget" is only an alert, never a cap.
+
+So if restaurants suddenly stop showing, or a request 429s, the cause may be the WAF or the quota — not the code. See [docs/incidents/2026-06-26-places-api-cost.md](docs/incidents/2026-06-26-places-api-cost.md).
+
+## Never block DE / Hetzner / datacenter ASNs at the Cloudflare edge — that's the own origin
+
+~40% of Cloudflare traffic shows country **DE** hitting `api.esdeveniments.cat` on SSR data paths (`/api/events`, `/api/places/regions/options`, …). That is **not** a bot — it's the Coolify box on **Hetzner** (ASN 24940, Germany) calling its own backend through Cloudflare on every render. A disabled "block non-ES" WAF rule already exists from a past attempt, and a Cloudflare AI assistant will recommend challenging datacenter ASNs (incl. 24940 / AWS). Applying either takes down SSR. Use *managed challenge* on named bot-source countries (SG/JP/CN), never *block* by geography/ASN, and always verify origin egress before any country/ASN edge rule.

--- a/app/GoogleScripts.tsx
+++ b/app/GoogleScripts.tsx
@@ -6,6 +6,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useAdContext } from "@lib/context/AdContext";
 import type { WindowWithGtag } from "types/common";
 import { isE2ETestMode } from "@utils/env";
+import { isProductionHost } from "@utils/production-host";
 import { scheduleIdleCallback } from "@utils/browser";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
@@ -114,6 +115,18 @@ function GoogleAnalyticsPageview({ adsAllowed }: { adsAllowed: boolean }) {
 export default function GoogleScripts() {
   const { adsAllowed } = useAdContext();
 
+  // Gate GA (pageviews + consent) and Auto Ads to the production host so they
+  // never fire on Vercel previews, staging, or the app embedded in the Coolify
+  // dashboard, all of which inline the same prod measurement ID. Reuses the
+  // existing prod-host allowlist (covers www + apex). Resolved after mount so
+  // the first client render matches SSR (both render nothing) — no hydration
+  // mismatch. The CMP/consent banner is intentionally NOT gated (it keeps its
+  // beforeInteractive ordering and sends nothing to GA on its own).
+  const [isProdHost, setIsProdHost] = useState(false);
+  useEffect(() => {
+    setIsProdHost(isProductionHost(window.location.hostname));
+  }, []);
+
   const [HeavyComponent, setHeavyComponent] = useState<
     React.ComponentType<{ adsAllowed: boolean }> | null
   >(null);
@@ -126,7 +139,7 @@ export default function GoogleScripts() {
   // because our TCF implementation (AdContext) provides a unified consent model.
   // This is intentional and aligns with our CMP's consent structure.
   useEffect(() => {
-    if (!GA_MEASUREMENT_ID || isE2ETestMode) return;
+    if (!GA_MEASUREMENT_ID || isE2ETestMode || !isProdHost) return;
     const win = ensureGtag();
     if (!win) return;
 
@@ -161,13 +174,14 @@ export default function GoogleScripts() {
     );
 
     return cleanup;
-  }, [adsAllowed]);
+  }, [adsAllowed, isProdHost]);
 
   // Load heavy tracking + Auto Ads only after hydration.
   // This prevents server/client HTML mismatches caused by client-only boundaries.
   useEffect(() => {
     if (!adsAllowed) return;
     if (isE2ETestMode) return;
+    if (!isProdHost) return;
     let cancelled = false;
 
     import("./GoogleScriptsHeavy")
@@ -182,12 +196,12 @@ export default function GoogleScripts() {
     return () => {
       cancelled = true;
     };
-  }, [adsAllowed]);
+  }, [adsAllowed, isProdHost]);
 
   return (
     <>
       {/* Google Analytics - Consent Mode v2 (defaults set inline to avoid race conditions) */}
-      {GA_MEASUREMENT_ID && !isE2ETestMode && (
+      {GA_MEASUREMENT_ID && !isE2ETestMode && isProdHost && (
         <>
           <Script id="google-analytics-consent" strategy="lazyOnload">
             {`
@@ -287,14 +301,14 @@ export default function GoogleScripts() {
       )}
 
       {/* Pageview tracking - wrapped in Suspense for useSearchParams */}
-      {GA_MEASUREMENT_ID && !isE2ETestMode && (
+      {GA_MEASUREMENT_ID && !isE2ETestMode && isProdHost && (
         <Suspense fallback={null}>
           <GoogleAnalyticsPageview adsAllowed={adsAllowed} />
         </Suspense>
       )}
 
       {/* Heavy tracking + Auto Ads: only load after consent */}
-      {!isE2ETestMode && adsAllowed && HeavyComponent && (
+      {!isE2ETestMode && isProdHost && adsAllowed && HeavyComponent && (
         <HeavyComponent adsAllowed={adsAllowed} />
       )}
     </>

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -7,7 +7,7 @@
  */
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 import {
   normalizeExternalImageUrl,
   isLegacyFileHandler,
@@ -93,7 +93,7 @@ async function fetchWithTimeout(
   url: string,
   redirectsRemaining = MAX_REDIRECTS,
   deadline = Date.now() + TIMEOUT_MS,
-): Promise<Response> {
+): Promise<Awaited<ReturnType<typeof undiciFetch>>> {
   const targetSafety = await getPublicFetchSafety(url);
   if (!targetSafety.isSafe) {
     throw new Error("Blocked unsafe image upstream");
@@ -111,7 +111,8 @@ async function fetchWithTimeout(
     const pinnedDnsDispatcher = targetSafety.dnsRecords
       ? buildPinnedDnsDispatcher(targetSafety.dnsRecords, !bypassTls)
       : null;
-    const init: RequestInit & { dispatcher?: unknown } = {
+    // Typed as undici's own request init so `dispatcher` is properly typed.
+    const init: NonNullable<Parameters<typeof undiciFetch>[1]> = {
       signal: controller.signal,
       redirect: "manual",
     };
@@ -120,7 +121,13 @@ async function fetchWithTimeout(
       init.dispatcher = pinnedDnsDispatcher ?? insecureTlsDispatcher;
     }
 
-    const response = await fetch(url, init as RequestInit);
+    // Use undici's own fetch (not the global one) so the response-body
+    // plumbing comes from the SAME undici copy as the dispatcher Agent above.
+    // Feeding a standalone-undici Agent into Node's global fetch (bundled
+    // undici) mismatches internal symbols and throws
+    // "controller[kState].transformAlgorithm is not a function" when decoding
+    // compressed upstream responses.
+    const response = await undiciFetch(url, init);
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");
       await response.body?.cancel();

--- a/app/api/places/nearby/route.ts
+++ b/app/api/places/nearby/route.ts
@@ -11,6 +11,11 @@ import {
   OpeningSegment,
 } from "types/api/restaurant";
 import { handleApiError } from "@utils/api-error-handler";
+import {
+  buildNearbyCacheKey,
+  nearbySearchCenter,
+} from "@lib/places/nearby-cache-key";
+import { cacheGetJson, cacheSetJson } from "@lib/cache/redis-client";
 
 export async function GET(request: NextRequest) {
   const t = await getTranslations("Api.PlacesNearby");
@@ -327,74 +332,118 @@ export async function GET(request: NextRequest) {
     return { info: { open_status: "unknown" }, weekdayText };
   }
 
-  // --- Main fetch + transform ---
+  // --- Cached fetch + transform ---
+  // Snap the search centre to a ~1.1km grid so every event in the same area
+  // shares one cache entry, and cache the raw upstream result in Redis under a
+  // build-independent key (unlike Next's fetch cache, which cache-handler.mjs
+  // scopes by buildId and wipes on every deploy). The Google request never
+  // depends on the event date — date handling is post-fetch — so one cached
+  // call serves the whole neighbourhood across every date. searchNearby is
+  // billed per request, so this is what bounds the Places bill by distinct
+  // locations instead of by traffic.
+  const cacheKey = buildNearbyCacheKey(lat, lng, radius);
+  const NEARBY_TTL_SECONDS = 60 * 60 * 12; // 12h — opening hours rarely change
+
   try {
-    const fields = [
-      "places.name",
-      "places.displayName",
-      "places.formattedAddress",
-      "places.rating",
-      "places.priceLevel",
-      "places.location",
-      "places.photos",
-      "places.businessStatus",
-      "places.currentOpeningHours",
-      "places.regularOpeningHours",
-      "places.utcOffsetMinutes",
-      "places.postalAddress.addressLines",
-      "places.postalAddress.locality",
-      "places.postalAddress.administrativeArea",
-      "places.postalAddress.postalCode",
-    ].join(",");
+    // Treat a corrupted cached value (not an array, or with null/non-object
+    // elements from a partial write) as a miss (re-fetch) so it can't make
+    // `.filter` throw and turn into a 500.
+    const cached = await cacheGetJson<GooglePlaceResponse[]>(cacheKey);
+    let places: GooglePlaceResponse[] | null =
+      Array.isArray(cached) && cached.every((p) => p && typeof p === "object")
+        ? cached
+        : null;
 
-    const url = new URL("https://places.googleapis.com/v1/places:searchNearby");
-    const requestedCount = Math.min(Math.max(limit * 3, 12), 20);
+    if (places === null) {
+      const fields = [
+        "places.name",
+        "places.displayName",
+        "places.formattedAddress",
+        "places.rating",
+        "places.priceLevel",
+        "places.location",
+        "places.photos",
+        "places.businessStatus",
+        "places.currentOpeningHours",
+        "places.regularOpeningHours",
+        "places.utcOffsetMinutes",
+        "places.postalAddress.addressLines",
+        "places.postalAddress.locality",
+        "places.postalAddress.administrativeArea",
+        "places.postalAddress.postalCode",
+      ].join(",");
 
-    const requestBody: GooglePlacesNearbyRequest = {
-      includedTypes: ["restaurant"],
-      maxResultCount: requestedCount,
-      locationRestriction: {
-        circle: {
-          center: { latitude: lat, longitude: lng },
-          radius,
-        },
-      },
-      rankPreference: "DISTANCE",
-      languageCode: "ca",
-    };
-
-    const response = await fetch(url.toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Goog-Api-Key": apiKey,
-        "X-Goog-FieldMask": fields,
-      },
-      body: JSON.stringify(requestBody),
-      next: {
-        revalidate: 3600,
-        tags: [
-          "places",
-          `places:${lat}:${lng}`,
-          eventDateISO ? `places:date:${eventDateISO}` : "places:date:none",
-        ],
-      },
-    });
-
-    const data: GooglePlacesSearchNearbyRawResponse = await response.json();
-
-    if (!response.ok) {
-      console.error("Google Places API error:", response.status, data);
-      return NextResponse.json(
-        { error: "Places API error", status: response.status, details: data },
-        {
-          status: 500,
-          headers: { "Cache-Control": "no-store" },
-        }
+      const url = new URL(
+        "https://places.googleapis.com/v1/places:searchNearby"
       );
-    }
+      // Always request the max: searchNearby is billed per request, not per
+      // result, and the cache key omits `limit`, so caching the largest set
+      // lets one entry serve any limit without underfilling after filtering.
+      const requestedCount = 20;
 
-    const places = Array.isArray(data.places) ? data.places : [];
+      const center = nearbySearchCenter(lat, lng, radius);
+      const requestBody: GooglePlacesNearbyRequest = {
+        includedTypes: ["restaurant"],
+        maxResultCount: requestedCount,
+        locationRestriction: {
+          circle: {
+            center: { latitude: center.lat, longitude: center.lng },
+            radius,
+          },
+        },
+        rankPreference: "DISTANCE",
+        languageCode: "ca",
+      };
+
+      // Fail soft: this is a non-critical widget. Any upstream failure — non-OK
+      // status, non-JSON body, or a network/DNS error — returns an empty result
+      // so the section just hides (never a 500 to the user) and we don't cache
+      // the failure. We cache the result ourselves, so the fetch opts out of
+      // Next's buildId-scoped data cache to avoid storing the payload twice.
+      const failSoftEmpty = () =>
+        NextResponse.json(
+          { results: [], status: "OK", attribution: "Powered by Google" },
+          { status: 200, headers: { "Cache-Control": "no-store" } }
+        );
+
+      try {
+        const response = await fetch(url.toString(), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Goog-Api-Key": apiKey,
+            "X-Goog-FieldMask": fields,
+          },
+          body: JSON.stringify(requestBody),
+          cache: "no-store",
+          // Bound the upstream call so a hung Google request can't tie up the
+          // worker; on timeout the fetch throws and we fail soft below.
+          signal: AbortSignal.timeout(5000),
+        });
+
+        if (!response.ok) {
+          const errText = await response.text().catch(() => "");
+          console.error("Google Places API error:", response.status, errText);
+          return failSoftEmpty();
+        }
+
+        const data: GooglePlacesSearchNearbyRawResponse =
+          await response.json();
+        // A 200 carrying an `error` body (or a null/invalid parse) is a soft
+        // failure — fail soft without caching, so it isn't suppressed for the
+        // 12h TTL after the upstream recovers. A genuinely empty area omits
+        // `places` with no error, and we DO cache that as [] (don't re-query).
+        if (data?.error) {
+          console.error("Google Places API soft error:", data.error);
+          return failSoftEmpty();
+        }
+        places = Array.isArray(data?.places) ? data.places : [];
+        await cacheSetJson(cacheKey, places, NEARBY_TTL_SECONDS);
+      } catch (fetchError) {
+        console.error("Google Places API fetch/parse error:", fetchError);
+        return failSoftEmpty();
+      }
+    }
 
     const filtered = places.filter((place: GooglePlaceResponse) => {
       if (!isOperational(place)) return false;

--- a/bundle-size-baseline.json
+++ b/bundle-size-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "lastUpdated": "2026-04-21T18:45:00+00:00",
+  "lastUpdated": "2026-06-26T00:00:00+00:00",
   "clientTotalBytes": 2283119,
   "thresholds": {
     "warning": {
@@ -118,7 +118,7 @@
       "fileCount": 8
     },
     "/api/places": {
-      "serverBytes": 95812,
+      "serverBytes": 142830,
       "fileCount": 24
     },
     "/api/events": {
@@ -170,7 +170,7 @@
       "fileCount": 6
     },
     "/api/places/nearby": {
-      "serverBytes": 24413,
+      "serverBytes": 70288,
       "fileCount": 6
     },
     "/api/news/[slug]": {

--- a/components/ui/restaurantPromotion/RestaurantPromotionSection.tsx
+++ b/components/ui/restaurantPromotion/RestaurantPromotionSection.tsx
@@ -40,7 +40,6 @@ export default function RestaurantPromotionSection({
   // All hooks must be called at the top level before any conditional returns
   const [placesResp, setPlacesResp] = useState<PlacesResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [openPromoInfo, setOpenPromoInfo] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const isVisible = useOnScreen(sectionRef as React.RefObject<Element>, {
@@ -112,7 +111,6 @@ export default function RestaurantPromotionSection({
 
     const fetchPlaces = async () => {
       setIsLoading(true);
-      setError(null);
 
       try {
         let dateParam = "";
@@ -128,12 +126,11 @@ export default function RestaurantPromotionSection({
         if (res.ok) {
           const data = await res.json();
           setPlacesResp(data);
-        } else {
-          setError("Failed to fetch places");
         }
+        // On failure, leave the section hidden — it's a non-critical widget,
+        // not worth showing the user an error.
       } catch (err) {
         console.error("Error fetching places", err);
-        setError("Error fetching places");
       } finally {
         setIsLoading(false);
       }
@@ -170,13 +167,6 @@ export default function RestaurantPromotionSection({
             setOpenPromoInfo(true);
           }}
         />
-      )}
-
-      {/* Error State */}
-      {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <p className="body-small text-error">{error}</p>
-        </div>
       )}
 
       {/* Active Promotion (if any) */}

--- a/docs/ci-build-push-migration.md
+++ b/docs/ci-build-push-migration.md
@@ -28,6 +28,15 @@ Most are already repo-level secrets. Add the gaps:
 - `NEXT_PUBLIC_VAPID_PUBLIC_KEY` = copy from the Coolify staging app env
 - Any other `NEXT_PUBLIC_*` that differs from prod for staging.
 
+**Analytics on non-prod:** a GitHub *environment* secret falls back to the
+repo-level (prod) secret when unset, so the staging image inlines the prod
+analytics IDs. That no longer pollutes prod analytics, because GA and Auto Ads
+are gated to the production host at runtime (see `app/GoogleScripts.tsx`, PR
+#374): they only fire on `www.esdeveniments.cat`, never on staging or previews.
+So you do not need to clear those IDs in the staging environment. (Setting a
+GitHub secret to an empty string isn't even possible — the API rejects it with
+HTTP 422.)
+
 `NEXT_PUBLIC_CONTACT_EMAIL` is not set anywhere today (builds empty); add it if
 you want it inlined.
 
@@ -52,8 +61,14 @@ For each frontend app (prod `ohrtinmo1t8sz798wrq1gav3`, staging
 3. **Remove `BUILD_VERSION` from the app's runtime env vars.** The image bakes
    `BUILD_VERSION=<git sha>` at build time, and a runtime override would shadow
    it, breaking the `/api/health` version gate the deploy workflow waits on.
-4. Keep the existing deploy webhook. It now triggers a pull-and-redeploy of the
-   new tag instead of an on-host build.
+4. Deploy trigger: a **Docker Image** app does not auto-deploy from git pushes
+   the way a Dockerfile/GitHub app does, so confirm the workflow's
+   `COOLIFY_WEBHOOK_URL` is this app's **Deploy Webhook** (Coolify → app →
+   Webhooks). The deploy job POSTs it explicitly, which makes Coolify re-pull
+   the moving tag (`:main` / `:develop`) and swap the container. After the first
+   prebuilt deploy, verify `/api/health` reports the new commit — if the tag
+   didn't re-pull, enable "force pull" / check the webhook points at the right
+   app.
 
 ## How it flows after migration
 

--- a/docs/ci-build-push-migration.md
+++ b/docs/ci-build-push-migration.md
@@ -1,0 +1,80 @@
+# Build in CI, deploy prebuilt image (Coolify)
+
+The Next.js build used to run on the Coolify host (`build_pack: dockerfile`,
+no dedicated build server). That host also runs prod + staging + the backends +
+databases on 4 vCPUs, so every on-server build starved prod of CPU and caused
+timeouts/500s during deploys.
+
+This change moves the build to a GitHub runner. `deploy-coolify.yml` now builds
+the image and pushes it to GHCR (`build-and-push` job); Coolify deploys that
+prebuilt image instead of building on the host. The Dockerfile and
+`output: "standalone"` are unchanged.
+
+## One-time setup (do these before merging the workflow)
+
+### 1. GitHub secrets for the build
+
+The build inlines `NEXT_PUBLIC_*` at build time, so they must exist in GitHub.
+Most are already repo-level secrets. Add the gaps:
+
+**Repo-level** (`Settings → Secrets → Actions`):
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY` — copy from the Coolify prod app env. Without it
+  the push CTA is missing in the image.
+
+**`staging` environment** (these override the repo-level prod values on the
+`develop` build, since `NEXT_PUBLIC_*` are baked per environment):
+- `NEXT_PUBLIC_API_URL` = `https://api-preproduction.esdeveniments.cat`
+- `NEXT_PUBLIC_SITE_URL` = `https://staging.esdeveniments.cat`
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY` = copy from the Coolify staging app env
+- Any other `NEXT_PUBLIC_*` that differs from prod for staging.
+
+`NEXT_PUBLIC_CONTACT_EMAIL` is not set anywhere today (builds empty); add it if
+you want it inlined.
+
+Runtime-only vars (Redis, Turso, Stripe webhooks, VAPID private key, Cloudflare,
+Places, revalidate secret) stay in Coolify as container env. The prebuilt image
+does not bake them, so nothing to copy.
+
+### 2. GHCR package visibility
+
+The image is `ghcr.io/esdeveniments/esdeveniments-frontend`. Keep it **private**
+and add a read-only pull credential in Coolify, or make the package public to
+skip pull auth. Private is recommended.
+
+### 3. Coolify app reconfiguration (prod and staging frontend apps)
+
+For each frontend app (prod `ohrtinmo1t8sz798wrq1gav3`, staging
+`nykpqplcbakwtuzezzuet80d`):
+1. Change the source from **Dockerfile / GitHub** to **Docker Image**:
+   - prod → `ghcr.io/esdeveniments/esdeveniments-frontend:main`
+   - staging → `ghcr.io/esdeveniments/esdeveniments-frontend:develop`
+2. Add the GHCR pull credential (if the package is private).
+3. **Remove `BUILD_VERSION` from the app's runtime env vars.** The image bakes
+   `BUILD_VERSION=<git sha>` at build time, and a runtime override would shadow
+   it, breaking the `/api/health` version gate the deploy workflow waits on.
+4. Keep the existing deploy webhook. It now triggers a pull-and-redeploy of the
+   new tag instead of an on-host build.
+
+## How it flows after migration
+
+1. Push to `main`/`develop` → CI runs quality, unit, e2e (main).
+2. `build-and-push` builds the image on the runner and pushes
+   `:<branch>` + `:sha-<commit>` to GHCR.
+3. `deploy` hits the Coolify webhook → Coolify pulls the new `:<branch>` image
+   and swaps the container. No build on the host.
+4. The deploy job's health gate confirms `/api/health` reports the new commit,
+   then purges Cloudflare and runs smoke tests (unchanged).
+
+## Rollback
+
+If a prebuilt deploy misbehaves, switch the Coolify app source back to
+Dockerfile/GitHub in the dashboard (one toggle). Revert the workflow change via
+git. No data is touched; this is all build/deploy plumbing.
+
+## Not covered here (follow-ups)
+
+- The **backend** (`esdeveniments-back-pro`) also builds on the host and is the
+  app that actually fell over on 2026-06-26. It needs the same treatment in its
+  own repo.
+- Right-size the frontend container memory (currently 1.5 GB, OOM-prone) and
+  consider moving staging + pre environments off the prod box.

--- a/docs/incidents/2026-06-26-places-api-cost.md
+++ b/docs/incidents/2026-06-26-places-api-cost.md
@@ -1,0 +1,104 @@
+# Incident: Google Places API Cost Climb from Bot Traffic (Jun 26, 2026)
+
+## Summary
+
+Google **Places API (New) "Nearby Search (Enterprise)"** spend climbed month over
+month — €0.16 (June 2025) → €0.49 (Mar) → €1.29 (May) → €5.02 (June 2026) — tracking
+toward the €10 budget. The driver was bot traffic, not real users: headless,
+JS-executing crawlers (mostly Singapore and Japan) scrolled event pages, tripped the
+`IntersectionObserver` gate on the "Where to eat" widget, and triggered
+`GET /api/places/nearby` → one billable `searchNearby` request per cache miss. The
+owner disabled the API by hand to stop the bleed.
+
+The widget's scroll gate genuinely cut calls for humans (that's why May was only
+€1.29), which is why it looked solved. It wasn't: the cache barely helped, and a bot
+wave in June multiplied the misses.
+
+## Impact
+
+| | |
+| --- | --- |
+| Cost | ~€5 in June 2026 (would have passed the €10 budget alert; never a true cap) |
+| Downtime | None |
+| User impact | While the API was manually disabled, the widget showed a red "Failed to fetch places" error box on upcoming-event pages (now fixed to fail soft) |
+
+The blast radius was always bounded: `SearchNearbyRequest` ships with a 100/day
+default quota, so the worst case was ~100 calls/day ≈ €3/day. The €10 "budget" only
+emails an alert — it never stops usage or billing.
+
+## Timeline
+
+- **Through June 2026** — Spend climbs with traffic; a bot wave (GA4: Singapore 13K /
+  Japan 8.9K "users" vs Barcelona 1.6K, 11s avg engagement, 24K new / 400 returning)
+  pushes June to €5.02.
+- **Jun 26** — Owner disables the Places API in Google Cloud to stop the spend.
+- **Jun 26** — Diagnosis: GA4 + Cloudflare edge analytics confirm bot origin;
+  `/api/places/nearby` traffic is ~75% real ES users, ~25% JP bots, but the wider
+  page-crawl is what multiplied misses. Three-layer fix shipped (PR #376) + edge +
+  quota controls applied. API re-enabled behind the new quota cap.
+
+## Root Cause
+
+Two things made nearly every call a cache miss:
+
+1. **The cache key was the exact lat/lng.** Two events ~200m apart never shared an
+   entry, so the per-event widget re-queried Google for each one.
+2. **The Next.js fetch cache is wiped every deploy.** `cache-handler.mjs` scopes keys
+   by `buildId` (correct for prerender shells — see
+   [2026-06-11](./2026-06-11-coolify-redis-stale-prerender.md)), so the Places
+   results it cached were dropped on each deploy. On a frequently-deployed,
+   bot-crawled site, the hit rate was near zero.
+
+On Cloudflare's Free plan `/api/*` isn't edge-cached either, so nothing absorbed the
+misses before they reached Google. `searchNearby` is billed **per request** (not per
+result), so reducing the result limit 3→2 earlier had not reduced cost.
+
+## Resolution
+
+Defense in depth — no single layer is load-bearing:
+
+1. **Origin (the real fix, PR #376)** — Cache the raw upstream result in Redis keyed
+   by `~1.1km-snapped` coordinates, in a **deploy-independent** key (separate from the
+   `buildId`-scoped Next handler). The Google request never depends on the event date
+   (date handling is post-fetch), so one cached call serves a whole area across every
+   date. 12h TTL. Calls now scale with distinct event areas (dozens/day), not traffic.
+   Fail soft (200 + empty) on any upstream error. `lib/cache/redis-client.ts`,
+   `lib/places/nearby-cache-key.ts`.
+2. **Edge (Cloudflare WAF, not in the repo)** — Managed-challenge `www` traffic from
+   SG/JP/CN (verified-bot-exempt via `cf.client.bot`, `www`-scoped so the origin's own
+   API calls are untouched), plus a per-IP rate-limit on `/api/places/nearby`
+   (15 req / 10s on Free).
+3. **Provider (GCP, not in the repo)** — `places.googleapis.com/SearchNearbyRequest`
+   daily quota capped at **50/day** via a Service Usage consumer override (default was
+   100). This is the hard ceiling; a `429` stops calls and billing for the day.
+
+## Prevention
+
+1. **Coordinate-snapped, deploy-independent cache** — the structural fix: cost is now a
+   function of distinct event locations, so a traffic or bot spike can't move it.
+2. **Daily quota cap (50/day)** — a true hard ceiling. The €10 budget is an alert, not
+   a cap; the quota is what bounds a runaway to one day instead of a month.
+3. **Per-IP edge rate-limit** — the only control that catches direct random-coordinate
+   abuse, which caching can't (random coords miss every time).
+4. **Bundle baseline updated** — the redis client adds ~44KB to the `/api/places*`
+   server bundles; `bundle-size-baseline.json` records it (thresholds unchanged).
+
+## Lessons Learned
+
+1. **A GCP "budget" is a smoke alarm, not a circuit breaker.** It emails; it never
+   stops spend. The hard stop is an **API quota limit** (`SearchNearbyRequest`
+   `/d/{project}`). Set the quota, not just the budget.
+2. **Cache cost drivers by a coarse key, and keep that cache off the `buildId`-scoped
+   handler.** Per-exact-coordinate keys + per-deploy eviction = a cache that doesn't
+   cache. For data that should outlive deploys, use the app-level Redis client
+   (`lib/cache/redis-client.ts`), not the Next incremental cache.
+3. **`searchNearby` bills per request, not per result.** Lowering the result count
+   does nothing for cost; lowering the *number of requests* (caching) is the lever.
+4. **Never block DE / Hetzner / datacenter ASNs at the edge — that is the own origin.**
+   ~40% of Cloudflare traffic is country=DE hitting `api.esdeveniments.cat`: the Coolify
+   box on Hetzner (ASN 24940) calling its own backend on SSR. A disabled "block non-ES"
+   WAF rule and a Cloudflare AI assistant both pointed at exactly this; applying it
+   would take down SSR. Use *managed challenge* on named bot-source countries, never
+   *block* by geography/ASN. Verify origin egress before any country/ASN edge rule.
+5. **A widget's data fetch must fail soft.** A non-critical section returned a 500 that
+   surfaced as a red error box to users when the upstream was unavailable. It now hides.

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -22,6 +22,7 @@ Files are named: `YYYY-MM-DD-short-description.md`
 
 | Date       | Incident                                                                   | Impact                                  | Status                |
 | ---------- | -------------------------------------------------------------------------- | --------------------------------------- | --------------------- |
+| 2026-06-26 | [Google Places API Cost Climb from Bot Traffic](./2026-06-26-places-api-cost.md) | Cost (~€5/mo, trending up; bot-driven) | Resolved              |
 | 2026-06-11 | [Coolify Redis Stale Prerender Drops SSR Metadata](./2026-06-11-coolify-redis-stale-prerender.md) | SEO (develop line: no SSR title/canonical) | Resolved              |
 | 2026-04-25 | [Orank Empty Shell Non-Issue](./2026-04-25-orank-empty-shell-non-issue.md) | None — diagnostic only                  | Resolved (Documented) |
 | 2026-04-23 | [Coolify PR Preview Empty HTML](./2026-04-23-coolify-pr-preview-empty-html.md) | SEO testing unreliable on PR previews | Resolved (Documented) |

--- a/docs/restaurant-promotion-implementation.md
+++ b/docs/restaurant-promotion-implementation.md
@@ -6,7 +6,7 @@ This document describes the complete implementation of the restaurant promotion 
 
 The system allows restaurants to promote themselves on event pages through a paid promotion system. It includes:
 
-1. **SSR "Where to eat" section** - Shows top 3 nearby restaurants via Google Places API
+1. **SSR "Where to eat" section** - Shows top 2 nearby restaurants via Google Places API
 2. **Restaurant promotion form** - Allows restaurants to create paid promotions
 3. **Stripe Checkout integration** - Handles payment processing
 4. **Webhook system** - Activates promotions after successful payment
@@ -41,9 +41,12 @@ The system allows restaurants to promote themselves on event pages through a pai
 **File**: `app/api/places/nearby/route.ts`
 
 - Proxies Google Places Nearby Search API
-- Fetches top 3 restaurants near event location
+- Fetches up to 2 restaurants near event location
 - Uses minimal field mask for performance
-- Implements proper caching with Next.js revalidate
+- Caches results in Redis keyed by ~1.1km-snapped coordinates (deploy-independent,
+  12h TTL) so cost scales with distinct event areas, not traffic. See
+  [the cost incident](./incidents/2026-06-26-places-api-cost.md) and `lib/cache/redis-client.ts`
+- Fails soft (200 + empty result) on any upstream error; the section hides
 - Shows required Google attribution
 - Only stores `place_id` indefinitely, `lat/lng` for max 30 days
 

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -1,0 +1,129 @@
+import "server-only";
+import { createClient } from "redis";
+
+/**
+ * App-level Redis cache, deliberately separate from the Next.js incremental
+ * cache handler (cache-handler.mjs). That handler namespaces every key by
+ * buildId, so its entries are dropped on each deploy — correct for prerender
+ * shells, wrong for data we want to outlive deploys (e.g. Google Places
+ * results). This client uses stable, unprefixed keys.
+ *
+ * Fails open: any connection or command error resolves to null / no-op so the
+ * caller falls back to the origin. It never throws into the request path.
+ */
+
+/** Back off this long after a failure so a Redis outage can't trigger a connect attempt on every request. */
+const FAILURE_COOLDOWN_MS = 30_000;
+
+const globalForRedis = globalThis as unknown as {
+  __appRedis?: Promise<ReturnType<typeof createClient> | null>;
+  __appRedisFailedAt?: number;
+};
+
+/** Mirrors cache-handler.mjs so both layers resolve Redis the same way. */
+function getRedisUrl(): string | null {
+  if (process.env.REDIS_URL?.trim()) return process.env.REDIS_URL;
+
+  const host = process.env.REDIS_HOST;
+  if (!host) return null;
+
+  const port = process.env.REDIS_PORT || "6379";
+  const password = process.env.REDIS_PASSWORD;
+  const username = process.env.REDIS_USERNAME;
+  const auth = password
+    ? `${username ? encodeURIComponent(username) : ""}:${encodeURIComponent(
+        password
+      )}@`
+    : username
+      ? `${encodeURIComponent(username)}@`
+      : "";
+
+  return `redis://${auth}${host}:${port}`;
+}
+
+async function getClient(): Promise<ReturnType<typeof createClient> | null> {
+  // Fail open during the cooldown after any failure — checked before reusing a
+  // cached client, so a client that errored *after* connecting is skipped too
+  // (otherwise the cached promise would always short-circuit this check).
+  if (
+    globalForRedis.__appRedisFailedAt &&
+    Date.now() - globalForRedis.__appRedisFailedAt < FAILURE_COOLDOWN_MS
+  ) {
+    return null;
+  }
+
+  if (globalForRedis.__appRedis) return globalForRedis.__appRedis;
+
+  const url = getRedisUrl();
+  if (!url) return null;
+
+  const isTls = url.startsWith("rediss://");
+
+  globalForRedis.__appRedis = (async () => {
+    let client: ReturnType<typeof createClient> | null = null;
+    try {
+      client = createClient({
+        url,
+        pingInterval: 10_000,
+        // Fail fast instead of queueing commands while disconnected, so a Redis
+        // outage falls through to the origin immediately rather than hanging.
+        disableOfflineQueue: true,
+        socket: isTls
+          ? { tls: true, rejectUnauthorized: false, connectTimeout: 2_000 }
+          : { connectTimeout: 2_000 },
+      });
+      // node-redis needs a persistent error listener or it throws on errors.
+      // It reconnects on its own, so we don't disconnect/recreate here — doing
+      // that risked a late error from an old client wiping a newer one's
+      // promise. We just stamp the failure (the cooldown check above uses it to
+      // fail open) and log it so errors aren't silently swallowed.
+      client.on("error", (err) => {
+        globalForRedis.__appRedisFailedAt = Date.now();
+        console.warn("[redis-cache] client error:", err?.message ?? err);
+      });
+      await client.connect();
+      return client;
+    } catch (error) {
+      // Disconnect the failed client so it doesn't keep retrying in the
+      // background — without this, each cooldown cycle during a prolonged
+      // outage would orphan a new client. Log so a silent connect failure
+      // (= running uncached, more paid Places calls) is noticeable.
+      client?.disconnect().catch(() => {});
+      console.warn("[redis-cache] connect failed:", error);
+      globalForRedis.__appRedis = undefined;
+      globalForRedis.__appRedisFailedAt = Date.now();
+      return null;
+    }
+  })();
+
+  return globalForRedis.__appRedis;
+}
+
+export async function cacheGetJson<T>(key: string): Promise<T | null> {
+  try {
+    const client = await getClient();
+    if (!client) return null;
+    const raw = await client.get(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheSetJson(
+  key: string,
+  value: unknown,
+  ttlSeconds: number
+): Promise<void> {
+  try {
+    const client = await getClient();
+    if (!client) return;
+    // SETEX (dedicated helper) avoids the deprecated { EX } option and is
+    // stable across redis v5/v6.
+    await client.setEx(key, ttlSeconds, JSON.stringify(value));
+  } catch (error) {
+    // best-effort: a failed cache write must never fail the request, but log
+    // it so write failures aren't silently swallowed.
+    console.warn("[redis-cache] set failed:", error);
+  }
+}

--- a/lib/places/nearby-cache-key.ts
+++ b/lib/places/nearby-cache-key.ts
@@ -1,0 +1,46 @@
+/**
+ * Cache-key helpers for Places "search nearby" results.
+ *
+ * Snapping coordinates to a coarse grid collapses many distinct event
+ * locations within the same area onto one key, so a single Google call serves
+ * the whole neighbourhood. The key intentionally excludes the event date: the
+ * upstream request doesn't depend on it (date handling happens after the
+ * fetch), so one cached result also serves every date in that cell.
+ *
+ * searchNearby is billed per request, so this is what keeps the Places bill a
+ * function of distinct locations, not of traffic.
+ */
+
+/** 2 decimal places: about 1.1 km of latitude (~0.8 km of longitude at Catalan latitudes), both well inside the 5 km search radius. */
+export const NEARBY_GRID = 100;
+
+/**
+ * Below this radius, snapping (which can move the centre up to ~700m) could
+ * push the search area off the caller's point and return wrong results, so
+ * exact coordinates are used instead. The app always searches at 5km, so it
+ * always snaps; only small-radius direct callers fall back to exact.
+ */
+export const SNAP_MIN_RADIUS_M = 2000;
+
+export function snapCoordinate(value: number): number {
+  return Math.round(value * NEARBY_GRID) / NEARBY_GRID;
+}
+
+/** The centre to actually search/cache with: snapped for wide radii, exact for narrow ones. */
+export function nearbySearchCenter(
+  lat: number,
+  lng: number,
+  radiusMeters: number
+): { lat: number; lng: number } {
+  if (radiusMeters < SNAP_MIN_RADIUS_M) return { lat, lng };
+  return { lat: snapCoordinate(lat), lng: snapCoordinate(lng) };
+}
+
+export function buildNearbyCacheKey(
+  lat: number,
+  lng: number,
+  radiusMeters: number
+): string {
+  const center = nearbySearchCenter(lat, lng, radiusMeters);
+  return `places:nearby:v1:${center.lat}:${center.lng}:r${radiusMeters}`;
+}

--- a/test/nearby-cache-key.test.ts
+++ b/test/nearby-cache-key.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  snapCoordinate,
+  nearbySearchCenter,
+  buildNearbyCacheKey,
+  SNAP_MIN_RADIUS_M,
+} from "@lib/places/nearby-cache-key";
+
+describe("nearby cache key", () => {
+  it("snaps coordinates to a ~1.1km grid", () => {
+    expect(snapCoordinate(41.387654)).toBe(41.39);
+    expect(snapCoordinate(2.169912)).toBe(2.17);
+  });
+
+  it("at the app's 5km radius, two points ~700m apart share a key (one Google call serves both)", () => {
+    const a = buildNearbyCacheKey(41.3851, 2.1734, 5000);
+    const b = buildNearbyCacheKey(41.3879, 2.1699, 5000);
+    expect(a).toBe(b);
+  });
+
+  it("keeps distant locations on separate keys", () => {
+    const bcn = buildNearbyCacheKey(41.3851, 2.1734, 5000);
+    const girona = buildNearbyCacheKey(41.9794, 2.8214, 5000);
+    expect(bcn).not.toBe(girona);
+  });
+
+  it("does not depend on the event date — same coords/radius always yield the same key", () => {
+    expect(buildNearbyCacheKey(41.39, 2.17, 5000)).toBe(
+      "places:nearby:v1:41.39:2.17:r5000"
+    );
+  });
+
+  it("separates keys by radius", () => {
+    expect(buildNearbyCacheKey(41.39, 2.17, 5000)).not.toBe(
+      buildNearbyCacheKey(41.39, 2.17, 1000)
+    );
+  });
+
+  it("does NOT snap below the minimum radius, so a small search stays on the caller's point", () => {
+    const narrow = 500;
+    expect(narrow).toBeLessThan(SNAP_MIN_RADIUS_M);
+    expect(nearbySearchCenter(41.3851, 2.1734, narrow)).toEqual({
+      lat: 41.3851,
+      lng: 2.1734,
+    });
+    // exact coords preserved, so two nearby points must NOT collide
+    expect(buildNearbyCacheKey(41.3851, 2.1734, narrow)).not.toBe(
+      buildNearbyCacheKey(41.3879, 2.1699, narrow)
+    );
+  });
+
+  it("snaps at or above the minimum radius", () => {
+    expect(nearbySearchCenter(41.3851, 2.1734, SNAP_MIN_RADIUS_M)).toEqual({
+      lat: 41.39,
+      lng: 2.17,
+    });
+  });
+});


### PR DESCRIPTION
## Release: develop → main (production)

Headline: **ships the Places API cost fix to production.** Prod (www = main) currently runs the old uncached code; until this merges, prod is protected only by the deploy-independent controls (50/day GCP quota + Cloudflare WAF) and lacks the cache + fail-soft.

### What's included (6 commits since #364)

**Places API cost (the reason for this release):**
- `#376` fix(places): Redis cache by ~1.1km-snapped coords (deploy-independent, 12h TTL), radius-gated snapping, fail-soft on upstream errors → Google calls scale with distinct event areas, not traffic
- `#377` docs(places): cost-incident post-mortem, LESSONS.md (three-layer control + never-block-DE), stale-doc fixes

**Other changes already merged to develop:**
- `#374` fix(analytics): load GA + Auto Ads only on the production host
- `#373` docs(ci-migration): Gemini review feedback on #371
- `#372` fix(image-proxy): use undici's fetch with the undici dispatcher
- `#371` ci: build prod image in CI, deploy prebuilt to Coolify

### Deploy notes

- Merging to `main` triggers the Coolify production deploy (`deploy-coolify.yml`, `IS_PRODUCTION = ref == 'main'`) → www.esdeveniments.cat.
- Post-deploy, the first `/api/places/nearby` calls warm the Redis cache; cost should drop to a function of distinct event areas. The 50/day quota cap and Cloudflare rules remain in force.
- Verify after deploy: raw HTML has SSR `<title>` (the recurring Coolify-Redis check), and the restaurant widget renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys the Places API cost fix to production. Adds a deploy‑independent Redis cache keyed by ~1.1km‑snapped coordinates (12h TTL) with fail‑soft behavior so Google Places calls scale with distinct areas, not traffic.

- **New Features**
  - Cache `searchNearby` results in Redis (`lib/cache/redis-client.ts`) using snapped‑coord keys (`lib/places/nearby-cache-key.ts`), radius‑gated snapping, 5s request timeout, and always request 20 results; fail soft on any upstream error.
  - Gate Google Analytics and Auto Ads to the production host only.
  - Fix image proxy by using `undici`’s `fetch` with the same dispatcher to avoid compressed‑response errors.
  - Build Docker images in CI and push to GHCR; Coolify deploys the prebuilt image (`.github/workflows/deploy-coolify.yml`).
  - Hide the restaurant widget on errors (no user‑visible error box).
  - Add incident docs, CI migration guide, tests for cache keys, and update bundle baselines.

<sup>Written for commit 39c7efea2428a852705d77dea7253f40ece2cff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

