### PR TITLE
Surface Logto invalid-credentials errors in publish E2E login

### DIFF
--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -84,6 +84,7 @@ async function loginViaUI(page: Page) {
           "verify the account exists and its email is verified in the preproduction Logto " +
           "tenant, and that the `staging` GitHub environment secret matches its password " +
           "(see scripts/e2e-staging-setup.sh).",
+        { cause: timeoutError },
       );
     }
     throw timeoutError;

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -61,13 +61,33 @@ async function loginViaUI(page: Page) {
     .click();
 
   // Wait until Logto redirects back to the app (off the auth domain / OIDC).
-  await page.waitForURL(
-    (url) =>
-      !/\/oidc\//.test(url.pathname) &&
-      !url.host.startsWith("auth-") &&
-      !url.pathname.includes("/iniciar-sessio"),
-    { timeout: 30_000 },
-  );
+  try {
+    await page.waitForURL(
+      (url) =>
+        !/\/oidc\//.test(url.pathname) &&
+        !url.host.startsWith("auth-") &&
+        !url.pathname.includes("/iniciar-sessio"),
+      { timeout: 30_000 },
+    );
+  } catch (timeoutError) {
+    // A stuck-on-Logto timeout is ambiguous by itself — surface the actual
+    // reason (usually a stale/unverified test-user password) instead of a
+    // bare "Timeout 30000ms exceeded" that sends the next person spelunking
+    // through API response logs.
+    const invalidCredentials = page
+      .getByText(/incorrect account or password|invalid.?credentials/i)
+      .first();
+    if (await invalidCredentials.isVisible().catch(() => false)) {
+      throw new Error(
+        "Logto rejected E2E_STAGING_EMAIL/E2E_STAGING_PASSWORD (\"Incorrect account or " +
+          "password\"). This is a staging test-user credentials problem, not an app bug — " +
+          "verify the account exists and its email is verified in the preproduction Logto " +
+          "tenant, and that the `staging` GitHub environment secret matches its password " +
+          "(see scripts/e2e-staging-setup.sh).",
+      );
+    }
+    throw timeoutError;
+  }
 }
 
 /** Delete event via API (direct fetch with cookies from browser context) */


### PR DESCRIPTION
## Summary

- Investigated the "E2E Integration (preproduction)" nightly workflow, which has failed on all 4 runs since it was added (Jul 2–5). The failure is not a code regression: `loginViaUI()` in `e2e/publish-integration.spec.ts` times out waiting for Logto to redirect back to the app.
- The real cause is only visible in the API response logs printed during the test: Logto's hosted sign-in rejects `E2E_STAGING_EMAIL`/`E2E_STAGING_PASSWORD` with `422 session.invalid_credentials — "Incorrect account or password."` This is a staging test-user/secrets problem (see the setup notes in `scripts/e2e-staging-setup.sh`), not something fixable in application code — it needs someone with Logto preproduction admin access to verify/reset the test user.
- What this PR *does* fix in code: `loginViaUI()` now detects that inline Logto error on timeout and throws a clear, actionable message instead of a bare `TimeoutError: page.waitForURL: Timeout 30000ms exceeded`, so the next CI failure is self-explanatory without digging through logs.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes (no new warnings/errors introduced)
- [ ] Re-run the "E2E Integration (preproduction)" workflow after the staging Logto test-user credentials are fixed, to confirm the flow passes end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01HBGxEURKAUnuuaUDuKeRWM)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface Logto invalid-credentials errors in the publish E2E login so failures are clear instead of timing out. If credentials are rejected, the error points to `E2E_STAGING_EMAIL`/`E2E_STAGING_PASSWORD` and preserves the original timeout as the cause.

- **Bug Fixes**
  - In `loginViaUI()`, on redirect timeout, detect Logto “Incorrect account or password”/“invalid credentials” and throw a clear error with the original `waitForURL` timeout as `cause`; otherwise rethrow the timeout.

<sup>Written for commit 2926757a5e4cd9419f1bc40f7269efb9aa04d865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved login flow checks during the publishing integration test.
  * If sign-in fails, the test now reports a clearer error when invalid credentials are detected, helping identify staging login issues faster.
  * If the failure is unrelated to credentials, the original timeout error is still shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->