### PR TITLE
feat(auth): enrich /api/auth/me with backend profile fields

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -5,6 +5,7 @@ import {
   refreshAccessToken,
   verifyStoredIdToken,
 } from "@lib/auth/logto";
+import { getAuthenticatedUserExternal } from "@lib/api/users-external";
 import {
   ACCESS_TOKEN_COOKIE,
   ID_TOKEN_COOKIE,
@@ -13,17 +14,44 @@ import {
   readTokenFromRequest,
   setTokenCookies,
 } from "@utils/auth-cookies";
+import type { AuthUser } from "types/auth";
 
 const NO_STORE = { "Cache-Control": "no-store" } as const;
+
+// Layers the backend-owned profile (pictureUrl/pictureSource/role/lastLoginAt)
+// on top of the id_token-derived user. The backend call is best-effort: an
+// unreachable/misconfigured backend must not break login, since the
+// id_token alone is already a valid, verified session.
+async function enrichWithBackendProfile(
+  user: AuthUser,
+  accessToken: string | null,
+): Promise<AuthUser> {
+  if (!accessToken) return user;
+  const backendUser = await getAuthenticatedUserExternal(accessToken);
+  if (!backendUser) return user;
+  return {
+    ...user,
+    id: backendUser.id,
+    email: backendUser.email,
+    name: backendUser.name,
+    username: backendUser.username,
+    avatarUrl: backendUser.pictureUrl ?? user.avatarUrl,
+    pictureSource: backendUser.pictureSource,
+    role: backendUser.role ?? user.role,
+    lastLoginAt: backendUser.lastLoginAt,
+  };
+}
 
 // Returns the current user from the verified id_token cookie — no userinfo
 // round-trip, so it works even when the access token is bound to a backend API
 // resource (aud != userinfo). If the id_token has expired, transparently
 // refreshes via the refresh token. Distinguishes a definitive auth failure
 // (clear cookies → 401) from a transient Logto outage (preserve cookies → 503).
+// Backend-owned profile fields are layered on afterwards (enrichWithBackendProfile).
 export async function GET(request: NextRequest): Promise<Response> {
   const idToken = readTokenFromRequest(request, ID_TOKEN_COOKIE);
   const refreshToken = readTokenFromRequest(request, REFRESH_TOKEN_COOKIE);
+  const accessToken = readTokenFromRequest(request, ACCESS_TOKEN_COOKIE);
 
   const unauthorized = (): Response => {
     const response = NextResponse.json(
@@ -53,8 +81,12 @@ export async function GET(request: NextRequest): Promise<Response> {
     if (idToken) {
       try {
         const claims = await verifyStoredIdToken(config, idToken);
+        const user = await enrichWithBackendProfile(
+          mapClaimsToAuthUser(claims),
+          accessToken,
+        );
         return NextResponse.json(
-          { user: mapClaimsToAuthUser(claims) },
+          { user },
           { status: 200, headers: NO_STORE },
         );
       } catch (e) {
@@ -71,8 +103,13 @@ export async function GET(request: NextRequest): Promise<Response> {
     const refreshed = await refreshAccessToken(config, refreshToken);
     if (!refreshed.id_token) return unauthorized();
     const claims = await verifyStoredIdToken(config, refreshed.id_token);
+    // Use the freshly refreshed access token, not the (possibly stale) cookie.
+    const user = await enrichWithBackendProfile(
+      mapClaimsToAuthUser(claims),
+      refreshed.access_token,
+    );
     const response = NextResponse.json(
-      { user: mapClaimsToAuthUser(claims) },
+      { user },
       { status: 200, headers: NO_STORE },
     );
     setTokenCookies(response, refreshed);

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -21,7 +21,9 @@ const NO_STORE = { "Cache-Control": "no-store" } as const;
 // Layers the backend-owned profile (pictureUrl/pictureSource/role/lastLoginAt)
 // on top of the id_token-derived user. The backend call is best-effort: an
 // unreachable/misconfigured backend must not break login, since the
-// id_token alone is already a valid, verified session.
+// id_token alone is already a valid, verified session. Identity fields
+// (id/email/name/username) stay sourced from the verified id_token — the
+// backend call only ever adds fields the id_token can't carry.
 async function enrichWithBackendProfile(
   user: AuthUser,
   accessToken: string | null,
@@ -31,10 +33,6 @@ async function enrichWithBackendProfile(
   if (!backendUser) return user;
   return {
     ...user,
-    id: backendUser.id,
-    email: backendUser.email,
-    name: backendUser.name,
-    username: backendUser.username,
     avatarUrl: backendUser.pictureUrl ?? user.avatarUrl,
     pictureSource: backendUser.pictureSource,
     role: backendUser.role ?? user.role,
@@ -78,7 +76,12 @@ export async function GET(request: NextRequest): Promise<Response> {
     const config = getLogtoConfig();
 
     // Try the stored id_token first (signature + iss/aud/exp; no nonce here).
-    if (idToken) {
+    // Require accessToken too: if it's missing/expired (shorter-lived cookie
+    // than id_token) but idToken is still valid, fall through to the refresh
+    // block below rather than returning a session with no bearer — otherwise
+    // every other authed endpoint (favorites, backend enrichment) 401s until
+    // the id_token itself expires and forces a refresh.
+    if (idToken && accessToken) {
       try {
         const claims = await verifyStoredIdToken(config, idToken);
         const user = await enrichWithBackendProfile(

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -24,7 +24,7 @@ const NO_STORE = { "Cache-Control": "no-store" } as const;
 // id_token alone is already a valid, verified session. Identity fields
 // (id/email/name/username) stay sourced from the verified id_token — the
 // backend call only ever adds fields the id_token can't carry.
-async function enrichWithBackendProfile(
+export async function enrichWithBackendProfile(
   user: AuthUser,
   accessToken: string | null,
 ): Promise<AuthUser> {
@@ -72,26 +72,33 @@ export async function GET(request: NextRequest): Promise<Response> {
       : NextResponse.json({ user: null }, { status: 401, headers: NO_STORE });
   }
 
+  // Set once a verified id_token yields a base user. A missing/failed refresh
+  // below must never log this session out if this is non-null — the id_token
+  // is already a valid, verified session on its own; a stale/absent access
+  // token only means enrichment (and access-token restoration) isn't possible
+  // right now.
+  let user: AuthUser | null = null;
+
   try {
     const config = getLogtoConfig();
 
     // Try the stored id_token first (signature + iss/aud/exp; no nonce here).
-    // Require accessToken too: if it's missing/expired (shorter-lived cookie
-    // than id_token) but idToken is still valid, fall through to the refresh
-    // block below rather than returning a session with no bearer — otherwise
-    // every other authed endpoint (favorites, backend enrichment) 401s until
-    // the id_token itself expires and forces a refresh.
-    if (idToken && accessToken) {
+    if (idToken) {
       try {
         const claims = await verifyStoredIdToken(config, idToken);
-        const user = await enrichWithBackendProfile(
-          mapClaimsToAuthUser(claims),
-          accessToken,
-        );
-        return NextResponse.json(
-          { user },
-          { status: 200, headers: NO_STORE },
-        );
+        user = mapClaimsToAuthUser(claims);
+        // accessToken may be missing/expired (shorter-lived cookie than
+        // id_token) even though the id_token itself is still valid — fall
+        // through to the refresh block to restore it instead of returning a
+        // session with no bearer, which would 401 every other authed
+        // endpoint (favorites, backend enrichment) until the id_token itself
+        // expires and forces a refresh.
+        if (accessToken) {
+          return NextResponse.json(
+            { user: await enrichWithBackendProfile(user, accessToken) },
+            { status: 200, headers: NO_STORE },
+          );
+        }
       } catch (e) {
         // A transient verification failure (JWKS unreachable) must NOT log the
         // user out — let it bubble to the 503 path. Only definitive failures
@@ -100,27 +107,35 @@ export async function GET(request: NextRequest): Promise<Response> {
       }
     }
 
-    if (!refreshToken) return unauthorized();
+    if (!refreshToken) {
+      if (user) return NextResponse.json({ user }, { status: 200, headers: NO_STORE });
+      return unauthorized();
+    }
 
     // Refresh → new tokens (incl. a fresh id_token) → derive the user from it.
     const refreshed = await refreshAccessToken(config, refreshToken);
-    if (!refreshed.id_token) return unauthorized();
+    if (!refreshed.id_token) {
+      if (user) return NextResponse.json({ user }, { status: 200, headers: NO_STORE });
+      return unauthorized();
+    }
     const claims = await verifyStoredIdToken(config, refreshed.id_token);
     // Use the freshly refreshed access token, not the (possibly stale) cookie.
-    const user = await enrichWithBackendProfile(
+    const refreshedUser = await enrichWithBackendProfile(
       mapClaimsToAuthUser(claims),
       refreshed.access_token,
     );
     const response = NextResponse.json(
-      { user },
+      { user: refreshedUser },
       { status: 200, headers: NO_STORE },
     );
     setTokenCookies(response, refreshed);
     return response;
   } catch (e) {
     const status = (e as { status?: number })?.status;
-    // Definitive auth failure (e.g. refresh token revoked/expired) → log out.
+    // Definitive auth failure (e.g. refresh token revoked/expired). Only log
+    // out if we never had a valid id_token-derived session to fall back on.
     if (status === 400 || status === 401 || status === 403) {
+      if (user) return NextResponse.json({ user }, { status: 200, headers: NO_STORE });
       return unauthorized();
     }
     // Transient (5xx, network, timeout): keep the session, signal retry.

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -27,7 +27,10 @@ export async function getAuthenticatedUserExternal(
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (!response.ok) {
-      console.error(`getAuthenticatedUserExternal: HTTP ${response.status}`);
+      const body = await response.text().catch(() => "<unreadable>");
+      console.error(
+        `getAuthenticatedUserExternal: HTTP ${response.status} — ${body}`
+      );
       return null;
     }
     return parseAuthenticatedUser(await response.json());

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -1,12 +1,41 @@
 import { fetchWithHmac } from "./fetch-wrapper";
-import { parseUserPublic } from "@lib/validation/user";
+import { parseAuthenticatedUser, parseUserPublic } from "@lib/validation/user";
 import { parsePagedEvents } from "@lib/validation/event";
 import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
-import type { UserPublicResponseDTO } from "types/api/user";
+import type { AuthenticatedUserDTO, UserPublicResponseDTO } from "types/api/user";
 import type {
   EventSummaryResponseDTO,
   PagedResponseDTO,
 } from "types/api/event";
+
+/**
+ * Authenticated session profile: GET /api/auth/me. Backend-owned fields
+ * (pictureUrl/pictureSource/role/lastLoginAt) that the Logto id_token can't
+ * carry — the id_token has no concept of an in-app avatar upload or login
+ * audit trail. Returns null on any failure so the caller can fall back to
+ * the id_token-derived user rather than breaking the session.
+ */
+export async function getAuthenticatedUserExternal(
+  accessToken: string
+): Promise<AuthenticatedUserDTO | null> {
+  if (!accessToken) return null;
+  if (!isApiUrlConfigured()) return null;
+  const apiUrl = getApiUrl();
+
+  try {
+    const response = await fetchWithHmac(`${apiUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!response.ok) {
+      console.error(`getAuthenticatedUserExternal: HTTP ${response.status}`);
+      return null;
+    }
+    return parseAuthenticatedUser(await response.json());
+  } catch (error) {
+    console.error("getAuthenticatedUserExternal: failed", error);
+    return null;
+  }
+}
 
 export async function getUserByUsernameExternal(
   username: string

--- a/lib/validation/user.ts
+++ b/lib/validation/user.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { UserPublicResponseDTO } from "types/api/user";
+import type { AuthenticatedUserDTO, UserPublicResponseDTO } from "types/api/user";
 
 export const UserPublicResponseDTOSchema = z.object({
   id: z.string(),
@@ -13,6 +13,28 @@ export function parseUserPublic(
   const result = UserPublicResponseDTOSchema.safeParse(input);
   if (!result.success) {
     console.error("parseUserPublic: invalid payload", result.error);
+    return null;
+  }
+  return result.data;
+}
+
+export const AuthenticatedUserDTOSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  name: z.string(),
+  username: z.string(),
+  pictureUrl: z.string().optional(),
+  pictureSource: z.enum(["LOGTO", "CUSTOM"]).optional(),
+  role: z.enum(["USER", "ADMIN", "ORGANIZATION"]).optional(),
+  lastLoginAt: z.string().optional(),
+});
+
+export function parseAuthenticatedUser(
+  input: unknown
+): AuthenticatedUserDTO | null {
+  const result = AuthenticatedUserDTOSchema.safeParse(input);
+  if (!result.success) {
+    console.error("parseAuthenticatedUser: invalid payload", result.error);
     return null;
   }
   return result.data;

--- a/lib/validation/user.ts
+++ b/lib/validation/user.ts
@@ -23,10 +23,18 @@ export const AuthenticatedUserDTOSchema = z.object({
   email: z.string(),
   name: z.string(),
   username: z.string(),
-  pictureUrl: z.string().optional(),
-  pictureSource: z.enum(["LOGTO", "CUSTOM"]).optional(),
-  role: z.enum(["USER", "ADMIN", "ORGANIZATION"]).optional(),
-  lastLoginAt: z.string().optional(),
+  // .nullish() (not .optional()): the backend serializes unset fields as an
+  // explicit `null`, not an omitted key — .optional() alone rejects that.
+  pictureUrl: z.string().nullish().transform((v) => v ?? undefined),
+  pictureSource: z
+    .enum(["LOGTO", "CUSTOM"])
+    .nullish()
+    .transform((v) => v ?? undefined),
+  role: z
+    .enum(["USER", "ADMIN", "ORGANIZATION"])
+    .nullish()
+    .transform((v) => v ?? undefined),
+  lastLoginAt: z.string().nullish().transform((v) => v ?? undefined),
 });
 
 export function parseAuthenticatedUser(

--- a/test/auth-me-enrichment.test.ts
+++ b/test/auth-me-enrichment.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as usersExternal from "@lib/api/users-external";
+import { enrichWithBackendProfile } from "@app/api/auth/me/route";
+import type { AuthUser } from "types/auth";
+
+vi.mock("@lib/api/users-external", () => ({
+  getAuthenticatedUserExternal: vi.fn(),
+}));
+
+const mockGetAuthenticatedUserExternal = vi.mocked(
+  usersExternal.getAuthenticatedUserExternal,
+);
+
+const idTokenUser: AuthUser = {
+  id: "logto-sub",
+  email: "gerard@example.com",
+  name: "Gerard",
+  username: "gerard_rovellat",
+  avatarUrl: "https://logto.example.com/avatar.png",
+  role: "USER",
+  emailVerified: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("enrichWithBackendProfile", () => {
+  it("returns the id_token-derived user unchanged without an access token", async () => {
+    const result = await enrichWithBackendProfile(idTokenUser, null);
+    expect(result).toEqual(idTokenUser);
+    expect(mockGetAuthenticatedUserExternal).not.toHaveBeenCalled();
+  });
+
+  it("returns the id_token-derived user unchanged when the backend call fails", async () => {
+    mockGetAuthenticatedUserExternal.mockResolvedValue(null);
+    const result = await enrichWithBackendProfile(idTokenUser, "token");
+    expect(result).toEqual(idTokenUser);
+  });
+
+  it("keeps id/email/name/username from the verified id_token, layers backend-owned fields", async () => {
+    mockGetAuthenticatedUserExternal.mockResolvedValue({
+      id: "backend-uuid",
+      email: "backend@example.com",
+      name: "Backend Name",
+      username: "backend_username",
+      pictureUrl: "https://cdn.example.com/avatar.png",
+      pictureSource: "CUSTOM",
+      role: "ADMIN",
+      lastLoginAt: "2026-07-02T10:00:00Z",
+    });
+
+    const result = await enrichWithBackendProfile(idTokenUser, "token");
+
+    expect(result).toEqual({
+      ...idTokenUser,
+      avatarUrl: "https://cdn.example.com/avatar.png",
+      pictureSource: "CUSTOM",
+      role: "ADMIN",
+      lastLoginAt: "2026-07-02T10:00:00Z",
+    });
+  });
+
+  it("falls back to the id_token's avatarUrl/role when the backend omits them", async () => {
+    mockGetAuthenticatedUserExternal.mockResolvedValue({
+      id: "backend-uuid",
+      email: "backend@example.com",
+      name: "Backend Name",
+      username: "backend_username",
+    });
+
+    const result = await enrichWithBackendProfile(idTokenUser, "token");
+
+    expect(result.avatarUrl).toBe(idTokenUser.avatarUrl);
+    expect(result.role).toBe(idTokenUser.role);
+    expect(result.pictureSource).toBeUndefined();
+    expect(result.lastLoginAt).toBeUndefined();
+  });
+});

--- a/test/users-external.test.ts
+++ b/test/users-external.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as fetchWrapper from "../lib/api/fetch-wrapper";
-import { getUserEventsExternal } from "../lib/api/users-external";
+import {
+  getAuthenticatedUserExternal,
+  getUserEventsExternal,
+} from "../lib/api/users-external";
 
 vi.mock("../lib/api/fetch-wrapper", () => ({
   fetchWithHmac: vi.fn(),
@@ -25,6 +28,17 @@ function pagedResponse(
     json: () => Promise.resolve(data),
   } as Response;
 }
+
+const authenticatedUserDTO = {
+  id: "orqbhkjfs6re",
+  email: "gerard.rovellat@gmail.com",
+  name: "gerard_rovellat",
+  username: "gerard_rovellat",
+  pictureUrl: "https://cdn.example.com/avatar.png",
+  pictureSource: "LOGTO",
+  role: "USER",
+  lastLoginAt: "2026-07-02T10:00:00Z",
+};
 
 const emptyPage = {
   content: [],
@@ -81,5 +95,48 @@ describe("getUserEventsExternal", () => {
     const result = await getUserEventsExternal("sala-apolo");
     expect(result.content).toEqual([]);
     expect(result.last).toBe(true);
+  });
+});
+
+describe("getAuthenticatedUserExternal", () => {
+  it("requests /auth/me with a bearer token", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(authenticatedUserDTO));
+
+    await getAuthenticatedUserExternal("some-access-token");
+
+    expect(mockFetchWithHmac).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetchWithHmac.mock.calls[0];
+    expect(url).toContain("/auth/me");
+    expect((options?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer some-access-token",
+    );
+  });
+
+  it("returns the backend profile fields on success", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(authenticatedUserDTO));
+
+    const result = await getAuthenticatedUserExternal("some-access-token");
+
+    expect(result).toEqual(authenticatedUserDTO);
+  });
+
+  it("returns null (no fetch) without an access token", async () => {
+    const result = await getAuthenticatedUserExternal("");
+    expect(result).toBeNull();
+    expect(mockFetchWithHmac).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the backend responds with an error", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(null, 500));
+    const result = await getAuthenticatedUserExternal("some-access-token");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on a malformed payload (no throw)", async () => {
+    mockFetchWithHmac.mockResolvedValue(
+      pagedResponse({ unexpected: "shape" }, 200),
+    );
+    const result = await getAuthenticatedUserExternal("some-access-token");
+    expect(result).toBeNull();
   });
 });

--- a/test/users-external.test.ts
+++ b/test/users-external.test.ts
@@ -133,6 +133,12 @@ describe("getAuthenticatedUserExternal", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null (no throw) on a network failure", async () => {
+    mockFetchWithHmac.mockRejectedValueOnce(new Error("network failure"));
+    const result = await getAuthenticatedUserExternal("some-access-token");
+    expect(result).toBeNull();
+  });
+
   it("returns null on a malformed payload (no throw)", async () => {
     mockFetchWithHmac.mockResolvedValue(
       pagedResponse({ unexpected: "shape" }, 200),

--- a/test/users-external.test.ts
+++ b/test/users-external.test.ts
@@ -26,6 +26,7 @@ function pagedResponse(
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
   } as Response;
 }
 
@@ -138,5 +139,32 @@ describe("getAuthenticatedUserExternal", () => {
     );
     const result = await getAuthenticatedUserExternal("some-access-token");
     expect(result).toBeNull();
+  });
+
+  it("normalizes explicit nulls on optional fields to undefined", async () => {
+    // The backend serializes unset optional fields as `null`, not an omitted
+    // key — the schema must accept that shape, not just a missing key.
+    mockFetchWithHmac.mockResolvedValue(
+      pagedResponse({
+        ...authenticatedUserDTO,
+        pictureUrl: null,
+        pictureSource: null,
+        role: null,
+        lastLoginAt: null,
+      }),
+    );
+
+    const result = await getAuthenticatedUserExternal("some-access-token");
+
+    expect(result).toEqual({
+      id: authenticatedUserDTO.id,
+      email: authenticatedUserDTO.email,
+      name: authenticatedUserDTO.name,
+      username: authenticatedUserDTO.username,
+      pictureUrl: undefined,
+      pictureSource: undefined,
+      role: undefined,
+      lastLoginAt: undefined,
+    });
   });
 });

--- a/types/api/user.ts
+++ b/types/api/user.ts
@@ -4,3 +4,17 @@ export interface UserPublicResponseDTO {
   name: string;
   username: string;
 }
+
+export type PictureSource = "LOGTO" | "CUSTOM";
+
+/** Backend DTO: GET /api/auth/me response (authenticated session profile). */
+export interface AuthenticatedUserDTO {
+  id: string;
+  email: string;
+  name: string;
+  username: string;
+  pictureUrl?: string;
+  pictureSource?: PictureSource;
+  role?: "USER" | "ADMIN" | "ORGANIZATION";
+  lastLoginAt?: string;
+}

--- a/types/api/user.ts
+++ b/types/api/user.ts
@@ -1,3 +1,5 @@
+import type { AuthRole } from "../auth";
+
 /** Backend DTO: GET /api/users/{username} response */
 export interface UserPublicResponseDTO {
   id: string;
@@ -15,6 +17,6 @@ export interface AuthenticatedUserDTO {
   username: string;
   pictureUrl?: string;
   pictureSource?: PictureSource;
-  role?: "USER" | "ADMIN" | "ORGANIZATION";
+  role?: AuthRole;
   lastLoginAt?: string;
 }

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,3 +1,5 @@
+import type { PictureSource } from "./api/user";
+
 export type AuthRole = "USER" | "ADMIN" | "ORGANIZATION";
 
 export interface AuthUser {
@@ -8,6 +10,9 @@ export interface AuthUser {
   avatarUrl?: string;
   role?: AuthRole;
   emailVerified?: boolean;
+  // Backend-owned fields (GET /api/auth/me) — absent until enrichment succeeds.
+  pictureSource?: PictureSource;
+  lastLoginAt?: string;
 }
 
 export type AuthStatus = "loading" | "authenticated" | "unauthenticated";


### PR DESCRIPTION
## Summary
- `/api/auth/me` derived the session user entirely from the Logto id_token, so backend-owned profile fields (`pictureUrl`, `pictureSource`, `role`, `lastLoginAt`) never reached the frontend — the backend's `GET /api/auth/me` was never called.
- Layer the backend profile on top of the id_token-derived user (bearer = access token cookie, HMAC-signed, same pattern as `lib/api/favorites-external.ts`). Verified the contract against the live OpenAPI spec at `api-preproduction.esdeveniments.cat/v3/api-docs`.
- Best-effort: an unreachable/misconfigured backend falls back to the id_token-derived user rather than breaking login.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test` (full suite, 2009/2009 passing)
- [x] New unit tests for `getAuthenticatedUserExternal` (bearer header, success, no-token, 5xx, malformed payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriches `/api/auth/me` by layering backend `/auth/me` fields into the id_token user so the frontend gets avatar source, role, and last login. Improves session resilience: if the access token is missing or refresh fails, keep the id_token-derived session and skip enrichment; use a refreshed bearer when available.

- **New Features**
  - Added `getAuthenticatedUserExternal` (Bearer via `fetchWithHmac`), `parseAuthenticatedUser` schema that accepts `null` and normalizes to `undefined`, and `AuthenticatedUserDTO` using `AuthRole`.
  - Introduced `enrichWithBackendProfile` and updated `/api/auth/me` to merge `avatarUrl`/`pictureSource`/`role`/`lastLoginAt` while preserving identity fields from the verified id_token. Falls through to refresh to restore cookies; never logs out solely due to an unrestorable access token.
  - Tests: new unit tests for merge/fallback logic, network failures, and external call behavior.

<sup>Written for commit 1745ef162cbc0d18b15ecf848fc5f280fd075951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

