### PR TITLE
docs(auth): manual test runbook + CSRF-403 favorites lesson

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -60,6 +60,10 @@ Logout looked broken on the first Logto preview: after sign-out the navbar staye
 
 Fix: a `NetworkOnly` route for `/api/auth/*` registered **before** the navigation and catch-all `/api/` routes (Workbox is first-match-wins). Any future auth-state or per-user endpoint needs the same treatment — never let it fall into a caching strategy. `test/service-worker.test.ts` asserts the auth route exists and is ordered before the catch-all. Generated `public/sw.js` is gitignored; edit the template and run `yarn prebuild`.
 
+## The CSRF origin allowlist makes `/api/favorites` a localhost-only false green
+
+The favorites POST is CSRF-guarded by an origin allowlist that includes `localhost:3000` in dev. So on localhost the write passes; it only **403s on a non-localhost / non-www host** — i.e. a Coolify PR preview or staging. Same shape as the proxy-origin bug: the environment that's convenient to test on is exactly the one that can't reproduce the failure. Test any origin/CSRF-gated write (favorites, and future authed mutations) on the Coolify preview, and if a POST 403s only off-localhost, suspect the allowlist host set, not the client. Manual runbook: `docs/logto-auth-setup.md`.
+
 ## `NEXT_PUBLIC_*` are baked at build (from GitHub) — not read from Coolify at runtime
 
 The prebuilt-image deploy (PR #371) builds the image in GitHub Actions and runs it in Coolify, so env vars split in two: `NEXT_PUBLIC_*` are inlined **at build** from the **GitHub** environment secrets; runtime secrets (`HMAC_SECRET`, `REDIS_URL`, `STRIPE_*`, …) are read **at runtime** from **Coolify**. The `getApiUrl`/`getApiOrigin` "indirect lookup" in `utils/api-helpers.ts` was meant to keep `NEXT_PUBLIC_API_URL` runtime-readable, but it does **not** — Turbopack still inlines it (grep `/app/.next/server` and you'll find literal copies). So for a Docker-Image app the Coolify `NEXT_PUBLIC_*` values are dead; GitHub's are authoritative.

--- a/docs/logto-auth-setup.md
+++ b/docs/logto-auth-setup.md
@@ -134,3 +134,74 @@ Consequence to know before merging: once auth is mandatory, the deploy gate
 will fail any environment whose Coolify app lacks `LOGTO_*`. Set staging's vars
 (and the `LOGTO_*_STAGING` GitHub secrets) before/with the merge to `develop`;
 set production's (against the prod instance) before promoting to `main`.
+
+## Manual test procedure (agent-browser)
+
+**Test on the Coolify PR preview (`https://pr-<N>.esdeveniments.cat`), not
+localhost.** Localhost is a false green for this feature: the proxy-origin bug
+and the CSRF-403 below are both invisible there (see `LESSONS.md`). Use
+localhost only for `yarn typecheck && yarn lint && npx vitest run` and the
+happy-path login shape. Previews don't auto-rebuild on push — a Coolify
+"redeploy" re-runs the pinned commit; confirm the live build first:
+
+```bash
+curl -s "https://pr-<N>.esdeveniments.cat/sw.js" | grep -c 'api/auth/'   # >0 = new build
+```
+
+Login / sign-up round-trip (a fresh agent-browser session):
+
+```bash
+s=test
+agent-browser --session $s open "https://pr-<N>.esdeveniments.cat/iniciar-sessio"
+agent-browser --session $s wait --load networkidle   # → proxy.ts → /api/auth/sign-in → Logto hosted page
+agent-browser --session $s snapshot -i                # identifier textbox + "Sign in"
+agent-browser --session $s fill @e4 "<test-username>"
+agent-browser --session $s click @e1
+agent-browser --session $s wait --load networkidle
+agent-browser --session $s snapshot -i                # password step
+agent-browser --session $s fill @e5 "<test-password>"
+agent-browser --session $s click @e3                  # Continue → callback → lands logged in
+```
+
+Sign-up is the same via the "Create account" link (`/register`): username →
+password → straight back logged in. This Logto instance's sign-in is
+**phone + SMS by default** on some configs; if you only see a phone field you
+can't self-register headlessly — use an existing test account.
+
+Verify session (in-browser fetch — must be an async IIFE, no top-level await):
+
+```bash
+cat <<'EOF' | agent-browser --session $s eval --stdin
+(async()=>{const r=await fetch('/api/auth/me',{credentials:'include'});return{status:r.status,body:await r.json()};})()
+EOF
+# expect 200 {user:{username:"…",...}}; navbar shows the user menu
+```
+
+Logout must land back on **our** origin before the next check — after sign-out
+the browser sits on the Logto domain, so a relative `fetch('/api/auth/me')`
+would hit `auth-preproduction…` (404), not the app:
+
+```bash
+agent-browser --session $s click @eNN                 # LOG OUT (re-snapshot for the ref)
+agent-browser --session $s open "https://pr-<N>.esdeveniments.cat/en"
+cat <<'EOF' | agent-browser --session $s eval --stdin
+(async()=>{const r=await fetch('/api/auth/me?cb='+Date.now(),{credentials:'include',cache:'no-store'});return{status:r.status};})()
+EOF
+# expect 401. A stale 200 here = the service worker served it (see LESSONS.md);
+# the ?cb= param, or curl (no SW), tells the truth. cache:'no-store' does NOT bypass the SW.
+```
+
+Favorites (same eval POST, logged in and out):
+
+```bash
+cat <<'EOF' | agent-browser --session $s eval --stdin
+(async()=>{const r=await fetch('/api/favorites',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({eventSlug:'x',eventId:'1',shouldBeFavorite:true})});return{status:r.status,body:await r.text()};})()
+EOF
+```
+
+agent-browser gotchas (the ones a fresh agent trips on):
+- Quote every URL — a bare `?` breaks in zsh.
+- HttpOnly cookies aren't in `document.cookie`; dump them via
+  `agent-browser --session $s cookies get` (CDP), not JS.
+- To inspect what the SW cached: `eval` `caches.keys()` then
+  `caches.open(n).keys()` and grep the URLs.


### PR DESCRIPTION
Captures the manual e2e test knowledge so the next agent (human or AI) doesn't relearn it.

- **docs/logto-auth-setup.md** — new "Manual test procedure (agent-browser)" section: step-by-step login/session/logout/favorites on the **Coolify PR preview**, plus the agent-browser gotchas (quote URLs in zsh, HttpOnly cookies via CDP, `?cb=` vs the service worker, navigate back to our origin after logout, inspect SW cache). The Logto setup + automated guards were already documented; the manual procedure was the gap.
- **LESSONS.md** — new lesson: the CSRF origin allowlist makes `/api/favorites` a **localhost-only false green** (403s only on a non-localhost/non-www host).

Both reinforce the standing rule already in LESSONS.md: localhost is a false green for the auth / CSRF / proxy-origin classes of bug — the Coolify PR preview is the only env that catches them.

Docs-only; no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a step-by-step agent-browser runbook to test Logto auth on Coolify PR previews (login, session, logout, favorites). Also documents that the CSRF origin allowlist makes `/api/favorites` pass on localhost but 403 off-localhost.

- **Docs**
  - `docs/logto-auth-setup.md`: Manual test for Coolify PR previews, including live build check (`sw.js` grep), login/sign-up, `/api/auth/me` eval, return to app origin after logout, favorites POST, and agent-browser tips (quote `?` in zsh, use CDP for HttpOnly cookies, use `?cb=`; `cache:'no-store'` doesn’t bypass the SW).
  - `LESSONS.md`: New lesson on the CSRF origin allowlist causing a localhost-only false green for `/api/favorites`; test writes on the Coolify preview.

<sup>Written for commit d5789a05575668815e5108f6d637ba4d2eeb3682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer manual testing steps for verifying authentication and logout on the Coolify preview domain.
  * Included checks for login, session status, favorites behavior, and service worker asset updates.
  * Added troubleshooting tips for common browser and terminal issues during manual testing.
* **New Features**
  * Added a new lesson describing CSRF-protected write requests and how to validate them in preview environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->