### PR TITLE
fix(favorites): send required period param on the list endpoint

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -166,6 +166,22 @@ If a future endpoint needs the same split, translate at the API-layer
 boundary rather than renaming the domain-level `status` everywhere it's
 threaded through.
 
+**Update, 2026-07-31:** the fix above only touched `users-external.ts`. It
+missed `/api/users/me/favorites/events` — the plan's own finding #2 argued
+favourites didn't need a `period` split yet, so `favorites-external.ts` was
+left sending just `page`/`size`. The backend enforces `period` there too,
+live, independent of whether the frontend favourites split has shipped:
+every `listFavoriteEventsExternal` call was failing with
+`HTTP 500 "Required request parameter 'period' ... is not present"`
+(confirmed via Coolify staging logs), which `/api/favorites` turns into a
+hardcoded 502, breaking `/preferits` and — because homepage cards never
+pass `initialIsFavorite` (`components/ui/hybridEventsList/index.tsx`) and
+rely entirely on the client fetch to `/api/favorites` to learn favorite
+state — leaving homepage hearts stuck unfavorited on every fresh load.
+There is no `period=all`; `listFavoriteEventsExternal` now fetches both
+`active` and `past` and merges them, since `/preferits` needs both (display
++ `FavoritesAutoPrune`'s expired-favourite cleanup, PR #430) in one list.
+
 `upcomingEventCount`/`pastEventCount` on `UserPublicResponseDTO`
 (`lib/validation/user.ts`) are unconfirmed — still `.nullish()`, degrading to
 a label-only tab until the backend starts sending them.

--- a/lib/api/favorites-external.ts
+++ b/lib/api/favorites-external.ts
@@ -26,6 +26,41 @@ function favoritesBaseUrl(): string | null {
   return `${getApiUrl()}/users/me/favorites/events`;
 }
 
+// Backend contract confirmed live on PRE (LESSONS.md: "The profile events
+// endpoint takes period=active|past, not status=upcoming|past"): `period` is
+// required on this endpoint too, or the backend returns HTTP 500
+// "Required request parameter 'period' ... is not present". There's no
+// "all periods" value, and MAX_FAVORITES-sized single-page callers (route.ts,
+// preferits/page.tsx) need both active and past items in one merged list —
+// the page renders active events and separately prunes expired ones — so
+// fetch both periods and merge rather than picking one.
+async function fetchFavoritesPeriod(
+  base: string,
+  accessToken: string,
+  period: "active" | "past",
+  page: number,
+  size: number
+): Promise<FavoriteEventsPageDTO | null> {
+  try {
+    const query = new URLSearchParams({
+      page: String(page),
+      size: String(size),
+      period,
+    }).toString();
+    const response = await fetchWithHmac(`${base}?${query}`, {
+      headers: authHeaders(accessToken),
+    });
+    if (!response.ok) {
+      await logBackendError(`listFavoriteEventsExternal(period=${period})`, response);
+      return null;
+    }
+    return parseFavoriteEventsPage(await response.json());
+  } catch (error) {
+    console.error(`listFavoriteEventsExternal(period=${period}): failed`, error);
+    return null;
+  }
+}
+
 export async function listFavoriteEventsExternal(
   accessToken: string,
   page = 0,
@@ -34,23 +69,22 @@ export async function listFavoriteEventsExternal(
   const base = favoritesBaseUrl();
   if (!base) return null;
 
-  try {
-    const query = new URLSearchParams({
-      page: String(page),
-      size: String(size),
-    }).toString();
-    const response = await fetchWithHmac(`${base}?${query}`, {
-      headers: authHeaders(accessToken),
-    });
-    if (!response.ok) {
-      await logBackendError("listFavoriteEventsExternal", response);
-      return null;
-    }
-    return parseFavoriteEventsPage(await response.json());
-  } catch (error) {
-    console.error("listFavoriteEventsExternal: failed", error);
-    return null;
-  }
+  const [activePage, pastPage] = await Promise.all([
+    fetchFavoritesPeriod(base, accessToken, "active", page, size),
+    fetchFavoritesPeriod(base, accessToken, "past", page, size),
+  ]);
+  // Either leg failing means the list is incomplete — surface unavailable
+  // rather than a partial list that looks complete.
+  if (activePage === null || pastPage === null) return null;
+
+  return {
+    content: [...activePage.content, ...pastPage.content],
+    currentPage: page,
+    pageSize: size,
+    totalElements: activePage.totalElements + pastPage.totalElements,
+    totalPages: Math.max(activePage.totalPages, pastPage.totalPages),
+    last: activePage.last && pastPage.last,
+  };
 }
 
 export async function isFavoriteEventExternal(

--- a/lib/api/favorites-external.ts
+++ b/lib/api/favorites-external.ts
@@ -82,12 +82,19 @@ export async function listFavoriteEventsExternal(
   // rather than a partial list that looks complete.
   if (activePage === null || pastPage === null) return null;
 
+  const content = [...activePage.content, ...pastPage.content];
+  const totalElements = activePage.totalElements + pastPage.totalElements;
+  // Up to `size` items come back from each leg, so content.length can reach
+  // 2*size — pageSize must reflect that bound, not the single-leg `size`,
+  // or a caller trusting content.length <= pageSize gets burned.
+  const pageSize = size * 2;
+
   return {
-    content: [...activePage.content, ...pastPage.content],
+    content,
     currentPage: page,
-    pageSize: size,
-    totalElements: activePage.totalElements + pastPage.totalElements,
-    totalPages: Math.max(activePage.totalPages, pastPage.totalPages),
+    pageSize,
+    totalElements,
+    totalPages: pageSize > 0 ? Math.ceil(totalElements / pageSize) : 0,
     last: activePage.last && pastPage.last,
   };
 }

--- a/lib/api/favorites-external.ts
+++ b/lib/api/favorites-external.ts
@@ -61,6 +61,11 @@ async function fetchFavoritesPeriod(
   }
 }
 
+// `page`/`size` are applied identically to both period calls, then
+// concatenated — correct for the "one page holds everything" callers this
+// has today (page=0, size=MAX_FAVORITES). A caller requesting page > 0
+// would NOT get a coherent "page N of the combined list", since active and
+// past are paginated independently before merging.
 export async function listFavoriteEventsExternal(
   accessToken: string,
   page = 0,

--- a/test/favorites-external.test.ts
+++ b/test/favorites-external.test.ts
@@ -108,6 +108,32 @@ describe("listFavoriteEventsExternal", () => {
     errorSpy.mockRestore();
   });
 
+  it("reports pageSize/totalPages consistent with content when both legs are full", async () => {
+    const size = 10;
+    const activeContent = Array.from({ length: size }, (_, i) =>
+      makeEvent(`active-${i}`)
+    );
+    const pastContent = Array.from({ length: size }, (_, i) =>
+      makeEvent(`past-${i}`)
+    );
+    mockFetchWithHmac.mockImplementation(async (url) => {
+      const u = url as string;
+      if (u.includes("period=active")) {
+        return pagedResponse(page(activeContent, size));
+      }
+      return pagedResponse(page(pastContent, size));
+    });
+
+    const result = await listFavoriteEventsExternal("token", 0, size);
+
+    expect(result?.content.length).toBe(2 * size);
+    expect(result?.content.length).toBeLessThanOrEqual(result!.pageSize);
+    expect(result?.totalElements).toBe(2 * size);
+    expect(result?.totalPages).toBe(
+      Math.ceil(result!.totalElements / result!.pageSize)
+    );
+  });
+
   it("returns null when the past period call fails, even if active succeeds", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockFetchWithHmac.mockImplementation(async (url) => {

--- a/test/favorites-external.test.ts
+++ b/test/favorites-external.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fetchWrapper from "../lib/api/fetch-wrapper";
+import { listFavoriteEventsExternal } from "../lib/api/favorites-external";
+
+vi.mock("../lib/api/fetch-wrapper", () => ({
+  fetchWithHmac: vi.fn(),
+}));
+
+vi.mock("@utils/api-helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@utils/api-helpers")>()),
+  getApiUrl: () => "http://localhost:8080/api",
+  isApiUrlConfigured: () => true,
+}));
+
+const mockFetchWithHmac = vi.mocked(fetchWrapper.fetchWithHmac);
+
+function pagedResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as Response;
+}
+
+function page(content: unknown[], totalElements = content.length) {
+  return {
+    content,
+    currentPage: 0,
+    pageSize: 10,
+    totalElements,
+    totalPages: 1,
+    last: true,
+  };
+}
+
+function makeEvent(slug: string) {
+  return {
+    id: `id-${slug}`,
+    hash: `hash-${slug}`,
+    slug,
+    title: `Title ${slug}`,
+    type: "FREE" as const,
+    url: "https://example.com",
+    description: "desc",
+    imageUrl: "https://example.com/img.jpg",
+    startDate: "2030-01-01",
+    startTime: null,
+    endDate: "2030-01-02",
+    endTime: null,
+    location: "loc",
+    visits: 0,
+    origin: "MANUAL" as const,
+    categories: [],
+  };
+}
+
+const activeEvent = makeEvent("active-event");
+const pastEvent = makeEvent("past-event");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listFavoriteEventsExternal", () => {
+  it("requests both period=active and period=past", async () => {
+    mockFetchWithHmac.mockResolvedValue(pagedResponse(page([])));
+
+    await listFavoriteEventsExternal("token", 0, 10);
+
+    const urls = mockFetchWithHmac.mock.calls.map((call) => call[0] as string);
+    expect(urls.some((url) => url.includes("period=active"))).toBe(true);
+    expect(urls.some((url) => url.includes("period=past"))).toBe(true);
+  });
+
+  it("merges active and past content into one list", async () => {
+    mockFetchWithHmac.mockImplementation(async (url) => {
+      const u = url as string;
+      if (u.includes("period=active")) {
+        return pagedResponse(page([activeEvent]));
+      }
+      return pagedResponse(page([pastEvent]));
+    });
+
+    const result = await listFavoriteEventsExternal("token", 0, 10);
+
+    expect(result?.content.map((e) => e.slug)).toEqual([
+      "active-event",
+      "past-event",
+    ]);
+    expect(result?.totalElements).toBe(2);
+  });
+
+  it("returns null when the active period call fails, even if past succeeds", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetchWithHmac.mockImplementation(async (url) => {
+      const u = url as string;
+      if (u.includes("period=active")) {
+        return pagedResponse({ error: "backend_down" }, 500);
+      }
+      return pagedResponse(page([pastEvent]));
+    });
+
+    const result = await listFavoriteEventsExternal("token", 0, 10);
+
+    expect(result).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("returns null when the past period call fails, even if active succeeds", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetchWithHmac.mockImplementation(async (url) => {
+      const u = url as string;
+      if (u.includes("period=past")) {
+        return pagedResponse({ error: "backend_down" }, 500);
+      }
+      return pagedResponse(page([activeEvent]));
+    });
+
+    const result = await listFavoriteEventsExternal("token", 0, 10);
+
+    expect(result).toBeNull();
+    errorSpy.mockRestore();
+  });
+});

