### PR TITLE
fix(e2e): wire Logto env into nightly integration workflow

### DIFF
--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -81,6 +81,15 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL || 'https://api-preproduction.esdeveniments.cat/api' }}
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           HMAC_SECRET: ${{ secrets.HMAC_SECRET }}
+          # Logto OIDC config (preproduction app). Without these, /iniciar-sessio
+          # → /api/auth/sign-in throws in getLogtoConfig() and returns a 500,
+          # so the login step never reaches Logto's form. Sourced from the
+          # repo-level *_STAGING secrets set for preproduction.
+          LOGTO_ENDPOINT: ${{ secrets.LOGTO_ENDPOINT_STAGING }}
+          LOGTO_APP_ID: ${{ secrets.LOGTO_APP_ID_STAGING }}
+          LOGTO_APP_SECRET: ${{ secrets.LOGTO_APP_SECRET_STAGING }}
+          LOGTO_COOKIE_SECRET: ${{ secrets.LOGTO_COOKIE_SECRET_STAGING }}
+          LOGTO_API_RESOURCE: ${{ secrets.LOGTO_API_RESOURCE_STAGING }}
 
       - name: Wait for server
         run: npx wait-on http://localhost:3000 --timeout 90000


### PR DESCRIPTION
## What

The nightly `E2E Integration (preproduction)` workflow's **Start app** step never passed the Logto OIDC config. The publish spec logs in via `/iniciar-sessio` → `/api/auth/sign-in`, which calls `getLogtoConfig()` → `requireEnv("LOGTO_ENDPOINT")`. With the var missing it throws and the route returns `{"error":"Internal server error"}`. The Logto sign-in form never loads, so `loginViaUI` times out waiting for the identifier input:

```
TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
  - waiting for locator('input[name="identifier"], input[type="email"], input[type="text"]')
```

Broken silently every night since the Logto migration (#375) added the login step without wiring the auth env.

## Fix

Add the Logto config to the Start-app step, sourced from the existing repo-level `*_STAGING` secrets (preproduction):

- `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, `LOGTO_APP_SECRET`, `LOGTO_COOKIE_SECRET`, `LOGTO_API_RESOURCE`

## Before merging — one manual check

The preproduction Logto app must allow `http://localhost:3000/api/auth/callback` as a redirect URI. Without the env the form never loaded (the current failure); with it, the form loads but the flow fails at `/callback` if that URI isn't registered.

## Not covered here (follow-up)

Nightly E2E failures are invisible today (no notification), same as the uptime monitor. Worth a separate change to surface them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nightly preproduction E2E publish flow by passing Logto OIDC env to the Start app step so login works and the tests run end-to-end. Adds deploy-time smokes to catch missing auth env and reduces E2E flakiness.

- **Bug Fixes**
  - E2E Integration (preproduction): inject `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, `LOGTO_APP_SECRET`, `LOGTO_COOKIE_SECRET`, `LOGTO_API_RESOURCE` from staging secrets into the Start app step.
  - Deploy smokes: assert `/api/auth/sign-in` redirects to Logto; wire the same `LOGTO_*` env in `prod-arch-smoke.yml` and the Coolify deploy smoke to fail fast when misconfigured.
  - E2E reliability: replace `networkidle` waits with bounded or `domcontentloaded` waits; add an auth mock helper for publish specs; ensure the service worker never caches `/api/auth/*` or `/api/favorites`.

- **Migration**
  - Preproduction Logto must allow `http://localhost:3000/api/auth/callback` as a redirect URI; otherwise the flow fails at `/callback`.
  - Staging GitHub Environment should define the five `LOGTO_*_STAGING` secrets used by the workflow.

<sup>Written for commit 8b7df31c4f525e80c40f82c4db409fab7b0dda42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

