### PR TITLE
release: deploy to production (2026-06-27) — de-flake + docker curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-slim AS base
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
+  curl \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 

--- a/e2e/favorites.flow.spec.ts
+++ b/e2e/favorites.flow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { waitForFavoritesReady } from "./helpers/events";
+import { waitForFavoritesReady, waitForFavoriteWrite } from "./helpers/events";
 
 function decodeCookieValue(raw: string): string {
   try {
@@ -92,7 +92,13 @@ test.describe("Favorites flow", () => {
     // Ensure the button has hydrated and SWR has settled before toggling, so
     // the click isn't dropped and a late GET can't reset the optimistic state.
     await favoritesReady;
+    // Await the mutation write too: a second SWR revalidation GET can still
+    // resolve after the click and reset the optimistic state before the POST
+    // makes it authoritative. Assert aria-pressed only once the write settles.
+    const favoriteWrite = waitForFavoriteWrite(page);
     await favButton.click();
+    const response = await favoriteWrite;
+    expect(response.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     await expect
@@ -166,7 +172,10 @@ test.describe("Favorites flow", () => {
     // Ensure hydration + SWR settle before toggling (see the add-favorite test).
     await favoritesReady;
     // Toggle ON
+    const favoriteWriteOn = waitForFavoriteWrite(page);
     await favButton.click();
+    const responseOn = await favoriteWriteOn;
+    expect(responseOn.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     // In CI the server action can keep the button disabled briefly.
@@ -175,7 +184,10 @@ test.describe("Favorites flow", () => {
     });
 
     // Toggle OFF
+    const favoriteWriteOff = waitForFavoriteWrite(page);
     await favButton.click();
+    const responseOff = await favoriteWriteOff;
+    expect(responseOff.ok()).toBe(true);
     await expect(favButton).toHaveAttribute("aria-pressed", "false");
 
     // Wait for the server action to finish; navigating too early can abort the request.

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -67,3 +67,23 @@ export function waitForFavoritesReady(page: Page): Promise<unknown> {
     )
     .catch(() => null);
 }
+
+/**
+ * Wait for the favorites mutation (`POST /api/favorites`) a toggle click fires.
+ * `waitForFavoritesReady` only awaits the *first* mount GET, but SWR can fire a
+ * later revalidation GET that resolves after the click and resets the optimistic
+ * `aria-pressed`. Once this POST resolves, the button reflects the
+ * server-authoritative list (the handler calls `mutateFavorites(..., { revalidate:
+ * false })`), so no later GET can clobber it — assert `aria-pressed` after this.
+ *
+ * Set up as a promise *before* the click, then await it before asserting. Unlike
+ * `waitForFavoritesReady` (a tolerant readiness hint), this is an assertion
+ * target: it intentionally does NOT swallow a timeout, so a missing write throws
+ * a descriptive Playwright timeout error instead of a cryptic downstream failure.
+ */
+export function waitForFavoriteWrite(page: Page) {
+  return page.waitForResponse((r) => {
+    const url = new URL(r.url());
+    return url.pathname === "/api/favorites" && r.request().method() === "POST";
+  }, { timeout: 30000 });
+}

--- a/e2e/sponsor-patrocina.spec.ts
+++ b/e2e/sponsor-patrocina.spec.ts
@@ -97,8 +97,12 @@ test.describe("Sponsor Landing Page (/patrocina)", () => {
 
     await backLink.click();
 
-    // Should navigate to home
-    await expect(page).toHaveURL("/");
+    // Should navigate to home. Allow a generous timeout: on a cold prod build
+    // the "/" navigation (and the default-locale 308 if the link is locale-
+    // prefixed) can take longer than the default expect timeout to commit.
+    await expect(page).toHaveURL("/", {
+      timeout: process.env.CI ? 30000 : 10000,
+    });
   });
 });
 


### PR DESCRIPTION
## Release: develop → main (production)

Small, low-risk release — **no runtime app-code changes**. Carries only:

- **#379** test(e2e): de-flake favorites + sponsor deploy-gate tests (test files only)
- **#380** fix(docker): install `curl` so the Coolify healthcheck can run (Dockerfile)

### Why now
- The **main deploy's E2E gate is the only place the de-flake is validated** — staging is already healthy on this exact code, so it should pass. If it fails, the deploy blocks and prod is untouched (the prod container is functionally identical to what's live now).
- `curl` lands on prod so its (currently disabled) healthcheck can be safely re-enabled later.

### Deploy notes
- Prod's domain redirect stays "www" (correct — its domain is www.esdeveniments.cat). Do **not** copy staging's non-www setting.
- Prod still builds on-host; if the workflow's 900s wait false-times-out, verify prod `buildVersion` directly (Coolify may finish the swap after the workflow gives up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the deploy E2E gate and fixes the container healthcheck for production. No runtime app-code changes.

- **Bug Fixes**
  - Docker: install `curl` so the Coolify healthcheck passes and container swaps can proceed.
  - E2E: deflake favorites by awaiting `POST /api/favorites` with `waitForFavoriteWrite` and asserting `response.ok()` before `aria-pressed`; increase `toHaveURL("/")` timeout (longer in CI).

<sup>Written for commit 510bdb9b782ea0d5b9d8cfc6cc1a6a9ccb2b3f94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

