### PR TITLE
fix(e2e): wire Logto env into nightly integration workflow

### DIFF
--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -81,6 +81,15 @@ jobs:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL || 'https://api-preproduction.esdeveniments.cat/api' }}
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
           HMAC_SECRET: ${{ secrets.HMAC_SECRET }}
+          # Logto OIDC config (preproduction app). Without these, /iniciar-sessio
+          # → /api/auth/sign-in throws in getLogtoConfig() and returns a 500,
+          # so the login step never reaches Logto's form. Sourced from the
+          # repo-level *_STAGING secrets set for preproduction.
+          LOGTO_ENDPOINT: ${{ secrets.LOGTO_ENDPOINT_STAGING }}
+          LOGTO_APP_ID: ${{ secrets.LOGTO_APP_ID_STAGING }}
+          LOGTO_APP_SECRET: ${{ secrets.LOGTO_APP_SECRET_STAGING }}
+          LOGTO_COOKIE_SECRET: ${{ secrets.LOGTO_COOKIE_SECRET_STAGING }}
+          LOGTO_API_RESOURCE: ${{ secrets.LOGTO_API_RESOURCE_STAGING }}
 
       - name: Wait for server
         run: npx wait-on http://localhost:3000 --timeout 90000


### PR DESCRIPTION
The publish-integration spec logs in through Logto's OIDC flow, but the "Start app" step never passed the Logto config. So /iniciar-sessio → /api/auth/sign-in hit requireEnv("LOGTO_ENDPOINT") in getLogtoConfig(), threw, and returned {"error":"Internal server error"} — the sign-in form never loaded and loginViaUI timed out waiting for the identifier input.

Broken silently since the Logto migration (#375) added the login step. Sourced from the existing repo-level *_STAGING secrets (preproduction).



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes Logto OIDC env vars to the nightly e2e integration workflow so the publish-integration test can load the sign-in form and log in. Fixes 500s from missing config in `/api/auth/sign-in`.

- **Bug Fixes**
  - Injected `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, `LOGTO_APP_SECRET`, `LOGTO_COOKIE_SECRET`, `LOGTO_API_RESOURCE` into the "Start app" step in `.github/workflows/e2e-integration.yml` from repo-level `*_STAGING` secrets.
  - Prevents `requireEnv` throw in `getLogtoConfig()` and restores the `loginViaUI` flow.

<sup>Written for commit 8b7df31c4f525e80c40f82c4db409fab7b0dda42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preproduction login setup so authentication can initialize correctly during end-to-end testing.
  * Reduced the chance of server errors when the app retrieves sign-in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->