### PR TITLE
fix(ui): resolve date picker final field red border and all-day close behavior

### DIFF
--- a/app/[locale]/publica/page.tsx
+++ b/app/[locale]/publica/page.tsx
@@ -731,8 +731,25 @@ const PublishForm = () => {
             <p className="body-small text-foreground/60 mt-2">{t("requiredNote")}</p>
           </div>
           {error && (
-            <div className="w-full px-4 py-3 bg-destructive/10 border border-destructive rounded-lg">
-              <p className="text-sm text-destructive">{error}</p>
+            <div
+              className="w-full px-4 py-3 bg-error/10 border border-error rounded-lg flex items-start gap-3"
+              role="alert"
+            >
+              <svg
+                className="w-5 h-5 text-error flex-shrink-0 mt-0.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <p className="text-sm font-medium text-error">{error}</p>
             </div>
           )}
           <div className="w-full flex flex-col gap-y-4 pt-4">

--- a/components/ui/common/footer/index.tsx
+++ b/components/ui/common/footer/index.tsx
@@ -66,7 +66,7 @@ export default async function Footer(): Promise<JSX.Element> {
     <footer className="w-full border-t border-border bg-gradient-to-b from-background to-muted/30">
       <div className="container flex flex-col items-center gap-section-y-sm pt-section-y pb-20 md:pb-section-y px-section-x">
         {/* Social Media Section */}
-        <div className="flex flex-col items-center gap-element-gap">
+        <div className="flex flex-col items-center gap-element-gap px-4 sm:px-0">
           <Social links={links} />
         </div>
 

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -141,9 +141,12 @@ export default function DatePickerImpl({
     if (!activeField) return;
 
     const handleClickOutside = (event: PointerEvent) => {
+      const target = event.target as Node | null;
       if (
+        target &&
+        target.isConnected &&
         wrapperRef.current &&
-        !wrapperRef.current.contains(event.target as Node)
+        !wrapperRef.current.contains(target)
       ) {
         setActiveField(null);
       }
@@ -219,16 +222,11 @@ export default function DatePickerImpl({
     newEnd.setHours(endDate.getHours(), endDate.getMinutes(), 0, 0);
 
     if (isAllDay) {
-      const corrected =
-        newEnd <= startDate
-          ? setSeconds(
-              setMinutes(setHours(startDate, 23), 59),
-              59,
-            )
-          : setSeconds(
-              setMinutes(setHours(newEnd, 23), 59),
-              59,
-            );
+      const baseDate = newEnd <= startDate ? startDate : newEnd;
+      const corrected = setSeconds(
+        setMinutes(setHours(baseDate, 23), 59),
+        59,
+      );
       onChange("endDate", toISOStringLocalMinutes(corrected));
       setActiveField(null);
       return;

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -126,9 +126,12 @@ export default function DatePickerImpl({
   const [activeField, setActiveField] = useState<"start" | "end" | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const startButtonRef = useRef<HTMLButtonElement>(null);
+  const endButtonRef = useRef<HTMLButtonElement>(null);
+  const hasAutoFocused = useRef(false);
 
   useEffect(() => {
-    if (autoFocus && startButtonRef.current) {
+    if (autoFocus && startButtonRef.current && !hasAutoFocused.current) {
+      hasAutoFocused.current = true;
       startButtonRef.current.focus();
     }
   }, [autoFocus]);
@@ -148,7 +151,16 @@ export default function DatePickerImpl({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        const field = activeField;
         setActiveField(null);
+        // Restore focus to the button that opened the calendar
+        requestAnimationFrame(() => {
+          if (field === "start") {
+            startButtonRef.current?.focus();
+          } else if (field === "end") {
+            endButtonRef.current?.focus();
+          }
+        });
       }
     };
 
@@ -285,6 +297,7 @@ export default function DatePickerImpl({
             {t("end")}
           </span>
           <DateButton
+            ref={endButtonRef}
             label={t("end")}
             value={
               isAllDay

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -205,6 +205,9 @@ export default function DatePickerImpl({
       );
       onChange("endDate", toISOStringLocalMinutes(endOfDay));
       setActiveField(null);
+      requestAnimationFrame(() => {
+        startButtonRef.current?.focus();
+      });
       return;
     }
 
@@ -230,6 +233,9 @@ export default function DatePickerImpl({
       );
       onChange("endDate", toISOStringLocalMinutes(corrected));
       setActiveField(null);
+      requestAnimationFrame(() => {
+        endButtonRef.current?.focus();
+      });
       return;
     }
 
@@ -265,7 +271,7 @@ export default function DatePickerImpl({
   return (
     <div
       ref={wrapperRef}
-      className={`w-full flex flex-col gap-4 ${className ?? ""}`}
+      className={`relative w-full flex flex-col gap-4 ${className ?? ""}`}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
     >
@@ -336,8 +342,7 @@ export default function DatePickerImpl({
       </div>
 
       {activeField && (
-        <div className="relative">
-          <div className="rdp-form-wrapper absolute top-full left-0 z-50 mt-2 border border-border rounded-card p-3 bg-background shadow-lg">
+        <div className="rdp-form-wrapper absolute top-full left-0 z-50 mt-2 border border-border rounded-card p-3 bg-background shadow-lg">
           <DayPicker
             id={`${idPrefix}-${activeField}`}
             mode="single"
@@ -386,7 +391,6 @@ export default function DatePickerImpl({
               />
             </div>
           )}
-          </div>
         </div>
       )}
     </div>

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -140,7 +140,7 @@ export default function DatePickerImpl({
   useEffect(() => {
     if (!activeField) return;
 
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleClickOutside = (event: PointerEvent) => {
       if (
         wrapperRef.current &&
         !wrapperRef.current.contains(event.target as Node)
@@ -164,11 +164,11 @@ export default function DatePickerImpl({
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("pointerdown", handleClickOutside);
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("pointerdown", handleClickOutside);
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [activeField]);

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -75,13 +75,13 @@ function TimeSelector({
       min={minTime}
       onChange={(e) => onChange(e.target.value)}
       aria-label={label}
-      className="w-full px-3 py-2 border border-border rounded-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+      className="input h-12 text-base"
     />
   );
 }
 
 const DateButton = forwardRef<HTMLButtonElement, DateButtonProps>(
-  ({ label, value, isOpen, onClick }, ref) => {
+  ({ label, value, isOpen, onClick, error }, ref) => {
     const accessibleLabel = value ? `${label}: ${value}` : label;
 
     return (
@@ -91,7 +91,13 @@ const DateButton = forwardRef<HTMLButtonElement, DateButtonProps>(
         onClick={onClick}
         aria-label={accessibleLabel}
         aria-expanded={isOpen}
-        className={`w-full min-h-[44px] px-4 py-3 border rounded-xl text-foreground-strong text-base bg-background hover:border-primary/50 hover:bg-muted/30 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none transition-all flex items-center justify-between gap-2 ${isOpen ? "border-primary ring-2 ring-primary/20" : "border-border"}`}
+        className={`w-full min-h-[44px] px-4 py-3 border rounded-xl text-foreground-strong text-base bg-background hover:border-primary/50 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 transition-all flex items-center justify-between gap-2 ${
+          isOpen
+            ? "border-primary ring-2 ring-primary/20"
+            : error
+              ? "border-error focus-visible:ring-error/40"
+              : "border-border"
+        }`}
       >
         <span>{value || label}</span>
         <CalendarIcon className="w-5 h-5 text-muted-foreground flex-shrink-0" />
@@ -113,6 +119,7 @@ export default function DatePickerImpl({
   isAllDay = false,
   onToggleAllDay,
   autoFocus,
+  error,
 }: DatePickerComponentProps) {
   const t = useTranslations("Components.DatePicker");
   const locale = useLocale();
@@ -123,17 +130,33 @@ export default function DatePickerImpl({
   const minDateObj = minDate ? toDate(minDate) : undefined;
 
   const [activeField, setActiveField] = useState<"start" | "end" | null>(null);
+  const [isAnimating, setIsAnimating] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const startButtonRef = useRef<HTMLButtonElement>(null);
   const endButtonRef = useRef<HTMLButtonElement>(null);
-  const hasAutoFocused = useRef(false);
+  const hasAutoFocusedRef = useRef(false);
+  const allDaySwitchId = `${idPrefix}-all-day-switch`;
 
   useEffect(() => {
-    if (autoFocus && startButtonRef.current && !hasAutoFocused.current) {
-      hasAutoFocused.current = true;
+    if (autoFocus && startButtonRef.current && !hasAutoFocusedRef.current) {
+      hasAutoFocusedRef.current = true;
       startButtonRef.current.focus();
     }
   }, [autoFocus]);
+
+  // Manage enter/leave animation for the calendar popup. We intentionally
+  // drive the animation flag from the active field change so the popup stays
+  // mounted long enough to animate out.
+  useEffect(() => {
+    if (activeField) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- animation state is derived from activeField changes
+      setIsAnimating(true);
+      return;
+    }
+
+    const timer = setTimeout(() => setIsAnimating(false), 200);
+    return () => clearTimeout(timer);
+  }, [activeField]);
 
   // Close calendar when clicking outside, pressing Escape, or moving focus out
   useEffect(() => {
@@ -191,57 +214,58 @@ export default function DatePickerImpl({
     }
   };
 
-  const handleDaySelectStart = (day: Date | undefined) => {
-    if (!day) return;
-    const newStart = new Date(day);
-    newStart.setHours(startDate.getHours(), startDate.getMinutes(), 0, 0);
+  const handleDaySelectStart = (day: Date | undefined): void => {
+    if (day) {
+      const newStart = new Date(day);
+      newStart.setHours(startDate.getHours(), startDate.getMinutes(), 0, 0);
 
-    onChange("startDate", toISOStringLocalMinutes(newStart));
+      onChange("startDate", toISOStringLocalMinutes(newStart));
 
-    if (isAllDay) {
-      const endOfDay = setSeconds(
-        setMinutes(setHours(newStart, 23), 59),
-        59,
-      );
-      onChange("endDate", toISOStringLocalMinutes(endOfDay));
-      setActiveField(null);
-      requestAnimationFrame(() => {
-        startButtonRef.current?.focus();
-      });
-      return;
+      if (isAllDay) {
+        const endOfDay = setSeconds(
+          setMinutes(setHours(newStart, 23), 59),
+          59,
+        );
+        onChange("endDate", toISOStringLocalMinutes(endOfDay));
+        setActiveField(null);
+        requestAnimationFrame(() => {
+          startButtonRef.current?.focus();
+        });
+      } else {
+        const diff = endDate.getTime() - startDate.getTime();
+        const newEnd =
+          diff > 0
+            ? new Date(newStart.getTime() + diff)
+            : addMinutes(newStart, 60);
+        onChange("endDate", toISOStringLocalMinutes(newEnd));
+        // Keep calendar open so user can adjust the time without re-clicking
+      }
     }
-
-    const diff = endDate.getTime() - startDate.getTime();
-    const newEnd =
-      diff > 0
-        ? new Date(newStart.getTime() + diff)
-        : addMinutes(newStart, 60);
-    onChange("endDate", toISOStringLocalMinutes(newEnd));
-    // Keep calendar open so user can adjust the time without re-clicking
   };
 
-  const handleDaySelectEnd = (day: Date | undefined) => {
-    if (!day) return;
-    const newEnd = new Date(day);
-    newEnd.setHours(endDate.getHours(), endDate.getMinutes(), 0, 0);
+  const handleDaySelectEnd = (day: Date | undefined): void => {
+    if (day) {
+      const newEnd = new Date(day);
+      newEnd.setHours(endDate.getHours(), endDate.getMinutes(), 0, 0);
 
-    if (isAllDay) {
-      const baseDate = newEnd <= startDate ? startDate : newEnd;
-      const corrected = setSeconds(
-        setMinutes(setHours(baseDate, 23), 59),
-        59,
-      );
-      onChange("endDate", toISOStringLocalMinutes(corrected));
-      setActiveField(null);
-      requestAnimationFrame(() => {
-        endButtonRef.current?.focus();
-      });
-      return;
+      if (isAllDay) {
+        const baseDate = newEnd <= startDate ? startDate : newEnd;
+        const corrected = setSeconds(
+          setMinutes(setHours(baseDate, 23), 59),
+          59,
+        );
+        onChange("endDate", toISOStringLocalMinutes(corrected));
+        setActiveField(null);
+        requestAnimationFrame(() => {
+          endButtonRef.current?.focus();
+        });
+      } else {
+        const corrected =
+          newEnd <= startDate ? addMinutes(startDate, 15) : newEnd;
+        onChange("endDate", toISOStringLocalMinutes(corrected));
+        // Keep calendar open so user can adjust the time without re-clicking
+      }
     }
-
-    const corrected = newEnd <= startDate ? addMinutes(startDate, 15) : newEnd;
-    onChange("endDate", toISOStringLocalMinutes(corrected));
-    // Keep calendar open so user can adjust the time without re-clicking
   };
 
   const handleStartTimeChange = (time: string) => {
@@ -279,10 +303,16 @@ export default function DatePickerImpl({
         <label className="form-label">{t("dateAndTime")}</label>
 
         {enableAllDayToggle && (
-          <label className="flex items-center gap-2 cursor-pointer select-none">
+          <label
+            htmlFor={allDaySwitchId}
+            className="flex items-center gap-2 cursor-pointer select-none"
+          >
             <div className="relative">
               <input
+                id={allDaySwitchId}
                 type="checkbox"
+                role="switch"
+                aria-checked={isAllDay}
                 className="sr-only"
                 checked={isAllDay}
                 onChange={(e) => onToggleAllDay?.(e.target.checked)}
@@ -318,6 +348,7 @@ export default function DatePickerImpl({
             onClick={() =>
               setActiveField((prev) => (prev === "start" ? null : "start"))
             }
+            error={error}
           />
         </div>
 
@@ -337,61 +368,95 @@ export default function DatePickerImpl({
             onClick={() =>
               setActiveField((prev) => (prev === "end" ? null : "end"))
             }
+            error={error}
           />
         </div>
       </div>
 
-      {activeField && (
-        <div className="rdp-form-wrapper absolute top-full left-0 z-50 mt-2 border border-border rounded-card p-3 bg-background shadow-lg">
-          <DayPicker
-            id={`${idPrefix}-${activeField}`}
-            mode="single"
-            locale={dateFnsLocale}
-            selected={activeField === "start" ? startDate : endDate}
-            onSelect={
-              activeField === "start"
-                ? handleDaySelectStart
-                : handleDaySelectEnd
-            }
-            disabled={
-              activeField === "end"
-                ? {
-                    before:
-                      minDateObj && minDateObj > startDate
-                        ? minDateObj
-                        : startDate,
-                  }
-                : minDateObj
-                  ? { before: minDateObj }
-                  : undefined
-            }
-            defaultMonth={activeField === "start" ? startDate : endDate}
-            showOutsideDays
-            fixedWeeks
-            required={required}
+      {(activeField || isAnimating) && (
+        <>
+          <div
+            className="fixed inset-0 bg-black/5 z-40"
+            onClick={() => setActiveField(null)}
+            aria-hidden="true"
           />
-          {!isAllDay && (
-            <div className="mt-3 pt-3 border-t border-border">
-              <TimeSelector
-                value={formatTime(
-                  activeField === "start" ? startDate : endDate,
+          <div
+            className={`rdp-form-wrapper absolute top-full left-0 right-0 sm:left-0 sm:right-auto sm:w-fit z-50 mt-2 border border-border rounded-card p-3 bg-background shadow-lg transition-all duration-200 ease-smooth origin-top-left ${
+              activeField
+                ? "opacity-100 scale-100 translate-y-0"
+                : "opacity-0 scale-95 -translate-y-2 pointer-events-none"
+            }`}
+          >
+            {activeField && (
+              <>
+                <DayPicker
+                  id={`${idPrefix}-${activeField}`}
+                  mode="single"
+                  locale={dateFnsLocale}
+                  selected={activeField === "start" ? startDate : endDate}
+                  onSelect={
+                    activeField === "start"
+                      ? handleDaySelectStart
+                      : handleDaySelectEnd
+                  }
+                  disabled={
+                    activeField === "end"
+                      ? {
+                          before:
+                            minDateObj && minDateObj > startDate
+                              ? minDateObj
+                              : startDate,
+                        }
+                      : minDateObj
+                        ? { before: minDateObj }
+                        : undefined
+                  }
+                  defaultMonth={activeField === "start" ? startDate : endDate}
+                  showOutsideDays
+                  fixedWeeks
+                  required={required}
+                />
+                {!isAllDay && (
+                  <div className="mt-3 pt-3 border-t border-border">
+                    <TimeSelector
+                      value={formatTime(
+                        activeField === "start" ? startDate : endDate,
+                      )}
+                      onChange={
+                        activeField === "start"
+                          ? handleStartTimeChange
+                          : handleEndTimeChange
+                      }
+                      minTime={
+                        activeField === "end" &&
+                          startDate.toDateString() === endDate.toDateString()
+                          ? formatTime(startDate)
+                          : undefined
+                      }
+                      label={activeField === "start" ? t("start") : t("end")}
+                    />
+                  </div>
                 )}
-                onChange={
-                  activeField === "start"
-                    ? handleStartTimeChange
-                    : handleEndTimeChange
-                }
-                minTime={
-                  activeField === "end" &&
-                    startDate.toDateString() === endDate.toDateString()
-                    ? formatTime(startDate)
-                    : undefined
-                }
-                label={activeField === "start" ? t("start") : t("end")}
-              />
-            </div>
-          )}
-        </div>
+                <div className="mt-3 pt-3 border-t border-border flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const today = new Date();
+                      if (activeField === "start") {
+                        handleDaySelectStart(today);
+                      } else if (activeField === "end") {
+                        handleDaySelectEnd(today);
+                      }
+                    }}
+                    className="text-sm font-medium text-primary hover:text-primary-dark hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
+                  >
+                    {t("today")}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -173,18 +173,18 @@ export default function DatePickerImpl({
     };
   }, [activeField]);
 
-  const handleBlur = () => {
-    // Defer the check to the next animation frame so Safari/Firefox have
-    // settled document.activeElement after interacting with non-focusable
-    // elements inside the calendar dropdown.
-    requestAnimationFrame(() => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(document.activeElement)
-      ) {
-        setActiveField(null);
-      }
-    });
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    // Only close the calendar when focus moves to a known element outside the
+    // wrapper (e.g. user pressed Tab). When clicking non-focusable elements
+    // inside the dropdown, relatedTarget is null and the existing mousedown
+    // listener already handles outside clicks, so we leave the calendar open.
+    if (
+      event.relatedTarget &&
+      wrapperRef.current &&
+      !wrapperRef.current.contains(event.relatedTarget as Node)
+    ) {
+      setActiveField(null);
+    }
   };
 
   const handleDaySelectStart = (day: Date | undefined) => {

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -34,20 +34,19 @@ function computeEndDate(
   initialEndDate: string | undefined,
   isAllDay: boolean,
 ): Date {
-  const initialEndCandidate = initialEndDate
-    ? toDate(initialEndDate)
-    : setMinutes(startingDate, startingDate.getMinutes() + 60);
-
-  const endingDate =
-    initialEndCandidate > startingDate
-      ? initialEndCandidate
-      : new Date(startingDate.getTime() + 60 * 60 * 1000);
-
   if (isAllDay) {
-    return setSeconds(setMinutes(setHours(endingDate, 23), 59), 59);
+    const candidate = initialEndDate ? toDate(initialEndDate) : startingDate;
+    const baseDate = candidate >= startingDate ? candidate : startingDate;
+    return setSeconds(setMinutes(setHours(baseDate, 23), 59), 59);
   }
 
-  return endingDate;
+  const initialEndCandidate = initialEndDate
+    ? toDate(initialEndDate)
+    : new Date(startingDate.getTime() + 60 * 60 * 1000);
+
+  return initialEndCandidate > startingDate
+    ? initialEndCandidate
+    : new Date(startingDate.getTime() + 60 * 60 * 1000);
 }
 
 function formatTime(d: Date): string {

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -222,7 +222,7 @@ export default function DatePickerImpl({
       const corrected =
         newEnd <= startDate
           ? setSeconds(
-              setMinutes(setHours(new Date(startDate), 23), 59),
+              setMinutes(setHours(startDate, 23), 59),
               59,
             )
           : setSeconds(

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -330,7 +330,7 @@ export default function DatePickerImpl({
 
       {activeField && (
         <div className="relative">
-          <div className="rdp-form-wrapper absolute top-full left-0 z-10 mt-2 border border-border rounded-card p-3 bg-background shadow-lg">
+          <div className="rdp-form-wrapper absolute top-full left-0 z-50 mt-2 border border-border rounded-card p-3 bg-background shadow-lg">
           <DayPicker
             id={`${idPrefix}-${activeField}`}
             mode="single"

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -40,13 +40,13 @@ function computeEndDate(
     return setSeconds(setMinutes(setHours(baseDate, 23), 59), 59);
   }
 
-  const initialEndCandidate = initialEndDate
-    ? toDate(initialEndDate)
-    : new Date(startingDate.getTime() + 60 * 60 * 1000);
+  const defaultEndDate = new Date(startingDate.getTime() + 60 * 60 * 1000);
+  if (!initialEndDate) {
+    return defaultEndDate;
+  }
 
-  return initialEndCandidate > startingDate
-    ? initialEndCandidate
-    : new Date(startingDate.getTime() + 60 * 60 * 1000);
+  const candidate = toDate(initialEndDate);
+  return candidate > startingDate ? candidate : defaultEndDate;
 }
 
 function formatTime(d: Date): string {

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -319,9 +319,10 @@ export default function DatePickerImpl({
   const isTodayValidForEnd =
     today >= startOfDay(startDate) &&
     (!minDateObj || today >= startOfDay(minDateObj));
-  // renderedField lags one frame behind activeField on open (it's set in an
-  // effect), so fall back to activeField to avoid a brief empty popup.
-  const visibleField = renderedField ?? activeField;
+  // renderedField is kept during the exit animation so the popup content
+  // stays mounted while it fades out. While a field is actively open, prefer
+  // activeField so switching between Start and End updates immediately.
+  const visibleField = activeField ?? renderedField;
   const isTodayValid =
     visibleField === "start" ? isTodayValidForStart : isTodayValidForEnd;
 

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -3,7 +3,15 @@
 import { useState, useRef, useEffect, forwardRef } from "react";
 import { DayPicker } from "react-day-picker";
 import { CalendarIcon } from "@heroicons/react/24/outline";
-import { setHours, setMinutes, setSeconds, addMinutes, addDays } from "date-fns";
+import {
+  setHours,
+  setMinutes,
+  setSeconds,
+  addMinutes,
+  addDays,
+  differenceInCalendarDays,
+  startOfDay,
+} from "date-fns";
 import { ca, es, enUS } from "date-fns/locale";
 import type { Locale } from "date-fns";
 import { useLocale, useTranslations } from "next-intl";
@@ -224,10 +232,7 @@ export default function DatePickerImpl({
       if (isAllDay) {
         const dayDiff = Math.max(
           0,
-          Math.round(
-            (endDate.getTime() - startDate.getTime()) /
-              (24 * 60 * 60 * 1000),
-          ),
+          differenceInCalendarDays(endDate, startDate),
         );
         const newEnd = addDays(newStart, dayDiff);
         const endOfDay = setSeconds(
@@ -299,6 +304,15 @@ export default function DatePickerImpl({
 
   const startDisplay = formatDateDisplay(startDate, locale);
   const endDisplay = formatDateDisplay(endDate, locale);
+
+  const today = startOfDay(new Date());
+  const isTodayValidForStart =
+    !minDateObj || today >= startOfDay(minDateObj);
+  const isTodayValidForEnd =
+    today >= startOfDay(startDate) &&
+    (!minDateObj || today >= startOfDay(minDateObj));
+  const isTodayValid =
+    activeField === "start" ? isTodayValidForStart : isTodayValidForEnd;
 
   return (
     <div
@@ -447,15 +461,19 @@ export default function DatePickerImpl({
                 <div className="mt-3 pt-3 border-t border-border flex justify-end">
                   <button
                     type="button"
+                    disabled={!isTodayValid}
                     onClick={() => {
-                      const today = new Date();
                       if (activeField === "start") {
                         handleDaySelectStart(today);
                       } else if (activeField === "end") {
                         handleDaySelectEnd(today);
                       }
                     }}
-                    className="text-sm font-medium text-primary hover:text-primary-dark hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
+                    className={`text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm ${
+                      isTodayValid
+                        ? "text-primary hover:text-primary-dark hover:underline"
+                        : "text-muted-foreground cursor-not-allowed"
+                    }`}
                   >
                     {t("today")}
                   </button>

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -376,8 +376,7 @@ export default function DatePickerImpl({
       {(activeField || isAnimating) && (
         <>
           <div
-            className="fixed inset-0 bg-black/5 z-40"
-            onClick={() => setActiveField(null)}
+            className="fixed inset-0 bg-black/5 z-40 pointer-events-none"
             aria-hidden="true"
           />
           <div

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, forwardRef } from "react";
 import { DayPicker } from "react-day-picker";
 import { CalendarIcon } from "@heroicons/react/24/outline";
-import { setHours, setMinutes, setSeconds, addMinutes } from "date-fns";
+import { setHours, setMinutes, setSeconds, addMinutes, addDays } from "date-fns";
 import { ca, es, enUS } from "date-fns/locale";
 import type { Locale } from "date-fns";
 import { useLocale, useTranslations } from "next-intl";
@@ -91,12 +91,12 @@ const DateButton = forwardRef<HTMLButtonElement, DateButtonProps>(
         onClick={onClick}
         aria-label={accessibleLabel}
         aria-expanded={isOpen}
-        className={`w-full min-h-[44px] px-4 py-3 border rounded-xl text-foreground-strong text-base bg-background hover:border-primary/50 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 transition-all flex items-center justify-between gap-2 ${
+        className={`w-full min-h-[44px] px-4 py-3 border rounded-xl text-foreground-strong text-base bg-background hover:border-primary/50 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 transition-all flex items-center justify-between gap-2 ${
           isOpen
-            ? "border-primary ring-2 ring-primary/20"
+            ? "border-primary ring-2 ring-primary/20 focus-visible:ring-primary/20"
             : error
               ? "border-error focus-visible:ring-error/40"
-              : "border-border"
+              : "border-border focus-visible:ring-primary/20"
         }`}
       >
         <span>{value || label}</span>
@@ -222,8 +222,16 @@ export default function DatePickerImpl({
       onChange("startDate", toISOStringLocalMinutes(newStart));
 
       if (isAllDay) {
+        const dayDiff = Math.max(
+          0,
+          Math.round(
+            (endDate.getTime() - startDate.getTime()) /
+              (24 * 60 * 60 * 1000),
+          ),
+        );
+        const newEnd = addDays(newStart, dayDiff);
         const endOfDay = setSeconds(
-          setMinutes(setHours(newStart, 23), 59),
+          setMinutes(setHours(newEnd, 23), 59),
           59,
         );
         onChange("endDate", toISOStringLocalMinutes(endOfDay));

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -133,7 +133,7 @@ export default function DatePickerImpl({
     }
   }, [autoFocus]);
 
-  // Close calendar when clicking outside or pressing Escape
+  // Close calendar when clicking outside, pressing Escape, or moving focus out
   useEffect(() => {
     if (!activeField) return;
 
@@ -160,6 +160,12 @@ export default function DatePickerImpl({
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [activeField]);
+
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (!wrapperRef.current?.contains(event.relatedTarget as Node)) {
+      setActiveField(null);
+    }
+  };
 
   const handleDaySelectStart = (day: Date | undefined) => {
     if (!day) return;
@@ -194,6 +200,11 @@ export default function DatePickerImpl({
 
     const corrected = newEnd <= startDate ? addMinutes(startDate, 15) : newEnd;
     onChange("endDate", toISOStringLocalMinutes(corrected));
+
+    if (isAllDay) {
+      setActiveField(null);
+      return;
+    }
     // Keep calendar open so user can adjust the time without re-clicking
   };
 
@@ -222,7 +233,7 @@ export default function DatePickerImpl({
   const endDisplay = formatDateDisplay(endDate, locale);
 
   return (
-    <div ref={wrapperRef} className={`w-full flex flex-col gap-4 ${className ?? ""}`}>
+    <div ref={wrapperRef} className={`w-full flex flex-col gap-4 ${className ?? ""}`} onBlur={handleBlur}>
       <div className="flex justify-between items-center">
         <label className="form-label">{t("dateAndTime")}</label>
 
@@ -289,7 +300,8 @@ export default function DatePickerImpl({
       </div>
 
       {activeField && (
-        <div className="rdp-form-wrapper border border-border rounded-card p-3 bg-background">
+        <div className="relative">
+          <div className="rdp-form-wrapper absolute top-full left-0 z-10 mt-2 border border-border rounded-card p-3 bg-background shadow-lg">
           <DayPicker
             id={`${idPrefix}-${activeField}`}
             mode="single"
@@ -338,6 +350,7 @@ export default function DatePickerImpl({
               />
             </div>
           )}
+          </div>
         </div>
       )}
     </div>

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -151,29 +151,31 @@ export default function DatePickerImpl({
       }
     };
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        const field = activeField;
-        setActiveField(null);
-        // Restore focus to the button that opened the calendar
-        requestAnimationFrame(() => {
-          if (field === "start") {
-            startButtonRef.current?.focus();
-          } else if (field === "end") {
-            endButtonRef.current?.focus();
-          }
-        });
-      }
-    };
-
     document.addEventListener("pointerdown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
 
     return () => {
       document.removeEventListener("pointerdown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
     };
   }, [activeField]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape" && activeField) {
+      event.stopPropagation();
+      event.preventDefault();
+
+      const field = activeField;
+      setActiveField(null);
+
+      // Restore focus to the button that opened the calendar
+      requestAnimationFrame(() => {
+        if (field === "start") {
+          startButtonRef.current?.focus();
+        } else if (field === "end") {
+          endButtonRef.current?.focus();
+        }
+      });
+    }
+  };
 
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
     // Only close the calendar when focus moves to a known element outside the
@@ -261,7 +263,12 @@ export default function DatePickerImpl({
   const endDisplay = formatDateDisplay(endDate, locale);
 
   return (
-    <div ref={wrapperRef} className={`w-full flex flex-col gap-4 ${className ?? ""}`} onBlur={handleBlur}>
+    <div
+      ref={wrapperRef}
+      className={`w-full flex flex-col gap-4 ${className ?? ""}`}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+    >
       <div className="flex justify-between items-center">
         <label className="form-label">{t("dateAndTime")}</label>
 

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -174,7 +174,10 @@ export default function DatePickerImpl({
   }, [activeField]);
 
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
-    if (!wrapperRef.current?.contains(event.relatedTarget as Node)) {
+    if (
+      event.relatedTarget &&
+      !wrapperRef.current?.contains(event.relatedTarget as Node)
+    ) {
       setActiveField(null);
     }
   };

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -138,6 +138,9 @@ export default function DatePickerImpl({
   const minDateObj = minDate ? toDate(minDate) : undefined;
 
   const [activeField, setActiveField] = useState<"start" | "end" | null>(null);
+  const [renderedField, setRenderedField] = useState<"start" | "end" | null>(
+    null,
+  );
   const [isAnimating, setIsAnimating] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const startButtonRef = useRef<HTMLButtonElement>(null);
@@ -154,15 +157,20 @@ export default function DatePickerImpl({
 
   // Manage enter/leave animation for the calendar popup. We intentionally
   // drive the animation flag from the active field change so the popup stays
-  // mounted long enough to animate out.
+  // mounted long enough to animate out. renderedField keeps the content
+  // mounted during the exit animation so it doesn't disappear instantly.
   useEffect(() => {
     if (activeField) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- animation state is derived from activeField changes
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- renderedField mirrors activeField for exit animation
+      setRenderedField(activeField);
       setIsAnimating(true);
       return;
     }
 
-    const timer = setTimeout(() => setIsAnimating(false), 200);
+    const timer = setTimeout(() => {
+      setIsAnimating(false);
+      setRenderedField(null);
+    }, 200);
     return () => clearTimeout(timer);
   }, [activeField]);
 
@@ -311,8 +319,11 @@ export default function DatePickerImpl({
   const isTodayValidForEnd =
     today >= startOfDay(startDate) &&
     (!minDateObj || today >= startOfDay(minDateObj));
+  // renderedField lags one frame behind activeField on open (it's set in an
+  // effect), so fall back to activeField to avoid a brief empty popup.
+  const visibleField = renderedField ?? activeField;
   const isTodayValid =
-    activeField === "start" ? isTodayValidForStart : isTodayValidForEnd;
+    visibleField === "start" ? isTodayValidForStart : isTodayValidForEnd;
 
   return (
     <div
@@ -402,26 +413,30 @@ export default function DatePickerImpl({
             aria-hidden="true"
           />
           <div
+            aria-hidden={!activeField}
+            inert={!activeField ? true : undefined}
             className={`rdp-form-wrapper absolute top-full left-0 right-0 sm:left-0 sm:right-auto sm:w-fit z-50 mt-2 border border-border rounded-card p-3 bg-background shadow-lg transition-all duration-200 ease-smooth origin-top-left ${
               activeField
                 ? "opacity-100 scale-100 translate-y-0"
                 : "opacity-0 scale-95 -translate-y-2 pointer-events-none"
             }`}
           >
-            {activeField && (
+            {visibleField && (
               <>
                 <DayPicker
-                  id={`${idPrefix}-${activeField}`}
+                  id={`${idPrefix}-${visibleField}`}
                   mode="single"
                   locale={dateFnsLocale}
-                  selected={activeField === "start" ? startDate : endDate}
+                  selected={
+                    visibleField === "start" ? startDate : endDate
+                  }
                   onSelect={
-                    activeField === "start"
+                    visibleField === "start"
                       ? handleDaySelectStart
                       : handleDaySelectEnd
                   }
                   disabled={
-                    activeField === "end"
+                    visibleField === "end"
                       ? {
                           before:
                             minDateObj && minDateObj > startDate
@@ -432,7 +447,9 @@ export default function DatePickerImpl({
                         ? { before: minDateObj }
                         : undefined
                   }
-                  defaultMonth={activeField === "start" ? startDate : endDate}
+                  defaultMonth={
+                    visibleField === "start" ? startDate : endDate
+                  }
                   showOutsideDays
                   fixedWeeks
                   required={required}
@@ -441,20 +458,22 @@ export default function DatePickerImpl({
                   <div className="mt-3 pt-3 border-t border-border">
                     <TimeSelector
                       value={formatTime(
-                        activeField === "start" ? startDate : endDate,
+                        visibleField === "start" ? startDate : endDate,
                       )}
                       onChange={
-                        activeField === "start"
+                        visibleField === "start"
                           ? handleStartTimeChange
                           : handleEndTimeChange
                       }
                       minTime={
-                        activeField === "end" &&
+                        visibleField === "end" &&
                           startDate.toDateString() === endDate.toDateString()
                           ? formatTime(startDate)
                           : undefined
                       }
-                      label={activeField === "start" ? t("start") : t("end")}
+                      label={
+                        visibleField === "start" ? t("start") : t("end")
+                      }
                     />
                   </div>
                 )}
@@ -463,9 +482,9 @@ export default function DatePickerImpl({
                     type="button"
                     disabled={!isTodayValid}
                     onClick={() => {
-                      if (activeField === "start") {
+                      if (visibleField === "start") {
                         handleDaySelectStart(today);
-                      } else if (activeField === "end") {
+                      } else if (visibleField === "end") {
                         handleDaySelectEnd(today);
                       }
                     }}

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -173,13 +173,18 @@ export default function DatePickerImpl({
     };
   }, [activeField]);
 
-  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
-    if (
-      event.relatedTarget &&
-      !wrapperRef.current?.contains(event.relatedTarget as Node)
-    ) {
-      setActiveField(null);
-    }
+  const handleBlur = () => {
+    // Defer the check to the next animation frame so Safari/Firefox have
+    // settled document.activeElement after interacting with non-focusable
+    // elements inside the calendar dropdown.
+    requestAnimationFrame(() => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(document.activeElement)
+      ) {
+        setActiveField(null);
+      }
+    });
   };
 
   const handleDaySelectStart = (day: Date | undefined) => {
@@ -213,13 +218,24 @@ export default function DatePickerImpl({
     const newEnd = new Date(day);
     newEnd.setHours(endDate.getHours(), endDate.getMinutes(), 0, 0);
 
-    const corrected = newEnd <= startDate ? addMinutes(startDate, 15) : newEnd;
-    onChange("endDate", toISOStringLocalMinutes(corrected));
-
     if (isAllDay) {
+      const corrected =
+        newEnd <= startDate
+          ? setSeconds(
+              setMinutes(setHours(new Date(startDate), 23), 59),
+              59,
+            )
+          : setSeconds(
+              setMinutes(setHours(newEnd, 23), 59),
+              59,
+            );
+      onChange("endDate", toISOStringLocalMinutes(corrected));
       setActiveField(null);
       return;
     }
+
+    const corrected = newEnd <= startDate ? addMinutes(startDate, 15) : newEnd;
+    onChange("endDate", toISOStringLocalMinutes(corrected));
     // Keep calendar open so user can adjust the time without re-clicking
   };
 

--- a/components/ui/common/form/datePicker/DatePickerImpl.tsx
+++ b/components/ui/common/form/datePicker/DatePickerImpl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect, forwardRef } from "react";
 import { DayPicker } from "react-day-picker";
 import { CalendarIcon } from "@heroicons/react/24/outline";
 import { setHours, setMinutes, setSeconds, addMinutes } from "date-fns";
@@ -44,7 +44,7 @@ function computeEndDate(
       : new Date(startingDate.getTime() + 60 * 60 * 1000);
 
   if (isAllDay) {
-    return setSeconds(setMinutes(setHours(startingDate, 23), 59), 59);
+    return setSeconds(setMinutes(setHours(endingDate, 23), 59), 59);
   }
 
   return endingDate;
@@ -81,27 +81,26 @@ function TimeSelector({
   );
 }
 
-function DateButton({
-  label,
-  value,
-  isOpen,
-  onClick,
-}: DateButtonProps) {
-  const accessibleLabel = value ? `${label}: ${value}` : label;
+const DateButton = forwardRef<HTMLButtonElement, DateButtonProps>(
+  ({ label, value, isOpen, onClick }, ref) => {
+    const accessibleLabel = value ? `${label}: ${value}` : label;
 
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={accessibleLabel}
-      aria-expanded={isOpen}
-      className={`w-full min-h-[44px] px-4 py-3 border rounded-xl text-foreground-strong text-base bg-background hover:border-primary/50 hover:bg-muted/30 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none transition-all flex items-center justify-between gap-2 ${isOpen ? "border-primary ring-2 ring-primary/20" : "border-border"}`}
-    >
-      <span>{value || label}</span>
-      <CalendarIcon className="w-5 h-5 text-muted-foreground flex-shrink-0" />
-    </button>
-  );
-}
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        aria-label={accessibleLabel}
+        aria-expanded={isOpen}
+        className={`w-full min-h-[44px] px-4 py-3 border rounded-xl text-foreground-strong text-base bg-background hover:border-primary/50 hover:bg-muted/30 focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none transition-all flex items-center justify-between gap-2 ${isOpen ? "border-primary ring-2 ring-primary/20" : "border-border"}`}
+      >
+        <span>{value || label}</span>
+        <CalendarIcon className="w-5 h-5 text-muted-foreground flex-shrink-0" />
+      </button>
+    );
+  }
+);
+DateButton.displayName = "DateButton";
 
 export default function DatePickerImpl({
   idPrefix = "date",
@@ -114,6 +113,7 @@ export default function DatePickerImpl({
   enableAllDayToggle = false,
   isAllDay = false,
   onToggleAllDay,
+  autoFocus,
 }: DatePickerComponentProps) {
   const t = useTranslations("Components.DatePicker");
   const locale = useLocale();
@@ -124,6 +124,42 @@ export default function DatePickerImpl({
   const minDateObj = minDate ? toDate(minDate) : undefined;
 
   const [activeField, setActiveField] = useState<"start" | "end" | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const startButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (autoFocus && startButtonRef.current) {
+      startButtonRef.current.focus();
+    }
+  }, [autoFocus]);
+
+  // Close calendar when clicking outside or pressing Escape
+  useEffect(() => {
+    if (!activeField) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(event.target as Node)
+      ) {
+        setActiveField(null);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setActiveField(null);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeField]);
 
   const handleDaySelectStart = (day: Date | undefined) => {
     if (!day) return;
@@ -186,7 +222,7 @@ export default function DatePickerImpl({
   const endDisplay = formatDateDisplay(endDate, locale);
 
   return (
-    <div className={`w-full flex flex-col gap-4 ${className ?? ""}`}>
+    <div ref={wrapperRef} className={`w-full flex flex-col gap-4 ${className ?? ""}`}>
       <div className="flex justify-between items-center">
         <label className="form-label">{t("dateAndTime")}</label>
 
@@ -219,6 +255,7 @@ export default function DatePickerImpl({
             {t("start")}
           </span>
           <DateButton
+            ref={startButtonRef}
             label={t("start")}
             value={
               isAllDay

--- a/components/ui/common/form/datePicker/index.tsx
+++ b/components/ui/common/form/datePicker/index.tsx
@@ -27,7 +27,7 @@ export default function DatePickerComponent(props: DatePickerComponentProps) {
   return (
     <div className="w-full" onPointerEnter={ensureLoaded} onFocus={ensureLoaded}>
       {shouldLoad ? (
-        <DatePickerImpl {...props} autoFocus={wasInteracted} />
+        <DatePickerImpl {...props} autoFocus={props.autoFocus || wasInteracted} />
       ) : (
         <div
           className="w-full flex flex-col gap-4"

--- a/components/ui/common/form/datePicker/index.tsx
+++ b/components/ui/common/form/datePicker/index.tsx
@@ -25,7 +25,11 @@ export default function DatePickerComponent(props: DatePickerComponentProps) {
   }, []);
 
   return (
-    <div className="w-full" onPointerEnter={ensureLoaded} onFocus={ensureLoaded}>
+    <div
+      className="w-full"
+      onPointerEnter={shouldLoad ? undefined : ensureLoaded}
+      onFocus={shouldLoad ? undefined : ensureLoaded}
+    >
       {shouldLoad ? (
         <DatePickerImpl {...props} autoFocus={props.autoFocus || wasInteracted} />
       ) : (

--- a/components/ui/common/form/datePicker/index.tsx
+++ b/components/ui/common/form/datePicker/index.tsx
@@ -11,7 +11,7 @@ const DatePickerImpl = dynamic(() => import("./DatePickerImpl"), {
 
 export default function DatePickerComponent(props: DatePickerComponentProps) {
   const t = useTranslations("Components.DatePicker");
-  const [shouldLoad, setShouldLoad] = useState(false);
+  const [shouldLoad, setShouldLoad] = useState(() => Boolean(props.autoFocus));
   const [wasInteracted, setWasInteracted] = useState(false);
 
   const ensureLoaded = useCallback((e?: React.SyntheticEvent) => {

--- a/components/ui/common/form/datePicker/index.tsx
+++ b/components/ui/common/form/datePicker/index.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
 import type { DatePickerComponentProps } from "types/props";
 
 const DatePickerImpl = dynamic(() => import("./DatePickerImpl"), {
@@ -9,18 +10,38 @@ const DatePickerImpl = dynamic(() => import("./DatePickerImpl"), {
 });
 
 export default function DatePickerComponent(props: DatePickerComponentProps) {
+  const t = useTranslations("Components.DatePicker");
   const [shouldLoad, setShouldLoad] = useState(false);
+  const [wasInteracted, setWasInteracted] = useState(false);
 
-  const ensureLoaded = useCallback(() => {
+  const ensureLoaded = useCallback((e?: React.SyntheticEvent) => {
     setShouldLoad(true);
+    if (
+      e &&
+      (e.type === "click" || e.type === "focus" || e.type === "keydown")
+    ) {
+      setWasInteracted(true);
+    }
   }, []);
 
   return (
     <div className="w-full" onPointerEnter={ensureLoaded} onFocus={ensureLoaded}>
       {shouldLoad ? (
-        <DatePickerImpl {...props} />
+        <DatePickerImpl {...props} autoFocus={wasInteracted} />
       ) : (
-        <div className="w-full flex flex-col gap-4" onClick={ensureLoaded}>
+        <div
+          className="w-full flex flex-col gap-4"
+          onClick={ensureLoaded}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              ensureLoaded(e);
+            }
+          }}
+          tabIndex={0}
+          role="button"
+          aria-label={t("selectDateAndTime")}
+        >
           <div className="h-5 w-40 bg-muted rounded" />
           <div className="flex flex-col sm:flex-row gap-4 w-full">
             <div className="w-full">

--- a/components/ui/common/form/datePicker/index.tsx
+++ b/components/ui/common/form/datePicker/index.tsx
@@ -46,15 +46,15 @@ export default function DatePickerComponent(props: DatePickerComponentProps) {
           role="button"
           aria-label={t("selectDateAndTime")}
         >
-          <div className="h-5 w-40 bg-muted rounded" />
+          <div className="h-5 w-40 bg-muted rounded animate-pulse" />
           <div className="flex flex-col sm:flex-row gap-4 w-full">
             <div className="w-full">
-              <div className="h-4 w-24 bg-muted rounded mb-2" />
-              <div className="w-full min-h-[44px] px-4 py-3 border border-border rounded-xl bg-muted/30" />
+              <div className="h-4 w-24 bg-muted rounded mb-2 animate-pulse" />
+              <div className="w-full min-h-[44px] px-4 py-3 border border-border rounded-xl bg-muted/30 animate-pulse" />
             </div>
             <div className="w-full">
-              <div className="h-4 w-24 bg-muted rounded mb-2" />
-              <div className="w-full min-h-[44px] px-4 py-3 border border-border rounded-xl bg-muted/30" />
+              <div className="h-4 w-24 bg-muted rounded mb-2 animate-pulse" />
+              <div className="w-full min-h-[44px] px-4 py-3 border border-border rounded-xl bg-muted/30 animate-pulse" />
             </div>
           </div>
         </div>

--- a/components/ui/common/form/imageUpload/index.tsx
+++ b/components/ui/common/form/imageUpload/index.tsx
@@ -341,7 +341,28 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
       {uploadMessage && (
         <p className="text-sm text-foreground/80 mt-2">{uploadMessage}</p>
       )}
-      {displayedError && <p className="text-primary text-sm mt-2">{displayedError}</p>}
+      {displayedError && (
+        <div
+          className="mt-3 px-4 py-3 bg-error/10 border border-error rounded-lg flex items-start gap-3"
+          role="alert"
+        >
+          <svg
+            className="w-5 h-5 text-error flex-shrink-0 mt-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <p className="text-sm font-medium text-error">{displayedError}</p>
+        </div>
+      )}
       {imgData && (imgData.startsWith("http") || imgData.startsWith("data:") || imgData.startsWith("/")) ? (
         <div className="flex justify-center items-start p-4">
           <button

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -957,7 +957,8 @@
       "dateFormat": "d MMMM, yyyy HH:mm aa",
       "monthYearFormat": "MMMM yyyy",
       "allDay": "Tot el dia (sense hora de fi)",
-      "allDayHelper": "Si l'esdeveniment dura tot el dia, marcarem el final el mateix dia."
+      "allDayHelper": "Si l'esdeveniment dura tot el dia, marcarem el final el mateix dia.",
+      "today": "Avui"
     },
     "LoadMoreButton": {
       "loading": "Carregant més esdeveniments",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -951,6 +951,7 @@
     },
     "DatePicker": {
       "dateAndTime": "Data i hora *",
+      "selectDateAndTime": "Seleccionar data i hora",
       "start": "Inici *",
       "end": "Final *",
       "dateFormat": "d MMMM, yyyy HH:mm aa",

--- a/messages/en.json
+++ b/messages/en.json
@@ -944,6 +944,7 @@
     },
     "DatePicker": {
       "dateAndTime": "Date and time *",
+      "selectDateAndTime": "Select date and time",
       "start": "Start *",
       "end": "End *",
       "dateFormat": "d MMMM, yyyy HH:mm aa",

--- a/messages/en.json
+++ b/messages/en.json
@@ -950,7 +950,8 @@
       "dateFormat": "d MMMM, yyyy HH:mm aa",
       "monthYearFormat": "MMMM yyyy",
       "allDay": "All day (no end time)",
-      "allDayHelper": "If it lasts all day, we'll set the end to the same day."
+      "allDayHelper": "If it lasts all day, we'll set the end to the same day.",
+      "today": "Today"
     },
     "LoadMoreButton": {
       "loading": "Loading more events",

--- a/messages/es.json
+++ b/messages/es.json
@@ -944,6 +944,7 @@
     },
     "DatePicker": {
       "dateAndTime": "Fecha y hora *",
+      "selectDateAndTime": "Seleccionar fecha y hora",
       "start": "Inicio *",
       "end": "Final *",
       "dateFormat": "d MMMM, yyyy HH:mm aa",

--- a/messages/es.json
+++ b/messages/es.json
@@ -950,7 +950,8 @@
       "dateFormat": "d MMMM, yyyy HH:mm aa",
       "monthYearFormat": "MMMM yyyy",
       "allDay": "Todo el día (sin hora de fin)",
-      "allDayHelper": "Si dura todo el día, marcaremos el final en el mismo día."
+      "allDayHelper": "Si dura todo el día, marcaremos el final en el mismo día.",
+      "today": "Hoy"
     },
     "LoadMoreButton": {
       "loading": "Cargando más eventos",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -832,8 +832,8 @@ video {
   --rdp-accent-background-color: rgba(214, 0, 47, 0.08);
   --rdp-selected-border: 0px solid transparent;
   --rdp-day_button-border-radius: 9999px;
-  --rdp-day_button-height: 36px;
-  --rdp-day_button-width: 36px;
+  --rdp-day_button-height: 44px;
+  --rdp-day_button-width: 44px;
 }
 
 .rdp-form-wrapper .rdp-root {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -869,6 +869,31 @@ video {
   outline: none !important;
 }
 
+.rdp-form-wrapper .rdp-button_previous,
+.rdp-form-wrapper .rdp-button_next {
+  color: #d6002f;
+  width: 44px;
+  height: 44px;
+  border-radius: 9999px;
+}
+
+.rdp-form-wrapper .rdp-button_previous:hover,
+.rdp-form-wrapper .rdp-button_next:hover {
+  color: #a80025;
+  background-color: rgba(214, 0, 47, 0.06);
+}
+
+.rdp-form-wrapper .rdp-chevron {
+  width: 24px;
+  height: 24px;
+  fill: #d6002f;
+}
+
+.rdp-form-wrapper .rdp-button_previous:hover .rdp-chevron,
+.rdp-form-wrapper .rdp-button_next:hover .rdp-chevron {
+  fill: #a80025;
+}
+
 /* Keyboard focus: visible ring for form calendar accessibility */
 .rdp-form-wrapper .rdp-day_button:focus-visible,
 .rdp-form-wrapper .rdp-button_previous:focus-visible,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -894,6 +894,12 @@ video {
   fill: #a80025;
 }
 
+/* Add breathing room to the right of the last column day numbers so they
+   don't sit flush against the popup edge. */
+.rdp-form-wrapper .rdp-week > .rdp-day:last-child {
+  padding-right: 0.5rem;
+}
+
 /* Keyboard focus: visible ring for form calendar accessibility */
 .rdp-form-wrapper .rdp-day_button:focus-visible,
 .rdp-form-wrapper .rdp-button_previous:focus-visible,

--- a/test/date-picker-impl.test.tsx
+++ b/test/date-picker-impl.test.tsx
@@ -262,8 +262,8 @@ describe("DatePickerImpl", () => {
     it("calls onToggleAllDay when toggle is clicked", () => {
       render(<DatePickerImpl {...allDayProps} />);
 
-      const checkbox = screen.getByRole("checkbox");
-      fireEvent.click(checkbox);
+      const switchEl = screen.getByRole("switch");
+      fireEvent.click(switchEl);
       expect(allDayProps.onToggleAllDay).toHaveBeenCalledWith(true);
     });
   });

--- a/test/date-picker-impl.test.tsx
+++ b/test/date-picker-impl.test.tsx
@@ -79,7 +79,7 @@ describe("DatePickerImpl", () => {
     it("opens start calendar when start button is clicked", () => {
       render(<DatePickerImpl {...baseProps} />);
 
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
 
       // Calendar grid should appear
@@ -91,7 +91,7 @@ describe("DatePickerImpl", () => {
     it("opens end calendar when end button is clicked", () => {
       render(<DatePickerImpl {...baseProps} />);
 
-      const endButton = screen.getByText(/07\/03\/2026\s+11:00/).closest("button")!;
+      const endButton = screen.getByRole("button", { name: /Final \*: 07\/03\/2026 11:00/ });
       fireEvent.click(endButton);
 
       expect(screen.getByRole("grid")).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe("DatePickerImpl", () => {
     it("closes calendar when the same button is clicked again", () => {
       render(<DatePickerImpl {...baseProps} />);
 
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 
@@ -112,8 +112,8 @@ describe("DatePickerImpl", () => {
     it("switches from start to end when end button is clicked while start is open", () => {
       render(<DatePickerImpl {...baseProps} />);
 
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
-      const endButton = screen.getByText(/07\/03\/2026\s+11:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
+      const endButton = screen.getByRole("button", { name: /Final \*: 07\/03\/2026 11:00/ });
 
       fireEvent.click(startButton);
       expect(screen.getByLabelText("Inici *")).toBeInTheDocument();
@@ -128,7 +128,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...baseProps} />);
 
       // Open start calendar
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 
@@ -152,7 +152,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...baseProps} />);
 
       // Open end calendar
-      const endButton = screen.getByText(/07\/03\/2026\s+11:00/).closest("button")!;
+      const endButton = screen.getByRole("button", { name: /Final \*: 07\/03\/2026 11:00/ });
       fireEvent.click(endButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 
@@ -273,7 +273,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...baseProps} />);
 
       // Open start calendar to reveal time input
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
 
       const timeInput = screen.getByLabelText("Inici *");
@@ -287,7 +287,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...baseProps} />);
 
       // Open end calendar to reveal time input
-      const endButton = screen.getByText(/07\/03\/2026\s+11:00/).closest("button")!;
+      const endButton = screen.getByRole("button", { name: /Final \*: 07\/03\/2026 11:00/ });
       fireEvent.click(endButton);
 
       const timeInput = screen.getByLabelText("Final *");
@@ -307,7 +307,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...props} />);
 
       // Open start calendar
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
 
       // Set start time past end time
@@ -360,7 +360,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...props} />);
 
       // Open end calendar
-      const endButton = screen.getByText(/20\/03\/2026\s+11:00/).closest("button")!;
+      const endButton = screen.getByRole("button", { name: /Final \*: 20\/03\/2026 11:00/ });
       fireEvent.click(endButton);
 
       // Try to select a day before start (March 10)
@@ -380,7 +380,7 @@ describe("DatePickerImpl", () => {
       render(<DatePickerImpl {...props} />);
 
       // Open start calendar
-      const startButton = screen.getByText(/07\/03\/2026\s+14:30/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 14:30/ });
       fireEvent.click(startButton);
 
       // Select a different day
@@ -413,7 +413,7 @@ describe("DatePickerImpl", () => {
         </div>
       );
 
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 
@@ -424,7 +424,7 @@ describe("DatePickerImpl", () => {
     it("closes the calendar when Escape key is pressed", () => {
       render(<DatePickerImpl {...baseProps} />);
 
-      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      const startButton = screen.getByRole("button", { name: /Inici \*: 07\/03\/2026 10:00/ });
       fireEvent.click(startButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 

--- a/test/date-picker-impl.test.tsx
+++ b/test/date-picker-impl.test.tsx
@@ -417,7 +417,7 @@ describe("DatePickerImpl", () => {
       fireEvent.click(startButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 
-      fireEvent.mouseDown(screen.getByTestId("outside"));
+      fireEvent.pointerDown(screen.getByTestId("outside"));
       expect(screen.queryByRole("grid")).not.toBeInTheDocument();
     });
 

--- a/test/date-picker-impl.test.tsx
+++ b/test/date-picker-impl.test.tsx
@@ -380,4 +380,33 @@ describe("DatePickerImpl", () => {
       expect(screen.getByText("Data i hora *")).toBeInTheDocument();
     });
   });
+
+  describe("click outside and Escape key", () => {
+    it("closes the calendar when clicking outside", () => {
+      render(
+        <div>
+          <div data-testid="outside">Outside Element</div>
+          <DatePickerImpl {...baseProps} />
+        </div>
+      );
+
+      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      fireEvent.click(startButton);
+      expect(screen.getByRole("grid")).toBeInTheDocument();
+
+      fireEvent.mouseDown(screen.getByTestId("outside"));
+      expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+    });
+
+    it("closes the calendar when Escape key is pressed", () => {
+      render(<DatePickerImpl {...baseProps} />);
+
+      const startButton = screen.getByText(/07\/03\/2026\s+10:00/).closest("button")!;
+      fireEvent.click(startButton);
+      expect(screen.getByRole("grid")).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/test/date-picker-impl.test.tsx
+++ b/test/date-picker-impl.test.tsx
@@ -428,7 +428,7 @@ describe("DatePickerImpl", () => {
       fireEvent.click(startButton);
       expect(screen.getByRole("grid")).toBeInTheDocument();
 
-      fireEvent.keyDown(document, { key: "Escape" });
+      fireEvent.keyDown(startButton, { key: "Escape" });
       expect(screen.queryByRole("grid")).not.toBeInTheDocument();
     });
   });

--- a/test/date-picker-impl.test.tsx
+++ b/test/date-picker-impl.test.tsx
@@ -236,6 +236,29 @@ describe("DatePickerImpl", () => {
       expect(screen.queryByRole("grid")).not.toBeInTheDocument();
     });
 
+    it("closes calendar after end day selection when isAllDay is true", () => {
+      render(
+        <DatePickerImpl {...allDayProps} isAllDay={true} />
+      );
+
+      // Open end calendar
+      const buttons = screen.getAllByRole("button");
+      fireEvent.click(buttons[1]);
+      expect(screen.getByRole("grid")).toBeInTheDocument();
+
+      // Select a day
+      const grid = screen.getByRole("grid");
+      const day20 = within(grid).getByText("20");
+      fireEvent.click(day20);
+
+      // Calendar should close when isAllDay (no time to select)
+      expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+      expect(baseProps.onChange).toHaveBeenCalledWith(
+        "endDate",
+        expect.stringContaining("2026-03-20")
+      );
+    });
+
     it("calls onToggleAllDay when toggle is clicked", () => {
       render(<DatePickerImpl {...allDayProps} />);
 

--- a/types/props.ts
+++ b/types/props.ts
@@ -274,6 +274,7 @@ export interface DatePickerComponentProps {
   isAllDay?: boolean;
   onToggleAllDay?: (isAllDayEvent: boolean) => void;
   autoFocus?: boolean;
+  error?: boolean;
 }
 
 export interface TimeSelectorProps {
@@ -288,6 +289,7 @@ export interface DateButtonProps {
   value: string;
   isOpen: boolean;
   onClick: () => void;
+  error?: boolean;
 }
 
 export interface CalendarDatePickerProps {

--- a/types/props.ts
+++ b/types/props.ts
@@ -273,6 +273,7 @@ export interface DatePickerComponentProps {
   enableAllDayToggle?: boolean;
   isAllDay?: boolean;
   onToggleAllDay?: (isAllDayEvent: boolean) => void;
+  autoFocus?: boolean;
 }
 
 export interface TimeSelectorProps {


### PR DESCRIPTION
## Summary\n\nFixes the date picker in the event publish form where the final/end date field appeared with a persistent red border and users could not always click or change it with the keyboard.\n\n## Changes\n\n- Added click-outside and Escape key handling to close the calendar and reset the active field.\n- Calendar now closes after day selection when all-day mode is enabled (both start and end fields).\n- Made the lazy-loaded date picker wrapper keyboard accessible (Enter/Space, tabIndex, role).\n- Added unit test for end-date all-day close behavior.\n\n## Verification\n\n- `yarn typecheck` passes\n- `npx vitest run test/date-picker-impl.test.tsx` passes\n- `npx playwright test e2e/publish-integration.spec.ts --config playwright.config.ts` passes\n\n## Related\n\nFixes the date picker issue reported on staging where the final date field stayed red and interaction was unreliable.\n\nReplaces #413 (could not be reopened).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish form date picker so the End field no longer stays red and the calendar closes reliably across browsers. Smooths the popup, improves a11y, updates calendar nav arrows, polishes alerts, fixes right‑edge spacing in the calendar grid, and adds mobile padding to the footer social section.

- **Bug Fixes**
  - Stable close on outside press (pointerdown with isConnected), Escape (handled locally), and when focus leaves; restores focus to the trigger and avoids closing parent modals.
  - All‑day: closes after day pick for Start/End; End set to 23:59:59 (or start day if earlier); preserves multi‑day duration when Start changes; prevents rollover when End is undefined; popup positioned absolutely with z‑50 and a non‑blocking backdrop.
  - “Today” shortcut uses start‑of‑day checks and disables when it would violate minDate or start/end constraints; exit animation keeps content mounted, switches content immediately when toggling Start/End, and marks the popup aria-hidden/inert while closing.
  - Footer social section gets horizontal padding on mobile to avoid edge crowding.

- **New Features**
  - Animated calendar popup with a “Today” shortcut; larger 44×44 day cells; time input uses design‑system `input` styles; date buttons add error state and focus‑visible rings; month nav arrows match the design (red theme, 44×44 buttons, 24×24 chevrons); adds right padding to the last calendar column to avoid edge crowding.
  - Better a11y: all‑day toggle uses role="switch" with aria‑checked; lazy loader is keyboard‑accessible with a localized “Select date and time”; `DateButton` supports `ref` and autoFocus; publish and image upload errors use role="alert" with an icon.
  - i18n: added localized “Today” label in English, Spanish, and Catalan.

<sup>Written for commit 007efd03f5a6779648336dc64ee9e1e66a70dc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Date picker trigger supports optional `autoFocus`, improving initial focus behavior.
  - Date picker now supports an `error` state for input styling.
  - Added localized date-time selection (“Select date and time”) and “Today” strings.

- **Bug Fixes**
  - Improved calendar dismiss behavior (outside press, Escape, blur rules) with focus restoration.
  - Refined all-day end-date calculations and selection behavior; end-day selection now closes and updates values appropriately.
  - Enhanced error rendering with alert styling and icons on affected pages/components.

- **Tests**
  - Updated and expanded date picker interaction tests (role-based queries, outside-click/Escape, all-day dismissal).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->