### PR TITLE
fix(proxy): allow localhost origin under E2E_TEST_MODE so deploy-gate POSTs pass

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ import {
 } from "@utils/hmac";
 import { handleCanonicalRedirects } from "@utils/middleware-redirects";
 import { isProductionHost } from "@utils/production-host";
+import { isE2ETestMode } from "@utils/env";
 import {
   DEFAULT_LOCALE,
   LOCALE_COOKIE,
@@ -197,7 +198,11 @@ function getAllowedOriginHosts(): Set<string> {
     addAllowedOriginHost(hosts, vercelBranchUrl);
   }
 
-  if (isDev) {
+  // E2E runs a production build on localhost:3000, so isDev is false there and
+  // the same-origin localhost POST would be rejected. E2E_TEST_MODE is set only
+  // during E2E runs (never in prod), so this widens the allowlist for tests
+  // without touching the production Origin check.
+  if (isDev || isE2ETestMode) {
     hosts.add("localhost:3000");
     hosts.add("127.0.0.1:3000");
     hosts.add("[::1]:3000");

--- a/test/proxy-origin-allowed.test.ts
+++ b/test/proxy-origin-allowed.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+/**
+ * Regression test for the deploy-gate 403: the E2E server runs on
+ * localhost:3000 under NODE_ENV=production, so `isDev` is false and the Origin
+ * allowlist only contains the site host — same-origin localhost POSTs (favorites,
+ * sponsor) were 403'd. The fix allows localhost origins when E2E_TEST_MODE is on
+ * (never set in prod), without widening production's Origin check.
+ *
+ * `isDev` / `isE2ETestMode` are module-level consts read at import, so each case
+ * resets modules and stubs env BEFORE importing proxy.
+ */
+const SITE = "https://www.esdeveniments.cat";
+
+function reqWithOrigin(origin: string | null): NextRequest {
+  return {
+    headers: { get: (k: string) => (k.toLowerCase() === "origin" ? origin : null) },
+  } as unknown as NextRequest;
+}
+
+async function importIsOriginAllowed(env: Record<string, string>) {
+  vi.resetModules();
+  vi.stubEnv("NODE_ENV", env.NODE_ENV ?? "production");
+  vi.stubEnv("NEXT_PUBLIC_SITE_URL", env.NEXT_PUBLIC_SITE_URL ?? SITE);
+  vi.stubEnv("E2E_TEST_MODE", env.E2E_TEST_MODE ?? "");
+  vi.stubEnv("NEXT_PUBLIC_E2E_TEST_MODE", env.NEXT_PUBLIC_E2E_TEST_MODE ?? "");
+  const mod = await import("../proxy");
+  return mod.isOriginAllowed;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("isOriginAllowed — localhost in the E2E deploy env", () => {
+  it("production + E2E_TEST_MODE: allows the localhost same-origin POST (the fix)", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({ E2E_TEST_MODE: "1" });
+    expect(isOriginAllowed(reqWithOrigin("http://localhost:3000"))).toBe(true);
+  });
+
+  it("production WITHOUT E2E mode: still rejects localhost (production Origin check unchanged)", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({});
+    expect(isOriginAllowed(reqWithOrigin("http://localhost:3000"))).toBe(false);
+  });
+
+  it("production + E2E_TEST_MODE: still rejects a cross-origin attacker", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({ E2E_TEST_MODE: "1" });
+    expect(isOriginAllowed(reqWithOrigin("https://evil.example.com"))).toBe(false);
+  });
+
+  it("production: always allows the real site origin", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({});
+    expect(isOriginAllowed(reqWithOrigin(SITE))).toBe(true);
+  });
+
+  it("rejects a missing Origin header", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({ E2E_TEST_MODE: "1" });
+    expect(isOriginAllowed(reqWithOrigin(null))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause (not a flake)

The deploy E2E gate runs a **production build on localhost:3000**. With `NODE_ENV=production`, `isDev` is false, so `getAllowedOriginHosts()` only allowed the site host (`NEXT_PUBLIC_SITE_URL` = www). The favorites/sponsor **same-origin POSTs from localhost** were therefore `403`'d by `isOriginAllowed` → `response.ok()` false → the specs failed. This is why they failed on every main deploy — it was never the timing issue the earlier de-flake assumed.

Confirmed via staging repro: `POST /api/favorites` with a matching `Origin` → `200`; without → `403`.

## Fix

Allow localhost origins when `isE2ETestMode` (`E2E_TEST_MODE=1`) — which is set only during E2E runs and **never in prod**, so the production Origin check is unchanged.

Grounding (not assumed): `proxy.ts` already reads non-public runtime env (`HMAC_SECRET`), and `isE2ETestMode` is consumed server-side in `lib/api/events.ts` and works in the E2E env — so it genuinely evaluates true server-side there.

## Verification

`test/proxy-origin-allowed.test.ts` — written failing-first: it **fails on the old code** for the production+E2E localhost case and passes with the fix. Also asserts cross-origin and missing-Origin are still rejected and the real site origin is still allowed (production check intact).

**The live proof is the next main deploy's E2E gate passing** — this PR only verifies the proxy logic. I'm not claiming the gate is green until I watch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix proxy origin allowlist so E2E deploy gate POSTs from localhost stop 403-ing. Allows same-origin POSTs for the E2E prod build on localhost without changing production behavior.

- **Bug Fixes**
  - Allow localhost origins when `E2E_TEST_MODE=1` in `getAllowedOriginHosts()`.
  - Added regression test to verify localhost is allowed in E2E and production checks remain strict (cross-origin and missing Origin still rejected).

<sup>Written for commit 54673aa97ca9517a34f711fa617d12c5808cdc0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

