### PR TITLE
fix(docker): install curl so the Coolify healthcheck can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-slim AS base
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
+  curl \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 


### PR DESCRIPTION
## Why

Staging deploys have failed across the last 3 attempts (stuck on an old commit). The Coolify deploy log shows the new container starts fine (`✓ Ready in 0ms`) but the **healthcheck** fails:

```
Healthcheck: /bin/sh: 1: curl: not found / wget: not found
New container is unhealthy. → Removing old containers
```

Coolify's per-app healthcheck (`health_check_path: /api/health`) shells out to curl/wget, but the `node:22-slim` runtime image ships neither (base only installs ca-certificates). So a perfectly healthy container is deemed unhealthy and the swap is refused. Prod escaped this only because its healthcheck is disabled — which is also why it's been crash-restarting unnoticed.

## Fix

Add `curl` to the base stage. One line, ~3MB. Satisfies Coolify's curl healthcheck for staging, the new GH-image app, and lets prod re-enable its healthcheck.

**Self-applies:** the new container is built *with* curl, so the healthcheck inside it passes and the swap completes on this deploy.

Note: the image already has a correct curl-free node `HEALTHCHECK` (line ~85); Coolify's config-level check overrides it. Adding curl is the portable fix that works regardless of Coolify's per-app config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `curl` in the `node:22-slim` base image so Coolify’s `/api/health` healthcheck runs successfully and container swaps complete. This unblocks staging deploys and lets production safely re-enable its healthcheck.

<sup>Written for commit f403bc0ee6bd0f5bfe6aeb34b9c0608064fc9881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container environment to include an additional command-line networking utility, improving support for network-related tasks during runtime and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->