### PR TITLE
fix(e2e): make the E2E gate reliable (drop networkidle waits + hermetic profile test)

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -2,6 +2,10 @@
 
 Repo-specific gotchas worth sharing. Read this during research on any task here.
 
+## Never `waitUntil: "networkidle"` in an e2e against a deployed build
+
+`load_more_with_filters.spec.ts` did `page.goto(..., { waitUntil: "networkidle" })`. Locally it passed; against the Vercel preview it timed out `page.goto` at 45s **every** retry, hard-failing the required E2E gate and blocking every develop PR — even a docs-only one. The cause isn't the test's data or mocks (that spec fully mocks `/api/events`): analytics, ads and Sentry keep the network busy on a deployed build, so "networkidle" (500ms of silence) never fires. Use `waitUntil: "domcontentloaded"` plus an explicit auto-waiting assertion for the element you need (`expect(getByTestId(...))`), the way `home.flow.spec.ts` does reliably. For a mid-test settle after an action, bound it: `page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {})`, never an unbounded wait. Grep `e2e/` for `networkidle` before trusting the gate.
+
 ## A test that skips on its own failure mode is worse than no test
 
 The image-proxy e2e tests skipped on any 502 (`test.skip("Test image service unavailable")`). When the dispatcher broke and 502'd every image, the suite read it as a flaky upstream and shipped green — for weeks (the May 2026 autoSelectFamily regression). If a test exists to catch failure X, it must **fail** on X, never skip. Retry to absorb genuine flakiness, then fail once retries are exhausted. Before trusting a green e2e run, grep for `if (status >= 500) test.skip` shapes.

--- a/e2e/ads-hybrid-rendering.spec.ts
+++ b/e2e/ads-hybrid-rendering.spec.ts
@@ -18,7 +18,13 @@ test.describe("Hybrid rendering: ads are SSR-only", () => {
     const loadMore = page.getByRole("button", { name: /carrega més|més/i });
     if (await loadMore.isVisible()) {
       await loadMore.click();
-      await page.waitForLoadState("networkidle");
+      // Bounded settle wait: on an ads page the network never truly idles
+      // (ad slots keep polling), so a bare networkidle wait would hang until
+      // timeout. Give the load-more fetch + client ad hydration a moment; the
+      // lenient count assertion below is the real check.
+      await page
+        .waitForLoadState("networkidle", { timeout: 5000 })
+        .catch(() => {});
     }
 
     const afterCount = await sponsoredHeadings.count();

--- a/e2e/home.flow.spec.ts
+++ b/e2e/home.flow.spec.ts
@@ -5,7 +5,7 @@ test.describe("Home flow", () => {
     await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
     // Auto-waiting assertion - no need for manual waits
     await expect(page.getByTestId("search-input")).toBeVisible({
-      timeout: 30000,
+      timeout: process.env.CI ? 60000 : 30000,
     });
   });
 
@@ -14,7 +14,7 @@ test.describe("Home flow", () => {
 
     // Wait for search input to ensure page is loaded
     await expect(page.getByTestId("search-input")).toBeVisible({
-      timeout: 30000,
+      timeout: process.env.CI ? 60000 : 30000,
     });
 
     // Verify that categorized events are actually displayed

--- a/e2e/load_more_with_filters.spec.ts
+++ b/e2e/load_more_with_filters.spec.ts
@@ -212,7 +212,11 @@ test.describe("Load more with filters via proxy", () => {
       return route.continue();
     });
 
-    await page.goto("/e2e/load-more", { waitUntil: "networkidle" });
+    // domcontentloaded, NOT networkidle: analytics/ads/telemetry keep the
+    // network busy on deployed builds, so networkidle never settles and
+    // page.goto times out (45s) on the Vercel preview. The explicit hasMore
+    // assertion below auto-waits for the harness to be interactive.
+    await page.goto("/e2e/load-more", { waitUntil: "domcontentloaded" });
     // Load more should be available initially
     await expect(page.getByTestId("hasMore")).toHaveText("true");
     const loadMore = page.getByTestId("load-more-button");

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -1,14 +1,17 @@
 import { fetchWithHmac } from "./fetch-wrapper";
 import { parseUserPublic } from "@lib/validation/user";
-import { getApiUrl } from "@utils/api-helpers";
+import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
 import type { UserPublicResponseDTO } from "types/api/user";
 
 export async function getUserByUsernameExternal(
   username: string
 ): Promise<UserPublicResponseDTO | null> {
   if (!username || !username.trim()) return null;
+  // Return null (no fetch) when the backend URL is genuinely unconfigured.
+  // getApiUrl() falls back to a hardcoded default, so guarding on its result
+  // is dead code and would fire a real request against the default host.
+  if (!isApiUrlConfigured()) return null;
   const apiUrl = getApiUrl();
-  if (!apiUrl) return null;
 
   try {
     const response = await fetchWithHmac(


### PR DESCRIPTION
The required **E2E gate is flaky and was blocking every develop PR** (even docs-only ones). Root causes, all fixed here.

## 1. `networkidle` waits hang on deployed builds
`load_more_with_filters.spec.ts` did `page.goto(..., { waitUntil: "networkidle" })`. Against the Vercel preview, analytics/ads/Sentry keep the network busy, so networkidle never settles → `page.goto` **times out at 45s every retry** → hard gate failure. The spec fully mocks `/api/events`, so it's not data — it's the wait strategy.

- `load_more`: `networkidle` → `domcontentloaded` (the existing `hasMore` assertion auto-waits for interactivity).
- `ads-hybrid-rendering`: the mid-test settle after "load more" is now a **bounded** `waitForLoadState("networkidle", { timeout: 5000 }).catch(()=>{})` — an ads page never idles; the lenient count assertion is the real check.

## 2. `home.flow` search-input timeout too tight
Bumped to CI-aware 60s (was flaking on slow cold-preview hydration, passing only on retry).

## 3. Latent bug surfaced by the pre-push hook
`getUserByUsernameExternal` guarded on `getApiUrl()`, which falls back to a hardcoded default — so with `NEXT_PUBLIC_API_URL` unset it fired a **real request against the default host**, hanging `test/profile-api.test.ts` to a 5s timeout (CI fast-failed the fetch, hiding it). Now guards on `isApiUrlConfigured()` (reads `process.env`, no fallback) → returns null without a network call. Hermetic test + real fix.

## Docs
`LESSONS.md`: never use `networkidle` in an e2e against a deployed build.

## Verification
`yarn typecheck` clean · `yarn lint` 0 errors · unit suite green (the profile-api timeout is fixed). This PR's own E2E run is the proof the gate is stable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky E2E gate by removing `networkidle` waits that hang on Vercel previews and making the profile API test hermetic. CI is stable again.

- **Bug Fixes**
  - E2E: Replaced `networkidle` with `domcontentloaded` in `load_more_with_filters`, added a bounded `waitForLoadState("networkidle", { timeout: 5000 })` in `ads-hybrid-rendering`, and increased `home.flow` search input visibility timeout to 60s on CI.
  - API: `getUserByUsernameExternal` now checks `isApiUrlConfigured()` and returns `null` when unset, avoiding accidental network calls and fixing the profile API unit test hang.

- **Docs**
  - Added guidance in `LESSONS.md` to avoid `networkidle` in E2E against deployed builds and to use explicit, bounded waits instead.

<sup>Written for commit b27d77a31f44fd3f677d283325a988092be93ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

