### PR TITLE
feat(profile): show the user's events on the profile page

### DIFF
--- a/components/partials/ProfilePageShell.tsx
+++ b/components/partials/ProfilePageShell.tsx
@@ -19,15 +19,12 @@ const PROFILE_EVENTS_PAGE_SIZE = 20;
 export default async function ProfilePageShell({
   profile,
 }: ProfilePageShellProps) {
-  const tBreadcrumbs = await getTranslations("Components.Breadcrumbs");
-  const tProfile = await getTranslations("Components.Profile");
-  const locale = await getLocaleSafely();
-
-  const eventsResponse = await fetchUserEvents(
-    profile.username,
-    0,
-    PROFILE_EVENTS_PAGE_SIZE,
-  );
+  const [tBreadcrumbs, tProfile, locale, eventsResponse] = await Promise.all([
+    getTranslations("Components.Breadcrumbs"),
+    getTranslations("Components.Profile"),
+    getLocaleSafely(),
+    fetchUserEvents(profile.username, 0, PROFILE_EVENTS_PAGE_SIZE),
+  ]);
   const activeEvents = filterActiveEvents(eventsResponse.content);
 
   const profileUrl = toLocalizedUrl(`/perfil/${profile.username}`, locale);

--- a/components/partials/ProfilePageShell.tsx
+++ b/components/partials/ProfilePageShell.tsx
@@ -5,17 +5,15 @@ import List from "@components/ui/list";
 import CardServer from "@components/ui/card/CardServer";
 import NoEventsFound from "@components/ui/common/noEventsFound";
 import { generateBreadcrumbList } from "@components/partials/seo-meta";
-import { getUserEventsExternal } from "@lib/api/users-external";
+import { fetchUserEvents } from "@lib/api/profiles";
 import { filterActiveEvents } from "@utils/event-helpers";
 import { getTranslations } from "next-intl/server";
 import { getLocaleSafely, toLocalizedUrl } from "@utils/i18n-seo";
 import type { BreadcrumbItem } from "types/common";
 import type { ProfilePageShellProps } from "types/props";
 
-// First-page size for the profile's event listing. Pagination ("load more")
-// is deferred — v1 shows the most recent page, matching the favourites page.
-// ponytail: add client pagination via /api/users/[username]/events when a
-// profile with many events actually needs it.
+// First page of the profile's event listing. Client pagination ("load more")
+// via /api/users/[username]/events is a follow-up; v1 renders the first page.
 const PROFILE_EVENTS_PAGE_SIZE = 20;
 
 export default async function ProfilePageShell({
@@ -25,7 +23,7 @@ export default async function ProfilePageShell({
   const tProfile = await getTranslations("Components.Profile");
   const locale = await getLocaleSafely();
 
-  const eventsResponse = await getUserEventsExternal(
+  const eventsResponse = await fetchUserEvents(
     profile.username,
     0,
     PROFILE_EVENTS_PAGE_SIZE,
@@ -69,10 +67,15 @@ export default async function ProfilePageShell({
 
         <section
           className="w-full mt-section-y"
-          aria-label={tProfile("events")}
+          aria-labelledby="profile-events-heading"
           data-testid="profile-events"
         >
-          <h2 className="heading-2 mb-element-gap">{tProfile("events")}</h2>
+          <h2
+            id="profile-events-heading"
+            className="heading-2 mb-element-gap"
+          >
+            {tProfile("events")}
+          </h2>
           {activeEvents.length === 0 ? (
             <NoEventsFound title={tProfile("noEvents")} />
           ) : (

--- a/components/partials/ProfilePageShell.tsx
+++ b/components/partials/ProfilePageShell.tsx
@@ -1,11 +1,22 @@
 import JsonLdServer from "./JsonLdServer";
 import ProfileHeader from "@components/ui/profile/ProfileHeader";
 import ProfileClaimCta from "@components/ui/profile/ProfileClaimCta";
+import List from "@components/ui/list";
+import CardServer from "@components/ui/card/CardServer";
+import NoEventsFound from "@components/ui/common/noEventsFound";
 import { generateBreadcrumbList } from "@components/partials/seo-meta";
+import { getUserEventsExternal } from "@lib/api/users-external";
+import { filterActiveEvents } from "@utils/event-helpers";
 import { getTranslations } from "next-intl/server";
 import { getLocaleSafely, toLocalizedUrl } from "@utils/i18n-seo";
 import type { BreadcrumbItem } from "types/common";
 import type { ProfilePageShellProps } from "types/props";
+
+// First-page size for the profile's event listing. Pagination ("load more")
+// is deferred — v1 shows the most recent page, matching the favourites page.
+// ponytail: add client pagination via /api/users/[username]/events when a
+// profile with many events actually needs it.
+const PROFILE_EVENTS_PAGE_SIZE = 20;
 
 export default async function ProfilePageShell({
   profile,
@@ -13,6 +24,13 @@ export default async function ProfilePageShell({
   const tBreadcrumbs = await getTranslations("Components.Breadcrumbs");
   const tProfile = await getTranslations("Components.Profile");
   const locale = await getLocaleSafely();
+
+  const eventsResponse = await getUserEventsExternal(
+    profile.username,
+    0,
+    PROFILE_EVENTS_PAGE_SIZE,
+  );
+  const activeEvents = filterActiveEvents(eventsResponse.content);
 
   const profileUrl = toLocalizedUrl(`/perfil/${profile.username}`, locale);
 
@@ -48,6 +66,27 @@ export default async function ProfilePageShell({
       <div className="container flex flex-col justify-center items-center pt-[6rem]">
         <ProfileHeader profile={profile} />
         <ProfileClaimCta username={profile.username} />
+
+        <section
+          className="w-full mt-section-y"
+          aria-label={tProfile("events")}
+          data-testid="profile-events"
+        >
+          <h2 className="heading-2 mb-element-gap">{tProfile("events")}</h2>
+          {activeEvents.length === 0 ? (
+            <NoEventsFound title={tProfile("noEvents")} />
+          ) : (
+            <List events={activeEvents}>
+              {(event, index) => (
+                <CardServer
+                  key={`${event.id}-${index}`}
+                  event={event}
+                  isPriority={index === 0}
+                />
+              )}
+            </List>
+          )}
+        </section>
       </div>
     </>
   );

--- a/lib/api/profiles.ts
+++ b/lib/api/profiles.ts
@@ -1,5 +1,8 @@
 import { cache } from "react";
-import { getUserByUsernameExternal } from "./users-external";
+import {
+  getUserByUsernameExternal,
+  getUserEventsExternal,
+} from "./users-external";
 import type { ProfileDetailResponseDTO } from "types/api/profile";
 
 async function fetchProfileByUsernameInternal(
@@ -10,3 +13,7 @@ async function fetchProfileByUsernameInternal(
 
 export const fetchProfileBySlug = cache(fetchProfileByUsernameInternal);
 export const fetchUserByUsername = cache(fetchProfileByUsernameInternal);
+
+// Request-level dedupe facade so components fetch a user's events through
+// lib/api rather than importing the *-external helper directly.
+export const fetchUserEvents = cache(getUserEventsExternal);

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -50,15 +50,20 @@ export async function getUserEventsExternal(
     totalPages: 0,
     last: true,
   };
-  if (!username || !username.trim()) return empty;
+  const trimmed = username?.trim();
+  if (!trimmed) return empty;
   const apiUrl = getApiUrl();
   if (!apiUrl) return empty;
 
   try {
     const qs = new URLSearchParams({ page: String(page), size: String(size) });
+    // No `next: { revalidate }` here — external wrappers must stay no-store
+    // (repo cost rule). Matches getUserByUsernameExternal on the same page.
     const response = await fetchWithHmac(
-      `${apiUrl}/users/${encodeURIComponent(username)}/events?${qs.toString()}`,
+      `${apiUrl}/users/${encodeURIComponent(trimmed)}/events?${qs.toString()}`,
     );
+    // 404 = unknown user / no public events: a normal empty result, not an error.
+    if (response.status === 404) return empty;
     if (!response.ok) {
       console.error(`getUserEventsExternal: HTTP ${response.status}`);
       return empty;

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -53,7 +53,6 @@ export async function getUserEventsExternal(
   const trimmed = username?.trim();
   if (!trimmed) return empty;
   const apiUrl = getApiUrl();
-  if (!apiUrl) return empty;
 
   try {
     const qs = new URLSearchParams({ page: String(page), size: String(size) });

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -1,7 +1,12 @@
 import { fetchWithHmac } from "./fetch-wrapper";
 import { parseUserPublic } from "@lib/validation/user";
+import { parsePagedEvents } from "@lib/validation/event";
 import { getApiUrl } from "@utils/api-helpers";
 import type { UserPublicResponseDTO } from "types/api/user";
+import type {
+  EventSummaryResponseDTO,
+  PagedResponseDTO,
+} from "types/api/event";
 
 export async function getUserByUsernameExternal(
   username: string
@@ -23,5 +28,44 @@ export async function getUserByUsernameExternal(
   } catch (error) {
     console.error("getUserByUsernameExternal: failed", error);
     return null;
+  }
+}
+
+/**
+ * Public listing of a user's events: GET /api/users/{username}/events.
+ * Same paged shape as /events; the endpoint only accepts page & size.
+ * Returns an empty page on error so the profile renders "no events" rather
+ * than crashing.
+ */
+export async function getUserEventsExternal(
+  username: string,
+  page = 0,
+  size = 12,
+): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
+  const empty: PagedResponseDTO<EventSummaryResponseDTO> = {
+    content: [],
+    currentPage: page,
+    pageSize: size,
+    totalElements: 0,
+    totalPages: 0,
+    last: true,
+  };
+  if (!username || !username.trim()) return empty;
+  const apiUrl = getApiUrl();
+  if (!apiUrl) return empty;
+
+  try {
+    const qs = new URLSearchParams({ page: String(page), size: String(size) });
+    const response = await fetchWithHmac(
+      `${apiUrl}/users/${encodeURIComponent(username)}/events?${qs.toString()}`,
+    );
+    if (!response.ok) {
+      console.error(`getUserEventsExternal: HTTP ${response.status}`);
+      return empty;
+    }
+    return parsePagedEvents(await response.json()) ?? empty;
+  } catch (error) {
+    console.error("getUserEventsExternal: failed", error);
+    return empty;
   }
 }

--- a/test/users-external.test.ts
+++ b/test/users-external.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fetchWrapper from "../lib/api/fetch-wrapper";
+import { getUserEventsExternal } from "../lib/api/users-external";
+
+vi.mock("../lib/api/fetch-wrapper", () => ({
+  fetchWithHmac: vi.fn(),
+}));
+
+const mockFetchWithHmac = vi.mocked(fetchWrapper.fetchWithHmac);
+
+function pagedResponse(
+  data: unknown,
+  status = 200,
+) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  } as Response;
+}
+
+const emptyPage = {
+  content: [],
+  currentPage: 0,
+  pageSize: 20,
+  totalElements: 0,
+  totalPages: 0,
+  last: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getUserEventsExternal", () => {
+  it("requests /users/{username}/events with page & size", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(emptyPage));
+
+    await getUserEventsExternal("sala-apolo", 2, 5);
+
+    const [url] = mockFetchWithHmac.mock.calls[0];
+    expect(url).toContain("/users/sala-apolo/events");
+    expect(url).toContain("page=2");
+    expect(url).toContain("size=5");
+  });
+
+  it("returns an empty page (no fetch) for a blank username", async () => {
+    const result = await getUserEventsExternal("   ");
+    expect(result.content).toEqual([]);
+    expect(mockFetchWithHmac).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty page when the backend responds with an error", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(null, 500));
+    const result = await getUserEventsExternal("sala-apolo");
+    expect(result.content).toEqual([]);
+    expect(result.last).toBe(true);
+  });
+});

--- a/test/users-external.test.ts
+++ b/test/users-external.test.ts
@@ -6,6 +6,12 @@ vi.mock("../lib/api/fetch-wrapper", () => ({
   fetchWithHmac: vi.fn(),
 }));
 
+// Pin the API URL so the test doesn't depend on env / api-defaults.json.
+vi.mock("@utils/api-helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@utils/api-helpers")>()),
+  getApiUrl: () => "http://localhost:8080/api",
+}));
+
 const mockFetchWithHmac = vi.mocked(fetchWrapper.fetchWithHmac);
 
 function pagedResponse(
@@ -52,6 +58,18 @@ describe("getUserEventsExternal", () => {
 
   it("returns an empty page when the backend responds with an error", async () => {
     mockFetchWithHmac.mockResolvedValue(pagedResponse(null, 500));
+    const result = await getUserEventsExternal("sala-apolo");
+    expect(result.content).toEqual([]);
+    expect(result.last).toBe(true);
+  });
+
+  it("treats a malformed 200 payload as an empty page (no throw)", async () => {
+    // Backend returning 200 with a non-paged/error body must not surface as a
+    // crash or as fake data: parsePagedEvents rejects it → empty page, so the
+    // profile renders "no events" instead of throwing in a server component.
+    mockFetchWithHmac.mockResolvedValue(
+      pagedResponse({ error: "Internal Server Error" }, 200),
+    );
     const result = await getUserEventsExternal("sala-apolo");
     expect(result.content).toEqual([]);
     expect(result.last).toBe(true);

--- a/test/users-external.test.ts
+++ b/test/users-external.test.ts
@@ -44,6 +44,7 @@ describe("getUserEventsExternal", () => {
 
     await getUserEventsExternal("sala-apolo", 2, 5);
 
+    expect(mockFetchWithHmac).toHaveBeenCalledTimes(1);
     const [url] = mockFetchWithHmac.mock.calls[0];
     expect(url).toContain("/users/sala-apolo/events");
     expect(url).toContain("page=2");
@@ -61,6 +62,12 @@ describe("getUserEventsExternal", () => {
     const result = await getUserEventsExternal("sala-apolo");
     expect(result.content).toEqual([]);
     expect(result.last).toBe(true);
+  });
+
+  it("treats a 404 (unknown user) as an empty page", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(null, 404));
+    const result = await getUserEventsExternal("ghost");
+    expect(result.content).toEqual([]);
   });
 
   it("treats a malformed 200 payload as an empty page (no throw)", async () => {


### PR DESCRIPTION
## What & why

The `[username]` profile page renders the user header + claim CTA but **no events**, and nothing on this branch consumes the backend's `GET /api/users/{username}/events`. This wires that endpoint in so a profile shows the user's upcoming events end-to-end.

## Changes
- `lib/api/users-external.ts`: `getUserEventsExternal(username, page, size)` → `GET /api/users/{username}/events`, validated with `parsePagedEvents`, returns an empty page on error/blank username (profile shows "no events" rather than crashing).
- `components/partials/ProfilePageShell.tsx`: fetch the user's events, `filterActiveEvents`, render `List` + `CardServer` under the header. Its own `<h2>` (so no second `<h1>` beside `ProfileHeader`). Mirrors the favourites page pattern — server-side SSR list, no place-filter apparatus.
- `test/users-external.test.ts`: URL/params + blank-username + backend-error paths.

## Scope note
Pagination ("load more") is deferred — v1 renders the first page, matching how the favourites page caps its list. Client pagination via a `/api/users/[username]/events` route + the `useEvents` `profileSlug` branch is an easy follow-up if a prolific organizer needs it.

## Verification
`yarn typecheck` clean · `yarn lint` 0 errors · full unit suite **1997 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the user’s upcoming events on the profile page by wiring `GET /api/users/{username}/events` and rendering them server-side under the header. Failures (blank username, 404/500, malformed payload, or unconfigured backend) fall back to “no events” instead of breaking.

- **New Features**
  - Added `getUserEventsExternal(username, page, size)` validated with `parsePagedEvents`; trims `username`, treats 404 as empty, and returns an empty page on blank username, backend errors, or when the API isn’t configured.
  - Profile fetches via cached `fetchUserEvents` facade in `lib/api/profiles`, filters active events, and renders a `List` of `CardServer` under an `<h2>` with `aria-labelledby`; shows `NoEventsFound` when empty; first page only.
  - Tests cover URL/params, blank username, 404/500, and malformed 200 payloads; `getApiUrl` is mocked for hermetic tests.

- **Refactors**
  - Parallelized translations, locale, and events fetch in `ProfilePageShell` with `Promise.all`; removed a dead `getApiUrl` guard.

<sup>Written for commit c064be51aa729e8ca312a8863a666a98a577d55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

