### PR TITLE
fix(deploy): pin Coolify to immutable per-commit image tag

### DIFF
--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -339,9 +339,24 @@ jobs:
         # configured alone and let the webhook redeploy it as-is.
         if: needs.build-and-push.result == 'success'
         env:
-          COOLIFY_TOKEN: ${{ github.ref_name == 'main' && secrets.COOLIFY_TOKEN || secrets.COOLIFY_TOKEN_STAGING }}
-          COOLIFY_WEBHOOK_URL: ${{ github.ref_name == 'main' && secrets.COOLIFY_WEBHOOK_URL || secrets.COOLIFY_WEBHOOK_URL_STAGING }}
+          # Branch-gated in bash, not in the `&&`/`||` expression below: that
+          # pattern falls through to the staging secret whenever the main
+          # secret happens to be empty (GH Actions treats "" as falsy), which
+          # would silently PATCH the staging app on a main-branch deploy.
+          IS_MAIN: ${{ github.ref_name == 'main' }}
+          COOLIFY_TOKEN_MAIN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_TOKEN_STAGING: ${{ secrets.COOLIFY_TOKEN_STAGING }}
+          COOLIFY_WEBHOOK_URL_MAIN: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_WEBHOOK_URL_STAGING: ${{ secrets.COOLIFY_WEBHOOK_URL_STAGING }}
         run: |
+          if [ "$IS_MAIN" = "true" ]; then
+            COOLIFY_TOKEN="$COOLIFY_TOKEN_MAIN"
+            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_MAIN"
+          else
+            COOLIFY_TOKEN="$COOLIFY_TOKEN_STAGING"
+            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_STAGING"
+          fi
+
           if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
             echo "::error::COOLIFY_WEBHOOK_URL secret is required"
             exit 1
@@ -349,8 +364,11 @@ jobs:
 
           # The webhook URL is Coolify's own `POST /api/v1/deploy?uuid=...`
           # trigger — reuse its host and uuid instead of adding new secrets.
-          COOLIFY_API_BASE=$(echo "$COOLIFY_WEBHOOK_URL" | grep -oP '^https?://[^/]+')
-          COOLIFY_APP_UUID=$(echo "$COOLIFY_WEBHOOK_URL" | grep -oP '(?<=[?&]uuid=)[^&]+')
+          # `|| true` on each: run: steps execute under `set -e`, so a
+          # non-matching grep (exit 1) would otherwise abort the script here
+          # instead of reaching the explicit "could not parse" check below.
+          COOLIFY_API_BASE=$(echo "$COOLIFY_WEBHOOK_URL" | grep -oP '^https?://[^/]+' || true)
+          COOLIFY_APP_UUID=$(echo "$COOLIFY_WEBHOOK_URL" | grep -oP '(?<=[?&]uuid=)[^&]+' || true)
 
           if [ -z "$COOLIFY_API_BASE" ] || [ -z "$COOLIFY_APP_UUID" ]; then
             echo "::error::Could not parse host/uuid out of COOLIFY_WEBHOOK_URL — expected .../api/v1/deploy?uuid=<uuid>. Refusing to deploy on the floating tag; fix the URL or this parsing."
@@ -370,13 +388,27 @@ jobs:
             exit 1
           fi
 
-          echo "Pinned esdeveniments-production to sha-${{ github.sha }}"
+          PINNED_APP_LABEL=$([ "$IS_MAIN" = "true" ] && echo "esdeveniments-production" || echo "esdeveniments-staging")
+          echo "Pinned $PINNED_APP_LABEL to sha-${{ github.sha }}"
 
       - name: Trigger Coolify deployment
         env:
-          COOLIFY_TOKEN: ${{ github.ref_name == 'main' && secrets.COOLIFY_TOKEN || secrets.COOLIFY_TOKEN_STAGING }}
-          COOLIFY_WEBHOOK_URL: ${{ github.ref_name == 'main' && secrets.COOLIFY_WEBHOOK_URL || secrets.COOLIFY_WEBHOOK_URL_STAGING }}
+          # See the "Pin Coolify" step above for why this is a bash if/else
+          # instead of a `&&`/`||` expression.
+          IS_MAIN: ${{ github.ref_name == 'main' }}
+          COOLIFY_TOKEN_MAIN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_TOKEN_STAGING: ${{ secrets.COOLIFY_TOKEN_STAGING }}
+          COOLIFY_WEBHOOK_URL_MAIN: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_WEBHOOK_URL_STAGING: ${{ secrets.COOLIFY_WEBHOOK_URL_STAGING }}
         run: |