--- a/test/favorites-external.test.ts
+++ b/test/favorites-external.test.ts
@@ -89,7 +89,11 @@ describe("listFavoriteEventsExternal", () => {
       "active-event",
       "past-event",
     ]);
+    expect(result?.currentPage).toBe(0);
+    expect(result?.pageSize).toBe(20);
     expect(result?.totalElements).toBe(2);
+    expect(result?.totalPages).toBe(1);
+    expect(result?.last).toBe(true);
   });
 
   it("returns null when the active period call fails, even if past succeeds", async () => {


### PR DESCRIPTION
## Summary
- `listFavoriteEventsExternal` (`lib/api/favorites-external.ts`) only sent `page`/`size` to `GET /users/me/favorites/events`. The backend requires `period=active|past` there too (same contract as `/users/{username}/events`, per `LESSONS.md`), so every call was failing with `HTTP 500 "Required request parameter 'period' ... is not present"` — confirmed against live staging logs, not inferred.
- `/api/favorites` turns that failure into a hardcoded 502, which broke `/preferits` (renders the explicit error state) and left homepage hearts stuck unfavorited on every fresh page load, since homepage cards never receive `initialIsFavorite` from SSR and depend entirely on this same call to learn favorite state client-side.
- Fix fetches both `period=active` and `period=past` and merges them (no `period=all` exists), since `/preferits` needs both — for display and for `FavoritesAutoPrune`'s expired-favourite cleanup (PR #430). Either leg failing returns `null` (unavailable), matching the existing "don't pretend the list is empty" behavior.
- Added `test/favorites-external.test.ts` covering both periods being requested, merge behavior, and null-on-partial-failure.
- `LESSONS.md` updated: this was the other half of the `period` migration in `9b2d0dba`, which only touched `users-external.ts`.

## Root cause verification
Confirmed via Coolify staging app logs (not the HAR alone), every `listFavoriteEventsExternal` call in the window returns:
```
listFavoriteEventsExternal: HTTP 500 — {"statusCode":500,"message":"An error occurred","detailedMessage":"Required request parameter 'period' for method parameter type EventPeriod is not present"}
```

## Known limitation (documented inline)
`listFavoriteEventsExternal` paginates active/past independently then concatenates — correct for both current call sites (`route.ts`, `preferits/page.tsx`), which always use `page=0, size=MAX_FAVORITES`. A future caller passing `page > 0` would not get a coherent combined page.

## Test plan
- [x] `yarn typecheck`
- [x] Full suite: `yarn vitest run` (2256 tests passing)
- [x] New unit tests for the merge/failure logic (`test/favorites-external.test.ts`)
- [x] Local smoke test: `yarn dev`, guest `/api/favorites` GET/`/preferits`/homepage all 200, no runtime errors from the changed module
- [ ] Could not verify the authenticated path end-to-end against PRE — no real logged-in session available; direct backend curls 401 on the HMAC/bearer-token check before ever reaching the `period` validation, so they don't discriminate the fix. Please verify on an authenticated PRE account before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix favorites fetching by sending the required `period` param and merging `active` and `past` results with correct combined pagination. Restores `/preferits` and homepage favorite hearts that were failing due to 502s.

- **Bug Fixes**
  - Call `GET /users/me/favorites/events` with `period=active` and `period=past`, merge results; set `pageSize = size*2`, derive `totalPages` from the combined total, and set `last = active.last && past.last`.
  - Return null if either period fails; extended tests to assert both period requests, merge behavior, and pagination fields (`currentPage`, `pageSize`, `totalPages`, `last`); documented the current `page`/`size` limitation.

<sup>Written for commit ae625b1948d80ff4860bf5bde1139743ba10e699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed favorites-page loading by retrieving both active and past favorite events.
  - Restored favorite-state detection on the homepage.
  - Improved cleanup support for expired favorites.
  - Combined results and pagination information across both event periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->