### PR TITLE
feat: profile pages on real /api/users endpoints + favourites backend proxy

### DIFF
--- a/app/api/users/[username]/events/route.ts
+++ b/app/api/users/[username]/events/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { fetchUserEventsExternal } from "@lib/api/events-external";
+import { handleApiError } from "@utils/api-error-handler";
+
+// GET /api/users/[username]/events - proxy to the public per-user events
+// listing with server-side HMAC signing. Only page & size are supported.
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ username: string }> },
+) {
+  try {
+    const { username } = await context.params;
+    const search = new URL(request.url).searchParams;
+
+    let page = 0;
+    let size = 12;
+    const rawPage = search.get("page");
+    const rawSize = search.get("size");
+    if (rawPage !== null) {
+      const n = parseInt(rawPage, 10);
+      if (Number.isFinite(n)) page = Math.max(0, n);
+    }
+    if (rawSize !== null) {
+      const n = parseInt(rawSize, 10);
+      if (Number.isFinite(n)) size = Math.min(50, Math.max(1, n));
+    }
+
+    const data = await fetchUserEventsExternal(username, page, size);
+    return NextResponse.json(data, {
+      status: 200,
+      headers: {
+        "Cache-Control": "public, s-maxage=1800, stale-while-revalidate=3600",
+      },
+    });
+  } catch (e) {
+    return handleApiError(e, "/api/users/[username]/events", {
+      fallbackData: {
+        content: [],
+        currentPage: 0,
+        pageSize: 12,
+        totalElements: 0,
+        totalPages: 0,
+        last: true,
+      },
+    });
+  }
+}

--- a/app/api/users/me/favorites/events/[eventId]/route.ts
+++ b/app/api/users/me/favorites/events/[eventId]/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import {
+  getFavoriteStatusExternal,
+  setFavoriteExternal,
+} from "@lib/api/favorites-external";
+import { handleApiError } from "@utils/api-error-handler";
+
+function getToken(request: Request): string | undefined {
+  return request.headers.get("Authorization")?.replace(/^Bearer\s+/i, "");
+}
+
+const unauthorized = () =>
+  NextResponse.json({ error: "Authorization token required" }, { status: 401 });
+
+// GET - whether the signed-in user has favourited this event.
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ eventId: string }> },
+) {
+  try {
+    const token = getToken(request);
+    if (!token) return unauthorized();
+    const { eventId } = await context.params;
+    const favorite = await getFavoriteStatusExternal(token, eventId);
+    return NextResponse.json(
+      { favorite },
+      { status: 200, headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (e) {
+    return handleApiError(e, "/api/users/me/favorites/events/[eventId]", {
+      fallbackData: { favorite: false },
+    });
+  }
+}
+
+// POST - add this event to favourites.
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ eventId: string }> },
+) {
+  try {
+    const token = getToken(request);
+    if (!token) return unauthorized();
+    const { eventId } = await context.params;
+    const ok = await setFavoriteExternal(token, eventId, true);
+    if (!ok) {
+      return NextResponse.json({ error: "favorite-failed" }, { status: 502 });
+    }
+    return NextResponse.json({ favorite: true }, { status: 200 });
+  } catch (e) {
+    return handleApiError(e, "/api/users/me/favorites/events/[eventId]");
+  }
+}
+
+// DELETE - remove this event from favourites.
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ eventId: string }> },
+) {
+  try {
+    const token = getToken(request);
+    if (!token) return unauthorized();
+    const { eventId } = await context.params;
+    const ok = await setFavoriteExternal(token, eventId, false);
+    if (!ok) {
+      return NextResponse.json({ error: "favorite-failed" }, { status: 502 });
+    }
+    return NextResponse.json({ favorite: false }, { status: 200 });
+  } catch (e) {
+    return handleApiError(e, "/api/users/me/favorites/events/[eventId]");
+  }
+}