+          if [ "$IS_MAIN" = "true" ]; then
+            COOLIFY_TOKEN="$COOLIFY_TOKEN_MAIN"
+            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_MAIN"
+          else
+            COOLIFY_TOKEN="$COOLIFY_TOKEN_STAGING"
+            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_STAGING"
+          fi
+
           if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
             echo "::error::COOLIFY_WEBHOOK_URL secret is required"
             exit 1

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -334,6 +334,10 @@ jobs:
       # every deploy removes the floating tag a restart could resurrect.
       # See docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md.
       - name: Pin Coolify to this commit's immutable image tag
+        # skip_ci (emergency deploy) also skips build-and-push above, so no
+        # sha-<commit> image exists to pin to — leave whatever tag is already
+        # configured alone and let the webhook redeploy it as-is.
+        if: needs.build-and-push.result == 'success'
         env:
           COOLIFY_TOKEN: ${{ github.ref_name == 'main' && secrets.COOLIFY_TOKEN || secrets.COOLIFY_TOKEN_STAGING }}
           COOLIFY_WEBHOOK_URL: ${{ github.ref_name == 'main' && secrets.COOLIFY_WEBHOOK_URL || secrets.COOLIFY_WEBHOOK_URL_STAGING }}

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -322,6 +322,30 @@ jobs:
             echo "**Trigger:** Push to ${{ github.ref_name }} ($([ '${{ github.ref_name }}' = 'main' ] && echo 'full CI' || echo 'lint+typecheck+unit'))" >> $GITHUB_STEP_SUMMARY
           fi
 
+      # Resolves COOLIFY_TOKEN/COOLIFY_WEBHOOK_URL once for both steps below,
+      # so the branch->secret selection logic lives in exactly one place.
+      # Branch-gated in bash, not in a `&&`/`||` expression: that pattern
+      # falls through to the staging secret whenever the main secret happens
+      # to be empty (GH Actions treats "" as falsy), which would silently
+      # PATCH/deploy the staging app on a main-branch push. Always runs
+      # (not gated on build-and-push) because "Trigger Coolify deployment"
+      # needs these even on the skip_ci emergency-deploy path.
+      - name: Resolve Coolify secrets for this branch
+        env:
+          IS_MAIN: ${{ github.ref_name == 'main' }}
+          COOLIFY_TOKEN_MAIN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_TOKEN_STAGING: ${{ secrets.COOLIFY_TOKEN_STAGING }}
+          COOLIFY_WEBHOOK_URL_MAIN: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_WEBHOOK_URL_STAGING: ${{ secrets.COOLIFY_WEBHOOK_URL_STAGING }}
+        run: |
+          if [ "$IS_MAIN" = "true" ]; then
+            echo "COOLIFY_TOKEN=$COOLIFY_TOKEN_MAIN" >> "$GITHUB_ENV"
+            echo "COOLIFY_WEBHOOK_URL=$COOLIFY_WEBHOOK_URL_MAIN" >> "$GITHUB_ENV"
+          else
+            echo "COOLIFY_TOKEN=$COOLIFY_TOKEN_STAGING" >> "$GITHUB_ENV"
+            echo "COOLIFY_WEBHOOK_URL=$COOLIFY_WEBHOOK_URL_STAGING" >> "$GITHUB_ENV"
+          fi
+
       # Coolify's app config points at the floating `:main` registry tag. A
       # health-check-triggered container restart recreates the container
       # from whatever image is locally cached under that tag WITHOUT going
@@ -339,24 +363,8 @@ jobs:
         # configured alone and let the webhook redeploy it as-is.
         if: needs.build-and-push.result == 'success'
         env:
-          # Branch-gated in bash, not in the `&&`/`||` expression below: that
-          # pattern falls through to the staging secret whenever the main
-          # secret happens to be empty (GH Actions treats "" as falsy), which
-          # would silently PATCH the staging app on a main-branch deploy.
           IS_MAIN: ${{ github.ref_name == 'main' }}
-          COOLIFY_TOKEN_MAIN: ${{ secrets.COOLIFY_TOKEN }}
-          COOLIFY_TOKEN_STAGING: ${{ secrets.COOLIFY_TOKEN_STAGING }}
-          COOLIFY_WEBHOOK_URL_MAIN: ${{ secrets.COOLIFY_WEBHOOK_URL }}
-          COOLIFY_WEBHOOK_URL_STAGING: ${{ secrets.COOLIFY_WEBHOOK_URL_STAGING }}
         run: |
-          if [ "$IS_MAIN" = "true" ]; then
-            COOLIFY_TOKEN="$COOLIFY_TOKEN_MAIN"
-            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_MAIN"
-          else
-            COOLIFY_TOKEN="$COOLIFY_TOKEN_STAGING"
-            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_STAGING"
-          fi
-
           if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
             echo "::error::COOLIFY_WEBHOOK_URL secret is required"
             exit 1
