### PR TITLE
release: deploy to production (2026-06-27) — E2E origin fix

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ import {
 } from "@utils/hmac";
 import { handleCanonicalRedirects } from "@utils/middleware-redirects";
 import { isProductionHost } from "@utils/production-host";
+import { isE2ETestMode } from "@utils/env";
 import {
   DEFAULT_LOCALE,
   LOCALE_COOKIE,
@@ -197,7 +198,11 @@ function getAllowedOriginHosts(): Set<string> {
     addAllowedOriginHost(hosts, vercelBranchUrl);
   }
 
-  if (isDev) {
+  // E2E runs a production build on localhost:3000, so isDev is false there and
+  // the same-origin localhost POST would be rejected. E2E_TEST_MODE is set only
+  // during E2E runs (never in prod), so this widens the allowlist for tests
+  // without touching the production Origin check.
+  if (isDev || isE2ETestMode) {
     hosts.add("localhost:3000");
     hosts.add("127.0.0.1:3000");
     hosts.add("[::1]:3000");

--- a/test/proxy-origin-allowed.test.ts
+++ b/test/proxy-origin-allowed.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+/**
+ * Regression test for the deploy-gate 403: the E2E server runs on
+ * localhost:3000 under NODE_ENV=production, so `isDev` is false and the Origin
+ * allowlist only contains the site host — same-origin localhost POSTs (favorites,
+ * sponsor) were 403'd. The fix allows localhost origins when E2E_TEST_MODE is on
+ * (never set in prod), without widening production's Origin check.
+ *
+ * `isDev` / `isE2ETestMode` are module-level consts read at import, so each case
+ * resets modules and stubs env BEFORE importing proxy.
+ */
+const SITE = "https://www.esdeveniments.cat";
+
+function reqWithOrigin(origin: string | null): NextRequest {
+  return {
+    headers: { get: (k: string) => (k.toLowerCase() === "origin" ? origin : null) },
+  } as unknown as NextRequest;
+}
+
+async function importIsOriginAllowed(env: Record<string, string>) {
+  vi.resetModules();
+  vi.stubEnv("NODE_ENV", env.NODE_ENV ?? "production");
+  vi.stubEnv("NEXT_PUBLIC_SITE_URL", env.NEXT_PUBLIC_SITE_URL ?? SITE);
+  vi.stubEnv("E2E_TEST_MODE", env.E2E_TEST_MODE ?? "");
+  vi.stubEnv("NEXT_PUBLIC_E2E_TEST_MODE", env.NEXT_PUBLIC_E2E_TEST_MODE ?? "");
+  const mod = await import("../proxy");
+  return mod.isOriginAllowed;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("isOriginAllowed — localhost in the E2E deploy env", () => {
+  it("production + E2E_TEST_MODE: allows the localhost same-origin POST (the fix)", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({ E2E_TEST_MODE: "1" });
+    expect(isOriginAllowed(reqWithOrigin("http://localhost:3000"))).toBe(true);
+  });
+
+  it("production WITHOUT E2E mode: still rejects localhost (production Origin check unchanged)", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({});
+    expect(isOriginAllowed(reqWithOrigin("http://localhost:3000"))).toBe(false);
+  });
+
+  it("production + E2E_TEST_MODE: still rejects a cross-origin attacker", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({ E2E_TEST_MODE: "1" });
+    expect(isOriginAllowed(reqWithOrigin("https://evil.example.com"))).toBe(false);
+  });
+
+  it("production: always allows the real site origin", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({});
+    expect(isOriginAllowed(reqWithOrigin(SITE))).toBe(true);
+  });
+
+  it("rejects a missing Origin header", async () => {
+    const isOriginAllowed = await importIsOriginAllowed({ E2E_TEST_MODE: "1" });
+    expect(isOriginAllowed(reqWithOrigin(null))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Release: develop → main (production)

Carries the E2E deploy-gate fix so the favorites/sponsor specs finally pass on the main gate:

- **#383** fix(proxy): allow localhost origin under `E2E_TEST_MODE` (the 403 root cause; production Origin check unchanged, verified by a failing-first test)

Builds on the already-merged **#379** (favorites timing wait + `ok()` assertion) and **#380** (curl for the healthcheck).

This is the run that actually validates the de-flake — the **Build & E2E tests** gate runs the favorites/sponsor POSTs from the now-allowed localhost origin. No runtime app-code change; prod container behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deploy-gate 403s by allowing localhost origins during E2E runs so favorites/sponsor POSTs pass. Production Origin checks stay the same; no prod runtime behavior changes.

- Bug Fixes
  - When `E2E_TEST_MODE` is set, add `localhost:3000`, `127.0.0.1:3000`, and `[::1]:3000` to the proxy Origin allowlist (E2E uses a prod build on localhost).
  - Added tests to verify: localhost allowed only in E2E mode, real site origin always allowed, cross-origin and missing Origin rejected.

<sup>Written for commit acaae288f1e91e29faafbc737dd9a4dcab2657d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