--- a/app/api/users/me/favorites/events/route.ts
+++ b/app/api/users/me/favorites/events/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { fetchFavoriteEventsExternal } from "@lib/api/favorites-external";
+import { handleApiError } from "@utils/api-error-handler";
+
+// GET /api/users/me/favorites/events - the signed-in user's favourite events.
+// Reads the Bearer token from the request and forwards it to the backend.
+export async function GET(request: Request) {
+  try {
+    const token = request.headers
+      .get("Authorization")
+      ?.replace(/^Bearer\s+/i, "");
+    if (!token) {
+      return NextResponse.json(
+        { error: "Authorization token required" },
+        { status: 401 },
+      );
+    }
+
+    const search = new URL(request.url).searchParams;
+    let page = 0;
+    let size = 12;
+    const rawPage = search.get("page");
+    const rawSize = search.get("size");
+    if (rawPage !== null) {
+      const n = parseInt(rawPage, 10);
+      if (Number.isFinite(n)) page = Math.max(0, n);
+    }
+    if (rawSize !== null) {
+      const n = parseInt(rawSize, 10);
+      if (Number.isFinite(n)) size = Math.min(50, Math.max(1, n));
+    }
+
+    const data = await fetchFavoriteEventsExternal(token, page, size);
+    return NextResponse.json(data, {
+      status: 200,
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (e) {
+    return handleApiError(e, "/api/users/me/favorites/events", {
+      fallbackData: {
+        content: [],
+        currentPage: 0,
+        pageSize: 12,
+        totalElements: 0,
+        totalPages: 0,
+        last: true,
+      },
+    });
+  }
+}

--- a/app/perfil/[slug]/page.tsx
+++ b/app/perfil/[slug]/page.tsx
@@ -1,14 +1,13 @@
 import { Suspense, use } from "react";
 import { notFound } from "next/navigation";
 import { fetchProfileBySlug } from "@lib/api/profiles";
-import { fetchEvents, insertAds } from "@lib/api/events";
+import { fetchUserEvents, insertAds } from "@lib/api/events";
 import { buildPageMeta } from "@components/partials/seo-meta";
 import ProfilePageShell from "@components/partials/ProfilePageShell";
 import { getTranslations } from "next-intl/server";
 import { getLocaleSafely, toLocalizedUrl } from "@utils/i18n-seo";
 import { siteUrl } from "@config/index";
 import type { PageData } from "types/common";
-import type { FetchEventsParams } from "types/event";
 
 // No generateStaticParams — profile slugs are user-generated with infinite
 // cardinality. Pages render on first request and are cached automatically.
@@ -72,17 +71,18 @@ async function ProfilePageGate({ slug }: { slug: string }) {
     notFound();
   }
 
-  const fetchParams: FetchEventsParams = {
-    page: 0,
-    size: 10,
-    profileSlug: slug,
-  };
-
-  const eventsResponse = await fetchEvents(fetchParams);
+  const eventsResponse = await fetchUserEvents(slug, 0, 10);
   const events = eventsResponse.content;
   const noEventsFound = events.length === 0;
   const serverHasMore = !eventsResponse.last;
   const eventsWithAds = insertAds(events);
+
+  // Backend doesn't return totalEvents on the user DTO yet — derive it from
+  // the events listing so the header count is correct today.
+  const profileWithCount = {
+    ...profile,
+    totalEvents: eventsResponse.totalElements,
+  };
 
   const pageData: PageData = {
     title: t("title", { name: profile.name }),
@@ -96,7 +96,7 @@ async function ProfilePageGate({ slug }: { slug: string }) {
 
   return (
     <ProfilePageShell
-      profile={profile}
+      profile={profileWithCount}
       initialEvents={eventsWithAds}
       noEventsFound={noEventsFound}
       serverHasMore={serverHasMore}

--- a/components/hooks/useEvents.ts
+++ b/components/hooks/useEvents.ts
@@ -13,13 +13,17 @@ import {
 } from "types/event";
 import { captureException } from "@sentry/nextjs";
 
-// SWR fetcher function for events API (single page) via internal proxy
+// SWR fetcher function for events API (single page) via internal proxy.
+// A profile page fetches a user's events from the dedicated per-user endpoint
+// (which only takes page & size); everything else uses the filtered list.
 const pageFetcher = async (
   params: FetchEventsParams,
 ): Promise<PagedResponseDTO<EventSummaryResponseDTO>> => {
-  const qs = buildEventsQuery(params);
+  const url = params.profileSlug
+    ? `/api/users/${encodeURIComponent(params.profileSlug)}/events?page=${params.page ?? 0}&size=${params.size ?? 12}`
+    : `/api/events?${buildEventsQuery(params).toString()}`;
 
-  const res = await fetch(`/api/events?${qs.toString()}`);
+  const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch events: ${res.status}`);
   }

--- a/docs/api-spec-profiles.md
+++ b/docs/api-spec-profiles.md
@@ -1,51 +1,55 @@
-# Profile API Spec (Backend)
+# Public User Profile API
 
-## Endpoints
+The public "profile" page (`/perfil/{slug}`) is backed by the backend's public
+**user** endpoints. An earlier draft of this doc proposed a richer `/api/v1/profiles/*`
+surface; the backend implemented a leaner user model instead. This documents what
+actually ships plus the gap the frontend is already prepared for.
 
-| Endpoint | Method | Params | Response |
-|---|---|---|---|
-| `/api/v1/profiles/{slug}` | GET | — | `ProfileDetailResponseDTO` |
-| `/api/v1/profiles` | GET | `?page&size` | `PagedResponseDTO<ProfileSummaryResponseDTO>` |
-| `/api/v1/events?profile={slug}` | GET | existing filters + `profile` | `PagedResponseDTO<EventSummaryResponseDTO>` |
+## Live endpoints
+
+| Endpoint | Method | Params | Auth | Response |
+|---|---|---|---|---|
+| `/api/users/{username}` | GET | — | public (HMAC) | `UserPublicResponseDTO` |
+| `/api/users/{username}/events` | GET | `page`, `size` | public (HMAC) | `PagedResponseDTO<EventSummaryResponseDTO>` |
+| `/api/users/me/favorites/events` | GET | `page`, `size` | Bearer | `PagedResponseDTO<EventSummaryResponseDTO>` |
+| `/api/users/me/favorites/events/{eventId}` | GET | — | Bearer | `FavoriteStatusResponseDTO` |
+| `/api/users/me/favorites/events/{eventId}` | POST / DELETE | — | Bearer | — |
+
+`GET /api/events` has **no** `profile`/`username` filter — per-user event listings
+must use `/api/users/{username}/events`.
 
 ## DTOs
 
-### ProfileSummaryResponseDTO
+### UserPublicResponseDTO
 
 ```json
 {
   "id": "uuid",
-  "slug": "razzmatazz",
-  "name": "Razzmatazz",
-  "avatarUrl": "https://...",
-  "coverUrl": "https://...",
-  "bio": "One of Barcelona's most iconic venues...",
-  "website": "https://www.salarazzmatazz.com",
-  "verified": true,
-  "joinedDate": "2024-01-15",
-  "totalEvents": 142,
-  "city": "Barcelona",
-  "region": "Barcelonès"
+  "name": "Sala Apolo",
+  "username": "sala-apolo",
+  "pictureUrl": "https://...",
+  "createdAt": "2024-03-01T00:00:00Z"
 }
 ```
 
-### ProfileDetailResponseDTO
+`username` maps to the FE `slug`, `pictureUrl` to `avatarUrl`, `createdAt` to
+`joinedDate`. See `mapUserToProfile` in `lib/api/profiles-external.ts`.
 
-Extends `ProfileSummaryResponseDTO` with:
+### FavoriteStatusResponseDTO
 
 ```json
-{
-  "socialLinks": {
-    "instagram": "https://instagram.com/razzmatazz",
-    "twitter": "https://twitter.com/razzmatazz"
-  }
-}
+{ "favorite": true }
 ```
 
-## Backend work needed
+## Backend gap (needed for the rich profile UI)
 
-- New `Profile` entity (id, name, slug, bio, avatarUrl, coverUrl, website, verified, city_id FK, created_at)
-- Flyway migration V12 — create `profile` table + add nullable `profile_id` FK to `event` table
-- `ProfileRepository`, `ProfileService`, `ProfileController`
-- Add `profile` filter to `EventFilterDTO` + `EventSpecification.filterByProfile()`
-- `ProfileSummaryResponseDTO`, `ProfileDetailResponseDTO` Java DTOs
+The profile header renders these conditionally and hides them when absent, so the
+page works today. Add them to `UserPublicResponseDTO` and they light up with no FE
+change:
+
+- `bio`, `coverUrl`, `website`
+- `verified` (boolean)
+- `socialLinks` (`{ instagram, twitter, ... }`)
+- `city`, `region`
+- `totalEvents` (the FE currently derives this from the events listing's
+  `totalElements`)

--- a/lib/api/events-external.ts
+++ b/lib/api/events-external.ts
@@ -65,6 +65,39 @@ export async function fetchEventsExternal(
   }
 }
 
+// Public listing of a user's events: GET /api/users/{username}/events.
+// Same paged shape as /events, but the backend endpoint only accepts
+// page & size (no place/category/date filters).
+export async function fetchUserEventsExternal(
+  username: string,
+  page = 0,
+  size = 12,
+): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
+  const api = getApiUrl();
+  const empty: PagedResponseDTO<EventSummaryResponseDTO> = {
+    content: [],
+    currentPage: page,
+    pageSize: size,
+    totalElements: 0,
+    totalPages: 0,
+    last: true,
+  };
+  try {
+    const qs = new URLSearchParams({ page: String(page), size: String(size) });
+    const res = await fetchWithHmac(
+      `${api}/users/${encodeURIComponent(username)}/events?${qs.toString()}`,
+    );
+    if (!res.ok) {
+      console.error(`fetchUserEventsExternal: HTTP ${res.status}`);
+      return empty;
+    }
+    return (await res.json()) as PagedResponseDTO<EventSummaryResponseDTO>;
+  } catch (error) {
+    console.error("fetchUserEventsExternal: failed", error);
+    return empty;
+  }
+}
+
 export async function fetchCategorizedEventsExternal(
   maxEventsPerCategory?: number,
 ): Promise<CategorizedEvents> {

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -18,6 +18,7 @@ import {
 import {
   fetchCategorizedEventsExternal,
   fetchEventsExternal,
+  fetchUserEventsExternal,
 } from "./events-external";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 import {
@@ -160,6 +161,41 @@ async function fetchEventsInternal(
 }
 
 export const fetchEvents = cache(fetchEventsInternal);
+
+async function fetchUserEventsInternal(
+  username: string,
+  page = 0,
+  size = 12,
+): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
+  const fallback: PagedResponseDTO<EventSummaryResponseDTO> = {
+    content: [],
+    currentPage: page,
+    pageSize: size,
+    totalElements: 0,
+    totalPages: 0,
+    last: true,
+  };
+
+  try {
+    const validated = parsePagedEvents(
+      await fetchUserEventsExternal(username, page, size),
+    );
+    if (!validated) {
+      console.error("fetchUserEvents: validation failed");
+      return fallback;
+    }
+    return validated;
+  } catch (error) {
+    console.error("fetchUserEvents: failed", error);
+    captureException(error, {
+      tags: { section: "user-events-fetch" },
+      extra: { username, page, size },
+    });
+    return fallback;
+  }
+}
+
+export const fetchUserEvents = cache(fetchUserEventsInternal);
 
 export async function fetchEventBySlug(
   fullSlug: string,

--- a/lib/api/favorites-external.ts
+++ b/lib/api/favorites-external.ts
@@ -1,0 +1,89 @@
+import { fetchWithHmac } from "./fetch-wrapper";
+import { getApiUrl } from "@utils/api-helpers";
+import { parsePagedEvents } from "@lib/validation/event";
+import type {
+  EventSummaryResponseDTO,
+  PagedResponseDTO,
+} from "types/api/event";
+
+// Authenticated per-user favourites: GET/POST/DELETE /api/users/me/favorites/events.
+// Every call forwards the caller's Bearer token to the backend (same pattern as
+// getMeExternal). The token acquisition is left to the auth layer — these
+// functions are provider-agnostic.
+const FAVORITES_PATH = "/users/me/favorites/events";
+
+function emptyPage(
+  page: number,
+  size: number,
+): PagedResponseDTO<EventSummaryResponseDTO> {
+  return {
+    content: [],
+    currentPage: page,
+    pageSize: size,
+    totalElements: 0,
+    totalPages: 0,
+    last: true,
+  };
+}
+
+export async function fetchFavoriteEventsExternal(
+  token: string,
+  page = 0,
+  size = 12,
+): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
+  const api = getApiUrl();
+  try {
+    const qs = new URLSearchParams({ page: String(page), size: String(size) });
+    const res = await fetchWithHmac(`${api}${FAVORITES_PATH}?${qs.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      console.error(`fetchFavoriteEventsExternal: HTTP ${res.status}`);
+      return emptyPage(page, size);
+    }
+    return parsePagedEvents(await res.json()) ?? emptyPage(page, size);
+  } catch (error) {
+    console.error("fetchFavoriteEventsExternal: failed", error);
+    return emptyPage(page, size);
+  }
+}
+
+export async function getFavoriteStatusExternal(
+  token: string,
+  eventId: string,
+): Promise<boolean> {
+  const api = getApiUrl();
+  try {
+    const res = await fetchWithHmac(
+      `${api}${FAVORITES_PATH}/${encodeURIComponent(eventId)}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) return false;
+    const json = (await res.json()) as { favorite?: unknown } | null;
+    return Boolean(json?.favorite);
+  } catch (error) {
+    console.error("getFavoriteStatusExternal: failed", error);
+    return false;
+  }
+}
+
+export async function setFavoriteExternal(
+  token: string,
+  eventId: string,
+  favorite: boolean,
+): Promise<boolean> {
+  const api = getApiUrl();
+  try {
+    const res = await fetchWithHmac(
+      `${api}${FAVORITES_PATH}/${encodeURIComponent(eventId)}`,
+      {
+        method: favorite ? "POST" : "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    return res.ok;
+  } catch (error) {
+    console.error("setFavoriteExternal: failed", error);
+    return false;
+  }
+}

--- a/lib/api/profiles-external.ts
+++ b/lib/api/profiles-external.ts
@@ -1,5 +1,6 @@
 import { fetchWithHmac } from "./fetch-wrapper";
-import { parseProfileDetail } from "@lib/validation/profile";
+import { parseUserPublic } from "@lib/validation/user";
+import type { UserPublicResponseDTO } from "types/api/user";
 import type { ProfileDetailResponseDTO } from "types/api/profile";
 
 // Mock data returned when backend is not yet ready (env guard fallback)
@@ -24,6 +25,27 @@ const MOCK_PROFILES: Record<string, ProfileDetailResponseDTO> = {
   },
 };
 
+// The backend exposes a lean public user (GET /api/users/{username}); the
+// profile UI expects the richer ProfileDetailResponseDTO. Fields the backend
+// does not return yet degrade to null/false/0 and the header hides them —
+// they light up automatically once the backend adds them.
+export function mapUserToProfile(
+  user: UserPublicResponseDTO
+): ProfileDetailResponseDTO {
+  return {
+    id: user.id,
+    slug: user.username,
+    name: user.name,
+    avatarUrl: user.pictureUrl ?? null,
+    coverUrl: null,
+    bio: null,
+    website: null,
+    verified: false,
+    joinedDate: user.createdAt,
+    totalEvents: 0,
+  };
+}
+
 export async function fetchProfileBySlugExternal(
   slug: string
 ): Promise<ProfileDetailResponseDTO | null> {
@@ -32,14 +54,16 @@ export async function fetchProfileBySlugExternal(
     return MOCK_PROFILES[slug] ?? null;
   }
   try {
-    const response = await fetchWithHmac(`${apiUrl}/profiles/${encodeURIComponent(slug)}`);
+    const response = await fetchWithHmac(
+      `${apiUrl}/users/${encodeURIComponent(slug)}`
+    );
     if (response.status === 404) return null;
     if (!response.ok) {
       console.error(`fetchProfileBySlugExternal: HTTP ${response.status}`);
       return null;
     }
-    const json = await response.json();
-    return parseProfileDetail(json);
+    const user = parseUserPublic(await response.json());
+    return user ? mapUserToProfile(user) : null;
   } catch (error) {
     console.error("fetchProfileBySlugExternal: failed", error);
     return null;

--- a/lib/api/profiles.ts
+++ b/lib/api/profiles.ts
@@ -1,36 +1,11 @@
 import { cache } from "react";
-import { fetchWithHmac } from "./fetch-wrapper";
-import { parseProfileDetail } from "@lib/validation/profile";
 import { fetchProfileBySlugExternal } from "./profiles-external";
-import { isBuildPhase } from "@utils/constants";
 import type { ProfileDetailResponseDTO } from "types/api/profile";
 
 async function fetchProfileBySlugInternal(
   slug: string
 ): Promise<ProfileDetailResponseDTO | null> {
-  if (isBuildPhase) {
-    return fetchProfileBySlugExternal(slug);
-  }
-
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  if (!apiUrl) {
-    return fetchProfileBySlugExternal(slug);
-  }
-
-  try {
-    const response = await fetchWithHmac(`${apiUrl}/profiles/${encodeURIComponent(slug)}`);
-    if (response.status === 404) return null;
-    if (!response.ok) {
-      console.error(
-        `fetchProfileBySlug: HTTP error! status: ${response.status}`
-      );
-      return null;
-    }
-    return parseProfileDetail(await response.json());
-  } catch (error) {
-    console.error("fetchProfileBySlug: failed", error);
-    return null;
-  }
+  return fetchProfileBySlugExternal(slug);
 }
 
 export const fetchProfileBySlug = cache(fetchProfileBySlugInternal);

--- a/lib/validation/user.ts
+++ b/lib/validation/user.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import type { UserPublicResponseDTO } from "types/api/user";
+
+export const UserPublicResponseDTOSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  username: z.string(),
+  pictureUrl: z.string().nullable().optional().default(null),
+  createdAt: z.string().optional().default(""),
+});
+
+export function parseUserPublic(
+  input: unknown
+): UserPublicResponseDTO | null {
+  const result = UserPublicResponseDTOSchema.safeParse(input);
+  if (!result.success) {
+    console.error("parseUserPublic: invalid user payload", result.error);
+    return null;
+  }
+  return result.data as UserPublicResponseDTO;
+}

--- a/test/favorites-external.test.ts
+++ b/test/favorites-external.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fetchWrapper from "../lib/api/fetch-wrapper";
+import {
+  fetchFavoriteEventsExternal,
+  getFavoriteStatusExternal,
+  setFavoriteExternal,
+} from "../lib/api/favorites-external";
+
+vi.mock("../lib/api/fetch-wrapper", () => ({
+  fetchWithHmac: vi.fn(),
+}));
+
+const mockFetchWithHmac = vi.mocked(fetchWrapper.fetchWithHmac);
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("favorites-external", () => {
+  it("forwards the Bearer token when listing favourites", async () => {
+    mockFetchWithHmac.mockResolvedValue(
+      jsonResponse({
+        content: [],
+        currentPage: 0,
+        pageSize: 12,
+        totalElements: 0,
+        totalPages: 0,
+        last: true,
+      }),
+    );
+
+    await fetchFavoriteEventsExternal("tok-123", 1, 5);
+
+    const [url, options] = mockFetchWithHmac.mock.calls[0];
+    expect(url).toContain("/users/me/favorites/events");
+    expect(url).toContain("page=1");
+    expect(url).toContain("size=5");
+    expect(
+      (options?.headers as Record<string, string>)?.Authorization,
+    ).toBe("Bearer tok-123");
+  });
+
+  it("reads the favourite flag from the status endpoint", async () => {
+    mockFetchWithHmac.mockResolvedValue(jsonResponse({ favorite: true }));
+    const result = await getFavoriteStatusExternal("tok", "evt-1");
+    expect(result).toBe(true);
+    const [url, options] = mockFetchWithHmac.mock.calls[0];
+    expect(url).toContain("/users/me/favorites/events/evt-1");
+    expect(
+      (options?.headers as Record<string, string>)?.Authorization,
+    ).toBe("Bearer tok");
+  });
+
+  it("returns false when the status call is not ok", async () => {
+    mockFetchWithHmac.mockResolvedValue(jsonResponse(null, 401));
+    expect(await getFavoriteStatusExternal("tok", "evt-1")).toBe(false);
+  });
+
+  it("POSTs to add and DELETEs to remove a favourite", async () => {
+    mockFetchWithHmac.mockResolvedValue(jsonResponse(null, 200));
+
+    await setFavoriteExternal("tok", "evt-9", true);
+    expect(mockFetchWithHmac.mock.calls[0][1]?.method).toBe("POST");
+
+    await setFavoriteExternal("tok", "evt-9", false);
+    expect(mockFetchWithHmac.mock.calls[1][1]?.method).toBe("DELETE");
+  });
+});

--- a/test/profile-api.test.ts
+++ b/test/profile-api.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchProfileBySlugExternal } from "../lib/api/profiles-external";
+import {
+  fetchProfileBySlugExternal,
+  mapUserToProfile,
+} from "../lib/api/profiles-external";
 import { buildEventsQuery } from "../utils/api-helpers";
 
 const originalEnv = { ...process.env };
@@ -30,6 +33,35 @@ describe("lib/api/profiles-external", () => {
 
     const result = await fetchProfileBySlugExternal("nonexistent");
     expect(result).toBeNull();
+  });
+});
+
+describe("mapUserToProfile", () => {
+  it("maps the lean user DTO to the profile view model", () => {
+    const profile = mapUserToProfile({
+      id: "u1",
+      name: "Sala Apolo",
+      username: "sala-apolo",
+      pictureUrl: "https://img.example/x.jpg",
+      createdAt: "2024-03-01T00:00:00Z",
+    });
+    expect(profile.slug).toBe("sala-apolo");
+    expect(profile.name).toBe("Sala Apolo");
+    expect(profile.avatarUrl).toBe("https://img.example/x.jpg");
+    expect(profile.joinedDate).toBe("2024-03-01T00:00:00Z");
+    expect(profile.verified).toBe(false);
+    expect(profile.totalEvents).toBe(0);
+  });
+
+  it("defaults a missing picture to null", () => {
+    const profile = mapUserToProfile({
+      id: "u2",
+      name: "X",
+      username: "x",
+      pictureUrl: null,
+      createdAt: "",
+    });
+    expect(profile.avatarUrl).toBeNull();
   });
 });
 

--- a/types/api/favorite.ts
+++ b/types/api/favorite.ts
@@ -1,0 +1,4 @@
+// GET /api/users/me/favorites/events/{eventId}
+export interface FavoriteStatusResponseDTO {
+  favorite: boolean;
+}

--- a/types/api/user.ts
+++ b/types/api/user.ts
@@ -1,0 +1,10 @@
+// Public user profile as returned by GET /api/users/{username}.
+// Leaner than ProfileDetailResponseDTO (no bio/cover/social/verified yet) —
+// see lib/api/profiles-external.ts for the mapping to the profile view model.
+export interface UserPublicResponseDTO {
+  id: string; // UUID
+  name: string;
+  username: string;
+  pictureUrl: string | null;
+  createdAt: string; // ISO date-time
+}


### PR DESCRIPTION
Stacked on `feat/connect-auth-backend` (depends on the profile pages + auth adapter that only exist there, not on `develop`).

## What & why

Gerard confirmed the real backend contract (swagger: `api-preproduction.esdeveniments.cat`). The frontend profile feature was built against an aspirational `/api/v1/profiles/*` spec the backend never implemented. This aligns the FE to what actually ships.

### 1. Profile pages → real `/api/users/{username}` (fixes 2 live bugs)
- `fetchProfileBySlug` hit `/profiles/{slug}` → **404 → null page** in prod. Now hits `GET /api/users/{username}`.
- Profile events used `/api/events?profileSlug=`, a param the backend **silently ignores**, so the page showed *all* events. Now uses `GET /api/users/{username}/events` for both SSR and "load more".
- The lean `UserPublicResponseDTO` maps onto the existing profile view model; rich fields (bio, cover, socialLinks, verified, totalEvents) degrade to null/false/0 and the header hides them, so they light up automatically once the backend adds them. `totalEvents` is derived from the events listing's `totalElements`.

### 2. Favourites backend proxy (Gerard's "call the API with the token")
- External calls + internal routes for `GET/POST/DELETE /api/users/me/favorites/events`, forwarding the caller's Bearer token (same pattern as `/api/auth/me`).
- **Provider-agnostic and not yet wired to UI.** It works with any JWT (custom login or Logto). The existing favourites UI is cookie-based/anonymous (keyed by slug); connecting authenticated users to this backend (keyed by event id) is a follow-up that needs a merge-vs-replace decision and is entangled with the in-flight Logto migration.

### 3. Docs
- `docs/api-spec-profiles.md` rewritten to the real `/api/users/*` contract + the list of rich fields still needed from the backend.

## Verification
- `yarn typecheck` clean, `yarn lint` 0 errors, full unit suite **1857 tests pass**.
- New tests: `mapUserToProfile` mapping + favourites token-forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch profile pages to the real `/api/users/{username}` endpoints and add a token-forwarding proxy for favourites. Fixes profile 404s and wrong event listings in production.

- **Bug Fixes**
  - Profile fetch now uses `GET /api/users/{username}` (instead of `/profiles/{slug}`) to prevent null pages.
  - Profile events now come from `GET /api/users/{username}/events` for SSR and “load more”, so only that user’s events are shown.

- **New Features**
  - Added internal proxies:
    - `GET /api/users/[username]/events` (public, HMAC; supports `page` and `size`).
    - `GET/POST/DELETE /api/users/me/favorites/events` and `GET /api/users/me/favorites/events/[eventId]` (forwards `Authorization: Bearer`).
  - Map `UserPublicResponseDTO` to the existing profile model; missing rich fields default to null/false, and `totalEvents` is derived from the events list.

<sup>Written for commit 88db72fad23576958e920fa27f47d473103d1307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