@@ -392,23 +400,7 @@ jobs:
           echo "Pinned $PINNED_APP_LABEL to sha-${{ github.sha }}"
 
       - name: Trigger Coolify deployment
-        env:
-          # See the "Pin Coolify" step above for why this is a bash if/else
-          # instead of a `&&`/`||` expression.
-          IS_MAIN: ${{ github.ref_name == 'main' }}
-          COOLIFY_TOKEN_MAIN: ${{ secrets.COOLIFY_TOKEN }}
-          COOLIFY_TOKEN_STAGING: ${{ secrets.COOLIFY_TOKEN_STAGING }}
-          COOLIFY_WEBHOOK_URL_MAIN: ${{ secrets.COOLIFY_WEBHOOK_URL }}
-          COOLIFY_WEBHOOK_URL_STAGING: ${{ secrets.COOLIFY_WEBHOOK_URL_STAGING }}
         run: |
-          if [ "$IS_MAIN" = "true" ]; then
-            COOLIFY_TOKEN="$COOLIFY_TOKEN_MAIN"
-            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_MAIN"
-          else
-            COOLIFY_TOKEN="$COOLIFY_TOKEN_STAGING"
-            COOLIFY_WEBHOOK_URL="$COOLIFY_WEBHOOK_URL_STAGING"
-          fi
-
           if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
             echo "::error::COOLIFY_WEBHOOK_URL secret is required"
             exit 1

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -322,6 +322,52 @@ jobs:
             echo "**Trigger:** Push to ${{ github.ref_name }} ($([ '${{ github.ref_name }}' = 'main' ] && echo 'full CI' || echo 'lint+typecheck+unit'))" >> $GITHUB_STEP_SUMMARY
           fi
 
