### PR TITLE
test(e2e): de-flake favorites + sponsor deploy-gate tests

### DIFF
--- a/e2e/favorites.flow.spec.ts
+++ b/e2e/favorites.flow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { waitForFavoritesReady } from "./helpers/events";
+import { waitForFavoritesReady, waitForFavoriteWrite } from "./helpers/events";
 
 function decodeCookieValue(raw: string): string {
   try {
@@ -92,7 +92,12 @@ test.describe("Favorites flow", () => {
     // Ensure the button has hydrated and SWR has settled before toggling, so
     // the click isn't dropped and a late GET can't reset the optimistic state.
     await favoritesReady;
+    // Await the mutation write too: a second SWR revalidation GET can still
+    // resolve after the click and reset the optimistic state before the POST
+    // makes it authoritative. Assert aria-pressed only once the write settles.
+    const favoriteWrite = waitForFavoriteWrite(page);
     await favButton.click();
+    await favoriteWrite;
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     await expect
@@ -166,7 +171,9 @@ test.describe("Favorites flow", () => {
     // Ensure hydration + SWR settle before toggling (see the add-favorite test).
     await favoritesReady;
     // Toggle ON
+    const favoriteWriteOn = waitForFavoriteWrite(page);
     await favButton.click();
+    await favoriteWriteOn;
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     // In CI the server action can keep the button disabled briefly.
@@ -175,7 +182,9 @@ test.describe("Favorites flow", () => {
     });
 
     // Toggle OFF
+    const favoriteWriteOff = waitForFavoriteWrite(page);
     await favButton.click();
+    await favoriteWriteOff;
     await expect(favButton).toHaveAttribute("aria-pressed", "false");
 
     // Wait for the server action to finish; navigating too early can abort the request.

--- a/e2e/favorites.flow.spec.ts
+++ b/e2e/favorites.flow.spec.ts
@@ -97,7 +97,8 @@ test.describe("Favorites flow", () => {
     // makes it authoritative. Assert aria-pressed only once the write settles.
     const favoriteWrite = waitForFavoriteWrite(page);
     await favButton.click();
-    await favoriteWrite;
+    const response = await favoriteWrite;
+    expect(response?.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     await expect
@@ -173,7 +174,8 @@ test.describe("Favorites flow", () => {
     // Toggle ON
     const favoriteWriteOn = waitForFavoriteWrite(page);
     await favButton.click();
-    await favoriteWriteOn;
+    const responseOn = await favoriteWriteOn;
+    expect(responseOn?.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     // In CI the server action can keep the button disabled briefly.
@@ -184,7 +186,8 @@ test.describe("Favorites flow", () => {
     // Toggle OFF
     const favoriteWriteOff = waitForFavoriteWrite(page);
     await favButton.click();
-    await favoriteWriteOff;
+    const responseOff = await favoriteWriteOff;
+    expect(responseOff?.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "false");
 
     // Wait for the server action to finish; navigating too early can abort the request.

--- a/e2e/favorites.flow.spec.ts
+++ b/e2e/favorites.flow.spec.ts
@@ -98,7 +98,7 @@ test.describe("Favorites flow", () => {
     const favoriteWrite = waitForFavoriteWrite(page);
     await favButton.click();
     const response = await favoriteWrite;
-    expect(response?.ok()).toBe(true);
+    expect(response.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     await expect
@@ -175,7 +175,7 @@ test.describe("Favorites flow", () => {
     const favoriteWriteOn = waitForFavoriteWrite(page);
     await favButton.click();
     const responseOn = await favoriteWriteOn;
-    expect(responseOn?.ok()).toBe(true);
+    expect(responseOn.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     // In CI the server action can keep the button disabled briefly.
@@ -187,7 +187,7 @@ test.describe("Favorites flow", () => {
     const favoriteWriteOff = waitForFavoriteWrite(page);
     await favButton.click();
     const responseOff = await favoriteWriteOff;
-    expect(responseOff?.ok()).toBe(true);
+    expect(responseOff.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "false");
 
     // Wait for the server action to finish; navigating too early can abort the request.

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -76,14 +76,14 @@ export function waitForFavoritesReady(page: Page): Promise<unknown> {
  * server-authoritative list (the handler calls `mutateFavorites(..., { revalidate:
  * false })`), so no later GET can clobber it — assert `aria-pressed` after this.
  *
- * Set up as a promise *before* the click, then await it before asserting.
- * Tolerates a missing/timed-out write so it never hangs the test.
+ * Set up as a promise *before* the click, then await it before asserting. Unlike
+ * `waitForFavoritesReady` (a tolerant readiness hint), this is an assertion
+ * target: it intentionally does NOT swallow a timeout, so a missing write throws
+ * a descriptive Playwright timeout error instead of a cryptic downstream failure.
  */
 export function waitForFavoriteWrite(page: Page) {
-  return page
-    .waitForResponse((r) => {
-      const url = new URL(r.url());
-      return url.pathname === "/api/favorites" && r.request().method() === "POST";
-    }, { timeout: 30000 })
-    .catch(() => null);
+  return page.waitForResponse((r) => {
+    const url = new URL(r.url());
+    return url.pathname === "/api/favorites" && r.request().method() === "POST";
+  }, { timeout: 30000 });
 }

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -67,3 +67,24 @@ export function waitForFavoritesReady(page: Page): Promise<unknown> {
     )
     .catch(() => null);
 }
+
+/**
+ * Wait for the favorites mutation (`POST /api/favorites`) a toggle click fires.
+ * `waitForFavoritesReady` only awaits the *first* mount GET, but SWR can fire a
+ * later revalidation GET that resolves after the click and resets the optimistic
+ * `aria-pressed`. Once this POST resolves, the button reflects the
+ * server-authoritative list (the handler calls `mutateFavorites(..., { revalidate:
+ * false })`), so no later GET can clobber it — assert `aria-pressed` after this.
+ *
+ * Set up as a promise *before* the click, then await it before asserting.
+ * Tolerates a missing/timed-out write so it never hangs the test.
+ */
+export function waitForFavoriteWrite(page: Page): Promise<unknown> {
+  return page
+    .waitForResponse(
+      (r) =>
+        r.url().includes("/api/favorites") && r.request().method() === "POST",
+      { timeout: 30000 }
+    )
+    .catch(() => null);
+}

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -79,12 +79,11 @@ export function waitForFavoritesReady(page: Page): Promise<unknown> {
  * Set up as a promise *before* the click, then await it before asserting.
  * Tolerates a missing/timed-out write so it never hangs the test.
  */
-export function waitForFavoriteWrite(page: Page): Promise<unknown> {
+export function waitForFavoriteWrite(page: Page) {
   return page
-    .waitForResponse(
-      (r) =>
-        r.url().includes("/api/favorites") && r.request().method() === "POST",
-      { timeout: 30000 }
-    )
+    .waitForResponse((r) => {
+      const url = new URL(r.url());
+      return url.pathname === "/api/favorites" && r.request().method() === "POST";
+    }, { timeout: 30000 })
     .catch(() => null);
 }

--- a/e2e/sponsor-patrocina.spec.ts
+++ b/e2e/sponsor-patrocina.spec.ts
@@ -97,8 +97,12 @@ test.describe("Sponsor Landing Page (/patrocina)", () => {
 
     await backLink.click();
 
-    // Should navigate to home
-    await expect(page).toHaveURL("/");
+    // Should navigate to home. Allow a generous timeout: on a cold prod build
+    // the "/" navigation (and the default-locale 308 if the link is locale-
+    // prefixed) can take longer than the default expect timeout to commit.
+    await expect(page).toHaveURL("/", {
+      timeout: process.env.CI ? 30000 : 10000,
+    });
   });
 });
 


### PR DESCRIPTION
## Why

The production deploy gate (`deploy-coolify.yml` → "Build & E2E tests") fails on two tests — `favorites.flow.spec.ts` and `sponsor-patrocina.spec.ts` — that **pass in PR CI**. This blocked a release and forced a `skip_e2e` deploy.

Root cause is environmental, not a regression: PR CI runs E2E against the **Vercel Preview**, while the deploy job runs against a **freshly-built localhost prod server** — the slowest, coldest env. Verified the failing flows have no synchronous analytics dependency, so #374 (analytics host-gating) is not involved and real prod users are unaffected.

## Fixes (both only *add waits* — they cannot make a passing test fail)

**favorites toggle** — #369 added `waitForFavoritesReady`, but that awaits only the *first* mount `GET /api/favorites`. A second SWR revalidation GET can resolve **after** the click and reset the optimistic `aria-pressed` back to false before the write lands. Added `waitForFavoriteWrite` to await the `POST /api/favorites` the toggle fires; the handler then calls `mutateFavorites(..., { revalidate: false })`, making state authoritative so no later GET clobbers it. Assert `aria-pressed` only after the write settles (3 toggle sites).

**sponsor "back to home"** — `toHaveURL("/")` had no explicit timeout. On a cold build the `/` navigation (plus the default-locale 308 if the link is locale-prefixed) can exceed the default expect timeout. Gave it `process.env.CI ? 30000 : 10000`.

## Honest caveat

These target the **diagnosed** cold-build timing races, but I can't reproduce that environment locally (it's the localhost-prod-build path, not PR CI / Vercel). So I can't prove the flake is gone from here — only that the fixes are sound in mechanism and strictly safer. The real confirmation is a green deploy run; `skip_e2e` stays available until then.

## Separate follow-up (not in this PR)

The deploy E2E build doesn't set `NEXT_PUBLIC_E2E_TEST_MODE=1` at *build* time, so the client bundle bakes E2E-mode `false` while the server runtime sees `true`. Harmless today (GA id also unset), but a real parity gap worth closing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflaked the favorites and sponsor E2E tests in the deploy gate by adding targeted waits and strict response checks for cold localhost prod builds. This stabilizes the "Build & E2E tests" step and unblocks deploys.

- **Bug Fixes**
  - Favorites: Added `waitForFavoriteWrite(page)`, set it up before the click, await it, and assert the `POST /api/favorites` `Response.ok()`. Match the URL by exact `pathname`, and do not swallow timeouts so a missing write throws a clear Playwright error. Prevents a late SWR revalidation GET from resetting optimistic state.
  - Sponsor: Increased `toHaveURL("/")` timeout to `process.env.CI ? 30000 : 10000` to handle cold navigation and a possible 308 redirect.

<sup>Written for commit f46ee21ea2d48aa9c147b1e4ce10aa836bb98267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end favorite/unfavorite flows by waiting for the server-side update before asserting the favorites toggle state and verifying persistence after reloads.
  * Improved the sponsor page “back to home” end-to-end assertion by using a CI-aware navigation timeout to reduce flaky failures on slower or locale/redirect-heavy environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->