+      # Coolify's app config points at the floating `:main` registry tag. A
+      # health-check-triggered container restart recreates the container
+      # from whatever image is locally cached under that tag WITHOUT going
+      # through this deploy pipeline — so a restart can silently resurrect
+      # stale code hours after a correct deploy, with no CI run, webhook, or
+      # API call to show for it. This happened on 2026-07-31: the RSC
+      # cache-poisoning fix (0cdf6f8e) deployed correctly at 14:34 UTC, then
+      # a restart at 19:01 UTC reverted it. Pinning to the immutable
+      # `sha-<commit>` tag (already pushed by build-and-push, above) before
+      # every deploy removes the floating tag a restart could resurrect.
+      # See docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md.
+      - name: Pin Coolify to this commit's immutable image tag
+        env:
+          COOLIFY_TOKEN: ${{ github.ref_name == 'main' && secrets.COOLIFY_TOKEN || secrets.COOLIFY_TOKEN_STAGING }}
+          COOLIFY_WEBHOOK_URL: ${{ github.ref_name == 'main' && secrets.COOLIFY_WEBHOOK_URL || secrets.COOLIFY_WEBHOOK_URL_STAGING }}
+        run: |
+          if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
+            echo "::error::COOLIFY_WEBHOOK_URL secret is required"
+            exit 1
+          fi
+
+          # The webhook URL is Coolify's own `POST /api/v1/deploy?uuid=...`
+          # trigger — reuse its host and uuid instead of adding new secrets.
+          COOLIFY_API_BASE=$(echo "$COOLIFY_WEBHOOK_URL" | grep -oP '^https?://[^/]+')
+          COOLIFY_APP_UUID=$(echo "$COOLIFY_WEBHOOK_URL" | grep -oP '(?<=[?&]uuid=)[^&]+')
+
+          if [ -z "$COOLIFY_API_BASE" ] || [ -z "$COOLIFY_APP_UUID" ]; then
+            echo "::error::Could not parse host/uuid out of COOLIFY_WEBHOOK_URL — expected .../api/v1/deploy?uuid=<uuid>. Refusing to deploy on the floating tag; fix the URL or this parsing."
+            exit 1
+          fi
+
+          HTTP_CODE=$(curl -s -o /tmp/coolify-patch-response.json -w "%{http_code}" \
+            -X PATCH "${COOLIFY_API_BASE}/api/v1/applications/${COOLIFY_APP_UUID}" \
+            -H "Authorization: Bearer $COOLIFY_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "{\"docker_registry_image_tag\": \"sha-${{ github.sha }}\"}" \
+            --max-time 15) || HTTP_CODE="000"
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Failed to pin docker_registry_image_tag (HTTP $HTTP_CODE) — aborting rather than deploying on the floating :main tag"
+            cat /tmp/coolify-patch-response.json 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "Pinned esdeveniments-production to sha-${{ github.sha }}"
+
       - name: Trigger Coolify deployment
         env:
           COOLIFY_TOKEN: ${{ github.ref_name == 'main' && secrets.COOLIFY_TOKEN || secrets.COOLIFY_TOKEN_STAGING }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,14 @@ USER nextjs
 # sizing + 0-byte image cache cleanup + Redis connect). The stale-cache purge
 # runs fire-and-forget after Redis connects (cache-handler.mjs) and isn't a
 # readiness gate, so it isn't counted here. See incident 2026-07-07.
+# The internal AbortController fires at 9500ms, just under Docker's own 10s
+# --timeout: Docker kills the whole probe process at 10s regardless, so an
+# internal abort tighter than that (the previous value here was 8000ms)
+# silently shrinks the documented 10s tolerance down to whatever the internal
+# value is — losing exactly the GC-pause headroom this timeout was raised to
+# provide. 9500ms leaves 500ms for the abort handler and process.exit() to
+# actually run before Docker's own kill would fire.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "const c=new AbortController(),t=setTimeout(()=>c.abort(),8000);fetch('http://127.0.0.1:3000/api/health',{signal:c.signal}).then(r=>{clearTimeout(t);process.exit(r.ok?0:1)}).catch(()=>{clearTimeout(t);process.exit(1)})"
+  CMD node -e "const c=new AbortController(),t=setTimeout(()=>c.abort(),9500);fetch('http://127.0.0.1:3000/api/health',{signal:c.signal}).then(r=>{clearTimeout(t);process.exit(r.ok?0:1)}).catch(()=>{clearTimeout(t);process.exit(1)})"
 
 CMD ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,9 @@ USER nextjs
 # memory stress the event loop stalls and /api/health can't respond within 3s
 # even though the process is alive, triggering false-unhealthy restarts.
 # 10s gives GC headroom; start-period 40s covers cold-start (entrypoint heap
-# sizing + 0-byte image cache cleanup + Redis connect + stale-cache purge).
-# See incident 2026-07-07.
+# sizing + 0-byte image cache cleanup + Redis connect). The stale-cache purge
+# runs fire-and-forget after Redis connects (cache-handler.mjs) and isn't a
+# readiness gate, so it isn't counted here. See incident 2026-07-07.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD node -e "const c=new AbortController(),t=setTimeout(()=>c.abort(),8000);fetch('http://127.0.0.1:3000/api/health',{signal:c.signal}).then(r=>{clearTimeout(t);process.exit(r.ok?0:1)}).catch(()=>{clearTimeout(t);process.exit(1)})"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,6 +60,9 @@ fi
 # writable layer and the leftover file re-triggers the bug immediately on
 # boot. Upstream bug, unfixed as of Next.js 16.2.10 / 16.3.0-canary.75:
 # https://github.com/vercel/next.js/issues/93757
-find .next/cache/images -type f -size 0 -delete 2>/dev/null || true
+if [ -d .next/cache/images ]; then
+  find .next/cache/images -type f -size 0 -delete ||
+    echo "[entrypoint] warning: failed to clean zero-byte image cache files" >&2
+fi
 
 exec node server.js

--- a/docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md
+++ b/docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md
@@ -33,7 +33,9 @@ The issue self-resolved after ~30 minutes when the `s-maxage=1800` TTL expired, 
 | 13:22 UTC       | Investigated; confirmed `cf-cache-status: HIT` with `content-type: text/x-component`        |
 | 13:59 UTC       | Revalidation re-run confirmed `/es` now returns `text/html` correctly                       |
 | 2026-04-20      | This doc backfilled into the repo (batch commit, no code change alongside it)               |
-| 2026-07-31      | **Recurred on `/en`** — the `isRscRequest` fix below was never actually committed (`git log -S"isRscRequest"` had zero hits). Implemented for real in `proxy.ts` + regression test in `test/proxy.test.ts`. |
+| 2026-07-31 14:34 UTC | **Recurred on `/en`** — the `isRscRequest` fix below was never actually committed (`git log -S"isRscRequest"` had zero hits). Implemented for real in `proxy.ts` (commit `0cdf6f8e`) + regression test in `test/proxy.test.ts`. Deployed correctly via CI. |
+| 2026-07-31 19:01 UTC | An untracked Coolify deployment (no GitHub Actions run, no webhook, no API call) silently reverted the 14:34 fix — see "Recurrence #2" below. |
+| 2026-08-01      | **Recurrence #2 discovered**: origin still served `public, s-maxage=1800` for RSC requests; the Cloudflare bypass rule added in response also turned out not to be firing. Both root-caused and fixed — see below. |
 
 ## Root Cause
 
@@ -87,6 +89,36 @@ If modifying the Cloudflare cache rule for `www.esdeveniments.cat`, be aware tha
 - Cloudflare doesn't vary cache by custom request headers (only `Accept-Encoding`)
 - Any cached page URL can receive both HTML and RSC requests
 - The cache rule should ideally exclude RSC responses, but since Cloudflare can't match on `RSC` header in Free/Pro plans, the server-side `private, no-store` approach is the correct solution
+- **Cache Rules apply cumulatively, and where two rules set the same field (e.g. Cache Eligibility) for a matching request, the LAST matching rule in the ordered list wins** — not the first. A narrow bypass rule placed *above* a broad "cache everything" rule gets silently overridden. Any bypass rule (RSC, AI bots, `/_next/image`) must sit *below* the broad HTML-caching rule in the Cache Rules list.
+
+## Recurrence #2 (2026-08-01): two independent bugs stacked
+
+Reported again on `/en` ("weird text instead of the website"). Live reproduction (not assumption) found **two separate, unrelated bugs**, either of which alone would have caused this:
+
+### Bug A: the 2026-07-31 fix never stayed deployed
+
+`proxy.ts` commit `0cdf6f8e` built and deployed correctly via GitHub Actions at 14:25-14:35 UTC on 2026-07-31 (confirmed via `gh run list` + Coolify deployment log timestamps). But an untracked Coolify deployment at 19:01 UTC the same day — no GitHub Actions run, no webhook, no API call, `force_rebuild: false` — silently reverted production to pre-fix behavior. Confirmed live on 2026-08-01: sending the literal header `proxy.ts` checks for (`RSC: 1`) still got `Cache-Control: public, max-age=0, s-maxage=1800` back from origin, even though Next.js itself correctly returned `content-type: text/x-component` for the same request — proving the header reached the process but the `isRscRequest` code path was simply not present in the running binary.
+
+Root cause: Coolify's `esdeveniments-production` app was configured with `docker_registry_image_tag: "main"` — a **floating** registry tag — with `health_check_enabled: true` (path `/`, 30s interval, 3 retries). CI already pushes an immutable `sha-<commit>` tag alongside `:main` (`.github/workflows/deploy-coolify.yml`, `build-and-push` job), but nothing used it. A health-check-triggered container restart recreates the container from whatever's locally cached under the `:main` tag, bypassing the deploy pipeline entirely — this box has prior history of the same class of bug (`3e1d8bc8` "clear zero-byte image cache files on boot", the Jul 7 crash incident in `cbd429df`).
+
+**Fix:** the `deploy` job in `.github/workflows/deploy-coolify.yml` now PATCHes the Coolify app's `docker_registry_image_tag` to `sha-${{ github.sha }}` before triggering the deploy webhook, on every deploy. There is no floating tag left for a restart to resurrect.
+
+### Bug B: the Cloudflare bypass rule was firing on the wrong side of an ordering conflict
+
+Independent of Bug A: a fresh URL fetched with `RSC: 1` + `Accept: text/x-component`, then fetched again with a plain `Accept: text/html` (simulating a normal visitor), came back `cf-cache-status: HIT` with `content-type: text/x-component` — live reproduction of the poisoning, reproduced on demand on a URL created solely for this test.
+
+The zone's Cache Rules, in order:
+
+| Order | Rule | Action |
+|---|---|---|
+| 1 | RSC flight payloads — never cache | Bypass |
+| 2 | Bypass cache for AI bots | Bypass |
+| 3 | Cache HTML pages - regular traffic (non-bots) | Eligible for cache |
+| 4 | Bypass cache for Next.js images | Bypass |
+
+Rule 3 has no RSC or bot-UA exclusion and matches `/en` (and effectively any non-`/api/` HTML path). Per the Cache Rules last-match-wins semantics documented above, rule 3 overrode rules 1 and 2's bypass for any request that also matched rule 3 — meaning **both the RSC bypass and the AI-bot bypass had been silently inert** since rule 3 was added or last reordered.
+
+**Fix:** reorder so "Cache HTML pages - regular traffic" is evaluated first (position 1), with all bypass rules below it.
 
 ## Lessons Learned
 
@@ -96,3 +128,5 @@ If modifying the Cloudflare cache rule for `www.esdeveniments.cat`, be aware tha
 4. **Self-resolving ≠ safe** — the issue resolved after 30 min via TTL, but could have affected SEO (Googlebot indexing RSC payload) and user trust.
 5. **RSC responses should never be CDN-cached** unless the CDN supports proper cache key differentiation (Enterprise Cloudflare or CloudFront with custom cache policy).
 6. **A "Resolution" section in an incident doc is not proof the fix shipped.** This doc was backfilled 16 days after the incident in a batch commit unrelated to `proxy.ts`, and the described fix was never committed — the same bug recurred on `/en` three months later. Verify fixes described in incident docs against `git log -S` or the current file, don't trust the prose.
+7. **A correct deploy is not proof the fix stays deployed.** A floating registry tag (`:main`) plus a health-check-triggered container restart can silently revert a correctly-shipped fix hours later, with no CI run, webhook, or API call in the audit trail. Pin deploys to immutable per-commit tags.
+8. **A "Bypass cache" rule is not proof requests are bypassed.** Cloudflare Cache Rules are last-match-wins per field across the whole ordered list — a bypass rule sitting above a broad "eligible for cache" rule is silently overridden. Reproduce the actual `cf-cache-status` on a fresh URL before trusting a rule is doing anything.

--- a/docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md
+++ b/docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md
@@ -101,7 +101,7 @@ Reported again on `/en` ("weird text instead of the website"). Live reproduction
 
 Root cause: Coolify's `esdeveniments-production` app was configured with `docker_registry_image_tag: "main"` — a **floating** registry tag — with `health_check_enabled: true` (path `/`, 30s interval, 3 retries). CI already pushes an immutable `sha-<commit>` tag alongside `:main` (`.github/workflows/deploy-coolify.yml`, `build-and-push` job), but nothing used it. A health-check-triggered container restart recreates the container from whatever's locally cached under the `:main` tag, bypassing the deploy pipeline entirely — this box has prior history of the same class of bug (`3e1d8bc8` "clear zero-byte image cache files on boot", the Jul 7 crash incident in `cbd429df`).
 
-**Fix:** the `deploy` job in `.github/workflows/deploy-coolify.yml` now PATCHes the Coolify app's `docker_registry_image_tag` to `sha-${{ github.sha }}` before triggering the deploy webhook, on every deploy. There is no floating tag left for a restart to resurrect.
+**Fix:** after a successful image build, the `deploy` job in `.github/workflows/deploy-coolify.yml` PATCHes the Coolify app's `docker_registry_image_tag` to `sha-${{ github.sha }}` before triggering the deploy webhook. Emergency `skip_ci` deployments intentionally retain the currently configured tag, since no commit image was built to pin to. The app itself no longer references the floating `:main`/`:develop` tag — `build-and-push` still pushes it to the registry alongside the immutable `sha-<commit>` tag, so a future manual re-point back to it would revive this bug class, but a restart alone can no longer resurrect it.
 
 ### Bug B: the Cloudflare bypass rule was firing on the wrong side of an ordering conflict
 

--- a/docs/incidents/2026-07-07-coolify-container-healthcheck-crash.md
+++ b/docs/incidents/2026-07-07-coolify-container-healthcheck-crash.md
@@ -70,7 +70,14 @@ The HEALTHCHECK timeout (3s, unchanged since the Dockerfile was first created)
 was correct for the *old* unconstrained regime but was never recalibrated for
 the *new* memory-bounded one.
 
-### The swappiness correlation is the smoking gun
+### The swappiness correlation is the leading hypothesis (unconfirmed)
+
+`vm.swappiness` rebalances reclaim priority between anonymous (process) and
+file-backed (page cache) memory — it doesn't directly trigger V8 GC. The
+correlation below is suggestive, not proof: no GC-pause metrics were captured
+during the incident, and the Sentinel review needed to confirm the causal
+chain is still pending (see Prevention #6). Treat the `20-30` recommendation
+below as a monitored change, not a validated fix.
 
 | Application | Swappiness | Memory | Crashed? |
 | --- | --- | --- | --- |
@@ -158,10 +165,12 @@ shared with everything else on the box.
    - **40s start-period** covers cold-start: `docker-entrypoint.sh` reads the
      cgroup limit, sizes the heap, clears 0-byte image cache files (the `find
      .next/cache/images -type f -size 0 -delete` scan added in `3e1d8bc8`),
-     then `node server.js` boots, connects to Redis, and runs the stale-cache
-     purge. The previous 20s was marginal — a slow Redis connect, a large
-     purge, or the 0-byte scan could exceed it, causing false-unhealthy on the
-     very first boot.
+     then `node server.js` boots and connects to Redis. The stale-cache purge
+     that follows the Redis connect (`cache-handler.mjs`) runs fire-and-forget
+     and doesn't gate `/api/health` readiness, so it isn't part of this
+     budget. The previous 20s was marginal — a slow Redis connect or the
+     0-byte scan could exceed it, causing false-unhealthy on the very first
+     boot.
    - **3 retries × 30s interval** unchanged — still 90s of sustained
      unresponsiveness before a restart is triggered, which is a reasonable
      signal that the process is genuinely stuck (not just a momentary GC pause).
@@ -172,17 +181,25 @@ shared with everything else on the box.
    stop-the-world pauses under memory pressure. The healthcheck should detect
    a genuinely dead process, not a temporarily slow one.
 
-2. **Start-period calibrated for cold-start** — 40s covers the full boot
-   sequence (entrypoint → heap sizing → cache cleanup → Node boot → Redis
-   connect → stale-cache purge) without false-unhealthy on first boot.
+2. **Start-period calibrated for cold-start** — 40s covers the full blocking
+   boot sequence (entrypoint → heap sizing → cache cleanup → Node boot →
+   Redis connect) without false-unhealthy on first boot. The stale-cache
+   purge that follows isn't part of this budget — it runs fire-and-forget and
+   doesn't gate `/api/health`.
 
-3. **Raise prod swappiness from 10 to 20–30** — Both prod containers crashed
-   at `swappiness=10`; neither staging container (20–60) has ever crashed.
-   Swappiness=10 forces the kernel to pressure V8 into GC rather than swapping,
-   directly increasing stop-the-world pause frequency and duration. Raising to
-   20–30 gives the kernel swap headroom and reduces GC pause frequency, at the
+3. **Raise prod swappiness from 10 to 20–30 (monitored hypothesis)** — Both
+   prod containers crashed at `swappiness=10`; neither staging container
+   (20–60) has ever crashed. This correlation suggests swappiness=10 forces
+   the kernel to pressure V8 into GC rather than swapping, increasing
+   stop-the-world pause frequency and duration — but it's unconfirmed without
+   GC-pause metrics (see #6 below). Raising to 20–30 gives the kernel swap
+   headroom and reduces GC pause frequency if the hypothesis holds, at the
    cost of some swap I/O under pressure. This is the highest-leverage Coolify
-   dashboard change to prevent recurrence.
+   dashboard change to try first, pending the metrics review below.
+   **Rollback criterion:** if either prod container crash-loops again at
+   swappiness 20–30 within the next monitoring window, that rules out
+   swappiness as the sole cause — revert to investigating heap sizing or the
+   memory limits directly instead of swappiness.
 
 4. **Uptime monitor confirmed working** — The GitHub Actions uptime monitor
    (`.github/workflows/uptime.yml`, every 15 min) detected the outage within

--- a/docs/incidents/2026-07-07-coolify-container-healthcheck-crash.md
+++ b/docs/incidents/2026-07-07-coolify-container-healthcheck-crash.md
@@ -196,10 +196,15 @@ shared with everything else on the box.
    headroom and reduces GC pause frequency if the hypothesis holds, at the
    cost of some swap I/O under pressure. This is the highest-leverage Coolify
    dashboard change to try first, pending the metrics review below.
+   **Monitoring window:** 14 days from the swappiness change, matching the
+   17–22 day gap observed between the Jun 15 memory-limit change and each
+   prod crash — shorter windows wouldn't have caught either incident.
+   **Success:** zero crash-loops (`last_restart_type: crash`) on either prod
+   container within the window.
    **Rollback criterion:** if either prod container crash-loops again at
-   swappiness 20–30 within the next monitoring window, that rules out
-   swappiness as the sole cause — revert to investigating heap sizing or the
-   memory limits directly instead of swappiness.
+   swappiness 20–30 within that 14-day window, that rules out swappiness as
+   the sole cause — revert to investigating heap sizing or the memory
+   limits directly instead of swappiness.
 
 4. **Uptime monitor confirmed working** — The GitHub Actions uptime monitor
    (`.github/workflows/uptime.yml`, every 15 min) detected the outage within

--- a/docs/self-hosted-resource-limits.md
+++ b/docs/self-hosted-resource-limits.md
@@ -40,15 +40,16 @@ Frontend application → **Resource Limits**:
   at 75%, the rest for `sharp`/buffers/RSS). Staging is at 1 GB. The hard limit
   is what OOM-kills; pair it with a soft limit slightly below.
 - **CPU:** 1–2 vCPU is plenty for the current traffic.
-- **Swappiness:** **avoid 10** — use **20–30** for prod. Both prod containers
-  crashed at `swappiness=10` (frontend Jul 7, backend Jul 2, 2026) because the
-  kernel aggressively pressured V8 into GC rather than swapping, producing
-  stop-the-world pauses that exceeded the Docker healthcheck timeout and
-  triggered a crash-loop. Neither staging container (swappiness 20–60) has
-  ever crash-looped. See incident
-  [2026-07-07](./incidents/2026-07-07-coolify-container-healthcheck-crash.md).
-  Swappiness=10 was set with the best intention (memory efficiency) but the
-  interaction with heap bounding + tight healthcheck timeouts made it lethal.
+- **Swappiness:** **avoid 10** — use **20–30** for prod (monitored hypothesis,
+  not a confirmed fix). Both prod containers crashed at `swappiness=10`
+  (frontend Jul 7, backend Jul 2, 2026); neither staging container
+  (swappiness 20–60) has ever crash-looped. The theory is that the kernel
+  aggressively pressured V8 into GC rather than swapping, producing
+  stop-the-world pauses that exceeded the Docker healthcheck timeout — but
+  this is a correlation from 2 data points, not something measured directly
+  (no GC-pause metrics were captured). See incident
+  [2026-07-07](./incidents/2026-07-07-coolify-container-healthcheck-crash.md#3-raise-prod-swappiness-from-10-to-2030-monitored-hypothesis)
+  for the pending Sentinel metrics review that would confirm or rule this out.
 
 Redis (`redis-pro`, `redis-pre`) → set a bound so a cache can't grow without limit:
 


### PR DESCRIPTION
## Summary

Root cause of the RSC cache-poisoning recurrence on `/en`: the 2026-07-31 fix (`0cdf6f8e`) built and deployed correctly at 14:34 UTC, then an untracked Coolify deployment at 19:01 UTC (no GitHub Actions run, no webhook, no API call) silently reverted production to pre-fix behavior. Confirmed live: sending the exact header `proxy.ts` checks for (`RSC: 1`) still returns `public, s-maxage=1800` from origin, even though Next.js itself honors the header — proving the code isn't running, not a header-matching bug.

Coolify's app config points `docker_registry_image_tag` at the floating `:main` tag with `health_check_enabled: true`. A health-check-triggered container restart recreates the container from whatever's locally cached under that tag, bypassing the deploy pipeline entirely — this box has prior history of the same class of bug (`3e1d8bc8`, the Jul 7 crash incident in `cbd429df`).

- `deploy` job now PATCHes `docker_registry_image_tag` to `sha-${{ github.sha }}` (already pushed by `build-and-push`) before triggering the deploy webhook, on every push to `main` or `develop`. No floating tag left for a restart to resurrect. Applies to staging (`develop`) too, which has the identical latent bug via its own floating `develop` tag.
- Guarded on `build-and-push.result == 'success'` so the `skip_ci` emergency-deploy path (which also skips the image build) keeps its pre-existing behavior instead of pinning to a tag that was never pushed.
- No `proxy.ts` changes — that fix is already correct on `main`.
- Incident doc updated with both this root cause and an independent, unrelated finding from the same investigation: the zone's Cloudflare Cache Rules apply last-match-wins per field, and the broad "Cache HTML pages" rule sat below the RSC/AI-bot bypass rules, silently overriding them since whenever it was added. That one's a dashboard reorder, not code — not in this diff.

## Verification needed before/after merge

- **`COOLIFY_TOKEN` / `COOLIFY_TOKEN_STAGING` must have write/deploy scope.** I hit a read-only-scoped Coolify API token via MCP while investigating this — if the CI secrets have the same restriction, the new PATCH step will fail loudly (by design, rather than silently deploying on the floating tag) and block deploys until the token scope is fixed.
- Cloudflare Cache Rules reorder (dashboard-only, not in this PR) still needed to close the second bug — see incident doc.

## Test plan

- [x] Full unit suite passes (1922/1922)
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Confirm `COOLIFY_TOKEN` has write scope before merging (see above)
- [ ] After merge, verify `curl -H "RSC: 1" https://www.esdeveniments.cat/en` returns `Cache-Control: private, no-store`
- [ ] After merge, confirm a subsequent deploy shows the app pinned to `sha-<commit>` in the Coolify dashboard, not `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Coolify deployments to immutable per-commit Docker image tags to prevent silent rollbacks after healthcheck restarts. Also hardens container startup and ensures RSC responses are never CDN-cached.

- **Bug Fixes**
  - CI deploy now PATCHes Coolify to use `sha-<commit>` before triggering the webhook; skipped when the image build is skipped.
  - Workflow: centralized branch-aware secrets resolution and robust webhook-URL parsing with clear errors.
  - Docker healthcheck: 10s timeout with a 9.5s internal abort and 40s start-period to avoid false-unhealthy restarts.
  - Entry point: delete zero-byte files in `.next/cache/images` on boot; warn on cleanup failure.
  - `proxy.ts`: RSC (`RSC: 1`) responses return `private, no-store`; adds a regression test.
  - Docs: clarifies Cloudflare Cache Rules last-match-wins ordering; marks swappiness guidance as a monitored hypothesis with a 14-day window and rollback criteria.

- **Migration**
  - Ensure `COOLIFY_TOKEN` and `COOLIFY_TOKEN_STAGING` have write/deploy scope; the PATCH will fail otherwise.

<sup>Written for commit 20523ede661ae19da5f728bd6a4b9806ec85b202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented personalized navigation data from being cached by CDNs.
  * Improved container startup reliability by allowing more time for health checks.
  * Cleaned up invalid image cache files before server startup.
  * Deployments now use the exact built image version when successful.

* **Documentation**
  * Added incident reports and prevention guidance for recent outages.
  * Updated self-hosted production memory and swap recommendations.

* **Tests**
  * Added coverage confirming personalized navigation responses are not cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->