### PR TITLE
fix(seo): resolve PPR metadata resume-mismatch on place/news/sitemap pages

### DIFF
--- a/app/[locale]/[place]/[byDate]/[category]/page.tsx
+++ b/app/[locale]/[place]/[byDate]/[category]/page.tsx
@@ -1,6 +1,7 @@
 import { insertAds } from "@lib/api/events";
-import { getCategories } from "@lib/api/categories";
+import { getCategories, fetchCategoriesForMetadata } from "@lib/api/categories";
 import { getPlaceTypeAndLabelCached } from "@utils/helpers";
+import { getPlaceTypeAndLabelForMetadata } from "@lib/seo/place-metadata";
 import { generatePagesData } from "@components/partials/generatePagesData";
 import {
   buildPageMeta,
@@ -43,7 +44,10 @@ import { DEFAULT_FILTER_VALUE } from "@utils/constants";
 import type { PlacePageEventsResult } from "types/props";
 import { addLocalizedDateFields } from "@utils/mappers/event";
 import { getPlaceAliasOrInvalidPlaceRedirectUrl } from "@utils/place-alias-or-invalid-redirect";
-import { getPlaceExpandability } from "@lib/seo/place-expandability";
+import {
+  getPlaceExpandability,
+  getPlaceExpandabilityForMetadata,
+} from "@lib/seo/place-expandability";
 import {
   SSR_EVENTS_SIZE_EXPANDABLE,
   SSR_EVENTS_SIZE_THIN,
@@ -65,7 +69,7 @@ export async function generateMetadata({
   // Fetch categories for metadata generation FIRST
   let categories: CategorySummaryResponseDTO[] = [];
   try {
-    categories = await getCategories();
+    categories = await fetchCategoriesForMetadata();
   } catch (error) {
     console.error("Error fetching categories for metadata:", error);
     categories = [];
@@ -94,7 +98,7 @@ export async function generateMetadata({
   // Find category name for SEO
   const categoryData = categories.find((cat) => cat.slug === filters.category);
 
-  const placeTypeAndLabel: PlaceTypeAndLabel = await getPlaceTypeAndLabelCached(
+  const placeTypeAndLabel: PlaceTypeAndLabel = await getPlaceTypeAndLabelForMetadata(
     filters.place
   );
 
@@ -113,7 +117,7 @@ export async function generateMetadata({
 
   // Noindex thin filter sub-pages for non-expandable places. See lib/seo/place-expandability.ts
   // and [byDate]/page.tsx for full rationale (sitemap/index policy must stay in sync).
-  const expandable = await getPlaceExpandability(
+  const expandable = await getPlaceExpandabilityForMetadata(
     filters.place,
     placeTypeAndLabel.type,
   );

--- a/app/[locale]/[place]/[byDate]/page.tsx
+++ b/app/[locale]/[place]/[byDate]/page.tsx
@@ -2,8 +2,9 @@ import { getTranslations } from "next-intl/server";
 import { locale as rootLocale } from "next/root-params";
 import { toLocalizedUrl } from "@utils/i18n-seo";
 import { insertAds } from "@lib/api/events";
-import { getCategories } from "@lib/api/categories";
+import { getCategories, fetchCategoriesForMetadata } from "@lib/api/categories";
 import { getPlaceTypeAndLabelCached, toLocalDateString } from "@utils/helpers";
+import { getPlaceTypeAndLabelForMetadata } from "@lib/seo/place-metadata";
 import { generatePagesData } from "@components/partials/generatePagesData";
 import {
   buildPageMeta,
@@ -45,7 +46,10 @@ import type { PlacePageEventsResult } from "types/props";
 import { siteUrl } from "@config/index";
 import { addLocalizedDateFields } from "@utils/mappers/event";
 import { getPlaceAliasOrInvalidPlaceRedirectUrl } from "@utils/place-alias-or-invalid-redirect";
-import { getPlaceExpandability } from "@lib/seo/place-expandability";
+import {
+  getPlaceExpandability,
+  getPlaceExpandabilityForMetadata,
+} from "@lib/seo/place-expandability";
 import {
   SSR_EVENTS_SIZE_EXPANDABLE,
   SSR_EVENTS_SIZE_THIN,
@@ -67,7 +71,7 @@ export async function generateMetadata({
 
   let categories: CategorySummaryResponseDTO[] = [];
   try {
-    categories = await getCategories();
+    categories = await fetchCategoriesForMetadata();
   } catch (error) {
     console.error("generateMetadata: Error fetching categories:", error);
   }
@@ -92,7 +96,7 @@ export async function generateMetadata({
   const actualDate = parsed.segments.date;
   const actualCategory = parsed.segments.category;
 
-  const placeTypeLabel: PlaceTypeAndLabel = await getPlaceTypeAndLabelCached(
+  const placeTypeLabel: PlaceTypeAndLabel = await getPlaceTypeAndLabelForMetadata(
     place
   );
 
@@ -119,7 +123,10 @@ export async function generateMetadata({
   // URLs in "Crawled — currently not indexed" (Dec 2025–May 2026 GSC drop).
   // Reversible: when inventory grows past the threshold, the meta tag stops being emitted
   // and the URL re-enters the sitemap on the same signal — Google re-indexes on next crawl.
-  const expandable = await getPlaceExpandability(place, placeTypeLabel.type);
+  const expandable = await getPlaceExpandabilityForMetadata(
+    place,
+    placeTypeLabel.type
+  );
 
   return buildPageMeta({
     title: pageData.metaTitle,

--- a/app/[locale]/[place]/page.tsx
+++ b/app/[locale]/[place]/page.tsx
@@ -3,6 +3,7 @@ import { Suspense, use } from "react";
 import type { JSX } from "react";
 import { fetchCategories } from "@lib/api/categories";
 import { getPlaceTypeAndLabelCached, formatPlaceName } from "@utils/helpers";
+import { getPlaceTypeAndLabelForMetadata } from "@lib/seo/place-metadata";
 import { fetchEventsWithFallback } from "@lib/helpers/event-fallback";
 import { generatePagesData } from "@components/partials/generatePagesData";
 import {
@@ -59,7 +60,7 @@ export async function generateMetadata({
 
   const locale = (await rootLocale()) as AppLocale;
 
-  const placeTypeLabel: PlaceTypeAndLabel = await getPlaceTypeAndLabelCached(
+  const placeTypeLabel: PlaceTypeAndLabel = await getPlaceTypeAndLabelForMetadata(
     place
   );
   const pageData: PageData = await generatePagesData({

--- a/app/[locale]/noticies/[place]/[article]/page.tsx
+++ b/app/[locale]/noticies/[place]/[article]/page.tsx
@@ -7,6 +7,7 @@ import { getTranslations } from "next-intl/server";
 import { siteUrl } from "@config/index";
 import { buildPageMeta } from "@components/partials/seo-meta";
 import { getPlaceTypeAndLabelCached } from "@utils/helpers";
+import { getPlaceTypeAndLabelForMetadata } from "@lib/seo/place-metadata";
 import { captureException } from "@sentry/nextjs";
 import NewsArticleDetail from "@components/noticies/NewsArticleDetail";
 import NewsArticleSkeleton from "@components/noticies/NewsArticleSkeleton";
@@ -64,7 +65,7 @@ export async function generateMetadata({
     throw error;
   }
   const canonicalPlace = getCanonicalPlaceSlugFromDetail(detail, place);
-  const placeType = await getPlaceTypeAndLabelCached(place);
+  const placeType = await getPlaceTypeAndLabelForMetadata(place);
   const locale = (await rootLocale()) as AppLocale;
   const t = await getTranslations({
     locale,

--- a/app/[locale]/noticies/[place]/page.tsx
+++ b/app/[locale]/noticies/[place]/page.tsx
@@ -10,6 +10,7 @@ import { locale as rootLocale } from "next/root-params";
 import { withLocalePath } from "@utils/i18n-seo";
 import { parseNewsPagination } from "@utils/news-helpers";
 import { getPlaceTypeAndLabelCached } from "@utils/helpers";
+import { getPlaceTypeAndLabelForMetadata } from "@lib/seo/place-metadata";
 import { siteUrl } from "@config/index";
 import { generateWebPageSchema } from "@components/partials/seo-meta";
 import type { AppLocale } from "types/i18n";
@@ -26,7 +27,7 @@ export async function generateMetadata({
   params: Promise<{ place: string }>;
 }): Promise<Metadata> {
   const { place } = await params;
-  const placeType = await getPlaceTypeAndLabelCached(place);
+  const placeType = await getPlaceTypeAndLabelForMetadata(place);
   const locale = (await rootLocale()) as AppLocale;
   const t = await getTranslations({ locale, namespace: "App.NewsPlace" });
   const base = buildPageMeta({

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -27,6 +27,7 @@ export async function generateMetadata() {
   const pageData: PageData = await generatePagesData({
     place: "",
     byDate: "",
+    placeTypeLabel: { type: "region", label: "Catalunya" },
     locale,
   });
   return buildPageMeta({
@@ -139,7 +140,12 @@ async function HomeContent({
   const [t, tTopAgenda, pageData] = await Promise.all([
     getTranslations({ locale, namespace: "App.Home" }),
     getTranslations({ locale, namespace: "Config.TopAgenda" }),
-    generatePagesData({ place: "", byDate: "", locale }),
+    generatePagesData({
+      place: "",
+      byDate: "",
+      placeTypeLabel: { type: "region", label: "Catalunya" },
+      locale,
+    }),
   ]);
   const agendaLabel = tTopAgenda("agenda");
 

--- a/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
+++ b/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
@@ -9,6 +9,7 @@ import { getTranslations } from "next-intl/server";
 import { siteUrl } from "@config/index";
 import { fetchEvents } from "@lib/api/events";
 import { getPlaceBySlug } from "@lib/api/places";
+import { fetchPlaceBySlugForMetadata } from "@lib/seo/place-metadata";
 import {
   getHistoricDates,
   normalizeMonthParam,
@@ -99,7 +100,7 @@ export async function generateMetadata({
   // Tolerate backend 5xx for place lookup (cosmetic; town slug is an acceptable
   // fallback). Prevents archive 500s from intermittent backend errors — the
   // main 5xx source per GSC on /sitemap/<town>/<year>/<month>.
-  const place = await getPlaceBySlug(town).catch(() => null);
+  const place = await fetchPlaceBySlugForMetadata(town).catch(() => null);
   const townLabel = place?.name || town;
   const placeType: "region" | "town" =
     place?.type === "CITY" ? "town" : "region";

--- a/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
+++ b/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
@@ -131,10 +131,15 @@ export async function generateMetadata({
     to: toStr,
     size: MAX_EVENTS_PER_PAGE,
   });
-  const realEventCount = Array.isArray(events.content)
-    ? (events.content as EventSummaryResponseDTO[]).filter((e) => !e.isAd)
-      .length
-    : 0;
+  // `events === null` means the probe itself failed (upstream outage, bad
+  // payload) — fail open (no robots override) rather than noindex a page
+  // that may well have real content; only a confirmed empty result should
+  // noindex.
+  const realEventCount =
+    events && Array.isArray(events.content)
+      ? (events.content as EventSummaryResponseDTO[]).filter((e) => !e.isAd)
+        .length
+      : null;
   const robotsOverride = realEventCount === 0 ? "noindex, follow" : undefined;
 
   return buildPageMeta({

--- a/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
+++ b/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "@utils/helpers";
 import { getTranslations } from "next-intl/server";
 import { siteUrl } from "@config/index";
-import { fetchEvents } from "@lib/api/events";
+import { fetchEvents, fetchEventsForMetadata } from "@lib/api/events";
 import { getPlaceBySlug } from "@lib/api/places";
 import { fetchPlaceBySlugForMetadata } from "@lib/seo/place-metadata";
 import {
@@ -113,7 +113,11 @@ export async function generateMetadata({
 
   // Probe events to set robots policy: noindex empty months so GSC stops
   // flagging them as soft 404 / "Crawled - currently not indexed". Uses the
-  // primitive-keyed fetchMonthEvents wrapper so Page reuses the same response.
+  // metadata-safe fetchEventsForMetadata, not the fetchMonthEvents wrapper
+  // Page uses below — fetchMonthEvents goes through fetchWithHmac, which
+  // unconditionally calls connection() and breaks the static shell if
+  // called from generateMetadata. See docs/incidents/
+  // 2026-06-13-cachecomponents-metadata-resume-mismatch.md.
   const { from, until } = getHistoricDates(
     canonicalMonthSlug,
     Number(year),
@@ -121,7 +125,12 @@ export async function generateMetadata({
   );
   const fromStr = from.toISOString().split("T")[0];
   const toStr = until.toISOString().split("T")[0];
-  const events = await fetchMonthEvents(town, fromStr, toStr);
+  const events = await fetchEventsForMetadata({
+    place: town,
+    from: fromStr,
+    to: toStr,
+    size: MAX_EVENTS_PER_PAGE,
+  });
   const realEventCount = Array.isArray(events.content)
     ? (events.content as EventSummaryResponseDTO[]).filter((e) => !e.isAd)
       .length

--- a/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
+++ b/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
@@ -97,19 +97,6 @@ export async function generateMetadata({
   const canonicalMonthSlug = DEFAULT_MONTHS_URL[monthIndex];
   const monthLabel =
     monthLabels[monthIndex] || normalizeMonthParam(canonicalMonthSlug).label;
-  // Tolerate backend 5xx for place lookup (cosmetic; town slug is an acceptable
-  // fallback). Prevents archive 500s from intermittent backend errors — the
-  // main 5xx source per GSC on /sitemap/<town>/<year>/<month>.
-  const place = await fetchPlaceBySlugForMetadata(town).catch(() => null);
-  const townLabel = place?.name || town;
-  const placeType: "region" | "town" =
-    place?.type === "CITY" ? "town" : "region";
-  const locationPhrase = formatPlacePreposition(
-    townLabel,
-    placeType,
-    locale,
-    false
-  );
 
   // Probe events to set robots policy: noindex empty months so GSC stops
   // flagging them as soft 404 / "Crawled - currently not indexed". Uses the
@@ -125,12 +112,30 @@ export async function generateMetadata({
   );
   const fromStr = from.toISOString().split("T")[0];
   const toStr = until.toISOString().split("T")[0];
-  const events = await fetchEventsForMetadata({
-    place: town,
-    from: fromStr,
-    to: toStr,
-    size: MAX_EVENTS_PER_PAGE,
-  });
+
+  // Place lookup and the events probe are independent — parallelize instead
+  // of awaiting sequentially.
+  const [place, events] = await Promise.all([
+    // Tolerate backend 5xx for place lookup (cosmetic; town slug is an
+    // acceptable fallback). Prevents archive 500s from intermittent backend
+    // errors — the main 5xx source per GSC on /sitemap/<town>/<year>/<month>.
+    fetchPlaceBySlugForMetadata(town).catch(() => null),
+    fetchEventsForMetadata({
+      place: town,
+      from: fromStr,
+      to: toStr,
+      size: MAX_EVENTS_PER_PAGE,
+    }),
+  ]);
+  const townLabel = place?.name || town;
+  const placeType: "region" | "town" =
+    place?.type === "CITY" ? "town" : "region";
+  const locationPhrase = formatPlacePreposition(
+    townLabel,
+    placeType,
+    locale,
+    false
+  );
   // `events === null` means the probe itself failed (upstream outage, bad
   // payload) — fail open (no robots override) rather than noindex a page
   // that may well have real content; only a confirmed empty result should

--- a/app/[locale]/sitemap/[town]/page.tsx
+++ b/app/[locale]/sitemap/[town]/page.tsx
@@ -5,6 +5,7 @@ import { MONTHS_URL as DEFAULT_MONTHS_URL } from "@utils/constants";
 // No headers/nonce needed with relaxed CSP
 import JsonLdServer from "@components/partials/JsonLdServer";
 import { getPlaceBySlug } from "@lib/api/places";
+import { fetchPlaceBySlugForMetadata } from "@lib/seo/place-metadata";
 import { getTranslations } from "next-intl/server";
 import type { TownStaticPathParams } from "types/common";
 import type { AppLocale } from "types/i18n";
@@ -35,7 +36,7 @@ export async function generateMetadata({
   // Tolerate backend 5xx: getPlaceBySlug throws on non-200/404. Falling back
   // to null lets the page render with the slug as the label instead of 500ing
   // — fixes ~698 5xx errors flagged by GSC on /sitemap/<town>/...
-  const place = await getPlaceBySlug(town).catch(() => null);
+  const place = await fetchPlaceBySlugForMetadata(town).catch(() => null);
   const label = place?.name || town;
   const placeType: "region" | "town" =
     place?.type === "CITY" ? "town" : "region";

--- a/components/partials/generatePagesData.ts
+++ b/components/partials/generatePagesData.ts
@@ -8,7 +8,7 @@ import {
   PlaceTypeAndLabel,
 } from "types/common";
 import { formatPlacePreposition } from "@utils/helpers";
-import { splitNotFoundText } from "@utils/notFoundMessaging";
+import { splitNotFoundText, appendSearchQuery } from "@utils/notFoundMessaging";
 import { applyLocaleToCanonical } from "@utils/i18n-seo";
 import { DEFAULT_FILTER_VALUE } from "@utils/constants";
 import { DEFAULT_LOCALE, type AppLocale } from "types/i18n";
@@ -73,16 +73,24 @@ const baseCreatePageData = (
   };
 };
 
-export async function generatePagesData({
+// Cached body, deliberately excluding `search`: it's free-text user input
+// (a query-string param), and "use cache" derives its cache key from the
+// function's arguments — including it here would create one cache entry per
+// unique search string, unbounded cardinality on the data cache. `search`
+// only ever affects notFoundTitle (via appendSearchQuery), so the exported
+// generatePagesData wrapper below appends it AFTER reading from the cache,
+// outside the cache boundary. See the Jan 20 2026 fetch-cache-cardinality
+// incident referenced in lib/api's external-fetch caching rules for the
+// same class of bug.
+async function generatePagesDataCached({
   currentYear,
   place = "",
   byDate = "",
   placeTypeLabel,
   category,
   categoryName,
-  search,
   locale,
-}: GeneratePagesDataProps & {
+}: Omit<GeneratePagesDataProps, "search"> & {
   placeTypeLabel: PlaceTypeAndLabel;
   locale?: AppLocale;
 }): Promise<PageData> {
@@ -221,7 +229,7 @@ export async function generatePagesData({
       metaDescription,
       applyLocaleToCanonical(canonical, resolvedLocale),
       notFoundText,
-      search,
+      undefined,
       resolvedLocale
     );
 
@@ -528,4 +536,28 @@ export async function generatePagesData({
     siteUrl,
     t("fallback.notFound")
   );
+}
+
+// Thin uncached wrapper: reads the cached PageData (search-independent, see
+// generatePagesDataCached above), then appends the search query to
+// notFoundTitle outside the cache boundary. appendSearchQuery is pure and
+// idempotent, so calling it here has no caching implications.
+export async function generatePagesData({
+  search,
+  ...rest
+}: GeneratePagesDataProps & {
+  placeTypeLabel: PlaceTypeAndLabel;
+  locale?: AppLocale;
+}): Promise<PageData> {
+  const pageData = await generatePagesDataCached(rest);
+  if (!search) return pageData;
+  const resolvedLocale = rest.locale || DEFAULT_LOCALE;
+  return {
+    ...pageData,
+    notFoundTitle: appendSearchQuery(
+      pageData.notFoundTitle,
+      search,
+      resolvedLocale
+    ),
+  };
 }

--- a/components/partials/generatePagesData.ts
+++ b/components/partials/generatePagesData.ts
@@ -4,8 +4,9 @@ import { cacheLife, cacheTag } from "next/cache";
 import { placesTag, placeTag } from "@lib/cache/tags";
 import {
   PageData,
-  GeneratePagesDataProps,
   PlaceTypeAndLabel,
+  GeneratePagesDataCachedProps,
+  GeneratePagesDataPublicProps,
 } from "types/common";
 import { formatPlacePreposition } from "@utils/helpers";
 import { splitNotFoundText, appendSearchQuery } from "@utils/notFoundMessaging";
@@ -90,10 +91,7 @@ async function generatePagesDataCached({
   category,
   categoryName,
   locale,
-}: Omit<GeneratePagesDataProps, "search"> & {
-  placeTypeLabel: PlaceTypeAndLabel;
-  locale?: AppLocale;
-}): Promise<PageData> {
+}: GeneratePagesDataCachedProps): Promise<PageData> {
   // No dynamic API (headers/cookies/searchParams) is read here — the only
   // request-time value is `now`, used solely as a fallback for the current
   // month/year label on pages with no explicit date/year/month segment (see
@@ -545,10 +543,7 @@ async function generatePagesDataCached({
 export async function generatePagesData({
   search,
   ...rest
-}: GeneratePagesDataProps & {
-  placeTypeLabel: PlaceTypeAndLabel;
-  locale?: AppLocale;
-}): Promise<PageData> {
+}: GeneratePagesDataPublicProps): Promise<PageData> {
   const pageData = await generatePagesDataCached(rest);
   if (!search) return pageData;
   const resolvedLocale = rest.locale || DEFAULT_LOCALE;

--- a/components/partials/generatePagesData.ts
+++ b/components/partials/generatePagesData.ts
@@ -1,7 +1,8 @@
 import { siteUrl } from "@config/index";
 import { getPlaceTypeAndLabel } from "@utils/helpers";
 import { getTranslations } from "next-intl/server";
-import { connection } from "next/server";
+import { cacheLife, cacheTag } from "next/cache";
+import { placesTag, placeTag } from "@lib/cache/tags";
 import {
   PageData,
   GeneratePagesDataProps,
@@ -86,6 +87,21 @@ export async function generatePagesData({
   placeTypeLabel?: PlaceTypeAndLabel;
   locale?: AppLocale;
 }): Promise<PageData> {
+  // No dynamic API (headers/cookies/searchParams) is read here — the only
+  // request-time value is `now`, used solely as a fallback for the current
+  // month/year label on pages with no explicit date/year/month segment (see
+  // effectiveYear/monthIndex below). Caching this "hours" trades exact
+  // per-request freshness for prerenderability: on a calendar-month rollover,
+  // the label can lag by up to ~1h (the "hours" profile's revalidate window)
+  // before self-correcting, same eventual-consistency tradeoff already made
+  // for places/regions/categories elsewhere in this fix. connection() here
+  // used to force this dynamic for every caller, including metadata, which
+  // broke the PPR static shell. See
+  // docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+  "use cache";
+  cacheTag(placesTag, placeTag(place || "catalunya"));
+  cacheLife("hours");
+
   const resolvedLocale = locale || DEFAULT_LOCALE;
 
   // Parallelize translation fetches to eliminate waterfall (2 calls → 1 round trip)
@@ -100,7 +116,6 @@ export async function generatePagesData({
     }),
   ]);
 
-  await connection();
   const now = new Date();
 
   // Used only for parsing numeric month/year parts deterministically.

--- a/components/partials/generatePagesData.ts
+++ b/components/partials/generatePagesData.ts
@@ -1,5 +1,4 @@
 import { siteUrl } from "@config/index";
-import { getPlaceTypeAndLabel } from "@utils/helpers";
 import { getTranslations } from "next-intl/server";
 import { cacheLife, cacheTag } from "next/cache";
 import { placesTag, placeTag } from "@lib/cache/tags";
@@ -84,7 +83,7 @@ export async function generatePagesData({
   search,
   locale,
 }: GeneratePagesDataProps & {
-  placeTypeLabel?: PlaceTypeAndLabel;
+  placeTypeLabel: PlaceTypeAndLabel;
   locale?: AppLocale;
 }): Promise<PageData> {
   // No dynamic API (headers/cookies/searchParams) is read here — the only
@@ -196,8 +195,7 @@ export async function generatePagesData({
     throw new Error("Invalid year range");
   }
 
-  const { type, label }: PlaceTypeAndLabel =
-    placeTypeLabel || (await getPlaceTypeAndLabel(place));
+  const { type, label }: PlaceTypeAndLabel = placeTypeLabel;
   // keep legacy naming compatibility without unused var warnings
   const labelWithArticle = formatPlacePreposition(
     label,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,10 +94,19 @@ export default [
           // headers()), which makes metadata runtime-dynamic, pushes the metadata
           // boundary into the resume tree and breaks PPR. Covers declaration and
           // arrow/expression forms. See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md
+          //
+          // fetchMonthEvents (2026-08-02, sitemap [year]/[month] page) is a
+          // locally-named `cache(async (...) => fetchEvents(...))` wrapper —
+          // this selector only matches by identifier name, so it missed the
+          // real fetchEvents call underneath until reviewed manually. Adding
+          // the specific local alias here is a stopgap, not a generalizable
+          // fix: any future locally-named wrapper around one of these readers
+          // can evade this rule the same way. There is no cheap identifier-only
+          // fix for that; a type-aware rule would be needed to close it fully.
           selector:
-            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEvents|fetchEventBySlug|fetchEventBySlugWithStatus|fetchNews|fetchNewsBySlug|fetchNewsCities)$/]",
+            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getEventBySlug|getNewsBySlug|fetchEvents|fetchMonthEvents|fetchEventBySlug|fetchEventBySlugWithStatus|fetchNews|fetchNewsBySlug|fetchNewsCities)$/]",
           message:
-            "Do not call event/news data readers inside generateMetadata — they read request data (headers()/connection()) and make metadata dynamic under cacheComponents, breaking PPR. Use the request-independent getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
+            "Do not call event/news data readers inside generateMetadata — they read request data (headers()/connection()) and make metadata dynamic under cacheComponents, breaking PPR. Use the request-independent getEventBySlugForMetadata / getNewsBySlugForMetadata / fetchEventsForMetadata instead.",
         },
         {
           // Same class of bug, different call chain: place/region/category

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,6 +99,19 @@ export default [
           message:
             "Do not call event/news data readers inside generateMetadata — they read request data (headers()/connection()) and make metadata dynamic under cacheComponents, breaking PPR. Use the request-independent getEventBySlugForMetadata / getNewsBySlugForMetadata instead.",
         },
+        {
+          // Same class of bug, different call chain: place/region/category
+          // readers found on 2026-08-01 (docs/incidents/2026-04-04-cloudflare-rsc-cache-poisoning.md
+          // is the caching incident; the PPR recurrence is documented in
+          // docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md).
+          // getPlaceTypeAndLabelCached/getCategories are React cache() only —
+          // request memoization, not "use cache" — so the revalidated fetch
+          // underneath still counts as runtime I/O and breaks the static shell.
+          selector:
+            ":matches(FunctionDeclaration[id.name='generateMetadata'], VariableDeclarator[id.name='generateMetadata']) CallExpression[callee.name=/^(getPlaceTypeAndLabelCached|getPlaceTypeAndLabel|fetchPlaceBySlug|getPlaceBySlug|fetchRegionsWithCities|getCategories|fetchCategories|getPlaceExpandability)$/]",
+          message:
+            "Do not call place/region/category data readers inside generateMetadata — they read request data or are only request-memoized (not prerenderable) under cacheComponents. Use the *ForMetadata variant instead (getPlaceTypeAndLabelForMetadata, fetchCategoriesForMetadata, getPlaceExpandabilityForMetadata).",
+        },
       ],
     },
   },

--- a/lib/api/categories.ts
+++ b/lib/api/categories.ts
@@ -74,7 +74,7 @@ export async function fetchCategoriesForMetadata(): Promise<
   });
   const response = await fetch(url, {
     headers: getVercelProtectionBypassHeaders(),
-    next: { revalidate: 86400, tags: ["categories"] },
+    next: { revalidate: 86400, tags: [categoriesTag] },
   });
   if (!response.ok) {
     // Categories are a fallback enrichment for metadata copy, not the

--- a/lib/api/categories.ts
+++ b/lib/api/categories.ts
@@ -6,7 +6,7 @@ import { createCache, createKeyedCache } from "lib/api/cache";
 import { getInternalApiUrl, getVercelProtectionBypassHeaders } from "@utils/api-helpers";
 import { cache as reactCache } from "react";
 import { parseCategories } from "lib/validation/category";
-import { isBuildPhase } from "@utils/constants";
+import { isBuildPhase } from "@utils/build-phase";
 import { categoriesTag } from "@lib/cache/tags";
 import { cacheLife, cacheTag } from "next/cache";
 import {

--- a/lib/api/categories.ts
+++ b/lib/api/categories.ts
@@ -7,6 +7,8 @@ import { getInternalApiUrl, getVercelProtectionBypassHeaders } from "@utils/api-
 import { cache as reactCache } from "react";
 import { parseCategories } from "lib/validation/category";
 import { isBuildPhase } from "@utils/constants";
+import { categoriesTag } from "@lib/cache/tags";
+import { cacheLife, cacheTag } from "next/cache";
 import {
   fetchCategoriesExternal,
   fetchCategoryByIdExternal,
@@ -57,6 +59,32 @@ export async function fetchCategories(): Promise<CategorySummaryResponseDTO[]> {
 
 // React per-request memoization for metadata+page deduplication
 export const getCategories = reactCache(fetchCategories);
+
+// Metadata-only reader: resolves the API origin from configuration instead of
+// request headers(), and is itself cached, so generateMetadata stays
+// prerenderable under cacheComponents. See
+// docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+export async function fetchCategoriesForMetadata(): Promise<
+  CategorySummaryResponseDTO[]
+> {
+  "use cache";
+  cacheTag(categoriesTag);
+  const url = await getInternalApiUrl(`/api/categories`, {
+    preferConfiguredOrigin: true,
+  });
+  const response = await fetch(url, {
+    headers: getVercelProtectionBypassHeaders(),
+    next: { revalidate: 86400, tags: ["categories"] },
+  });
+  if (!response.ok) {
+    // Categories are a fallback enrichment for metadata copy, not the
+    // primary lookup — degrade to empty rather than throw.
+    return [];
+  }
+  cacheLife("hours");
+  const json = await response.json();
+  return parseCategories(json);
+}
 
 async function fetchCategoryByIdApi(
   id: string | number

--- a/lib/api/cities.ts
+++ b/lib/api/cities.ts
@@ -5,7 +5,7 @@ import {
   getVercelProtectionBypassHeaders,
 } from "@utils/api-helpers";
 import { fetchCitiesExternal } from "./cities-external";
-import { PHASE_PRODUCTION_BUILD } from "next/constants";
+import { isBuildPhase } from "@utils/constants";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 
 const { cache: citiesListCache, clear: clearCitiesListCache } =
@@ -49,11 +49,6 @@ export async function fetchCities(): Promise<CitySummaryResponseDTO[]> {
 
   // During build phase, bypass internal proxy and call external API directly
   // This ensures SSG pages (sitemap) can fetch data during next build
-  // Detection: Check if NEXT_PHASE is set, or if we're in production build context
-  const isBuildPhase =
-    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD ||
-    (process.env.NODE_ENV === "production" && !process.env.VERCEL_URL);
-
   if (isBuildPhase) {
     try {
       return await fetchCitiesExternal();

--- a/lib/api/cities.ts
+++ b/lib/api/cities.ts
@@ -5,7 +5,7 @@ import {
   getVercelProtectionBypassHeaders,
 } from "@utils/api-helpers";
 import { fetchCitiesExternal } from "./cities-external";
-import { isBuildPhase } from "@utils/constants";
+import { isBuildPhase } from "@utils/build-phase";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 
 const { cache: citiesListCache, clear: clearCitiesListCache } =

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -173,37 +173,46 @@ export const fetchEvents = cache(fetchEventsInternal);
 // static shell when called from generateMetadata. This variant hits the
 // internal /api/events route with a plain, tagged fetch instead. See
 // docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+//
+// Returns `null` (not an empty page) on any failure to fetch/parse, so
+// callers can tell "genuinely no events" apart from "couldn't check" and
+// fail open (e.g. don't noindex a page just because the probe errored) —
+// same convention as getPlaceExpandability's fail-open contract.
 export async function fetchEventsForMetadata(
   params: FetchEventsParams,
-): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
+): Promise<PagedResponseDTO<EventSummaryResponseDTO> | null> {
   "use cache";
   cacheTag(eventsTag);
-  const fallbackResponse: PagedResponseDTO<EventSummaryResponseDTO> = {
-    content: [],
-    currentPage: params.page ?? 0,
-    pageSize: params.size ?? 12,
-    totalElements: 0,
-    totalPages: 0,
-    last: true,
-  };
-  const queryString = buildEventsQuery(params);
-  const url = await getInternalApiUrl(`/api/events?${queryString}`, {
-    preferConfiguredOrigin: true,
-  });
-  const response = await fetch(url, {
-    headers: getVercelProtectionBypassHeaders(),
-    next: { revalidate: 600, tags: [eventsTag] },
-  });
-  if (!response.ok) {
-    // Transient upstream failure — cache briefly rather than "hours" so a
-    // recovering backend doesn't leave metadata degraded for a long window.
+  try {
+    const queryString = buildEventsQuery(params);
+    const url = await getInternalApiUrl(`/api/events?${queryString}`, {
+      preferConfiguredOrigin: true,
+    });
+    const response = await fetch(url, {
+      headers: getVercelProtectionBypassHeaders(),
+      next: { revalidate: 600, tags: [eventsTag] },
+    });
+    if (!response.ok) {
+      // Transient upstream failure — cache briefly rather than "hours" so a
+      // recovering backend doesn't leave metadata degraded for a long window.
+      cacheLife("minutes");
+      return null;
+    }
+    const data = await response.json();
+    const validated = parsePagedEvents(data);
+    if (!validated) {
+      // Malformed 2xx payload — same short-lived treatment as a failed
+      // request, not "hours": a schema/proxy blip shouldn't be cached as
+      // if it were a confirmed empty result.
+      cacheLife("minutes");
+      return null;
+    }
+    cacheLife("hours");
+    return validated;
+  } catch {
     cacheLife("minutes");
-    return fallbackResponse;
+    return null;
   }
-  const data = await response.json();
-  const validated = parsePagedEvents(data);
-  cacheLife("hours");
-  return validated ?? fallbackResponse;
 }
 
 export async function fetchEventBySlug(

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -26,8 +26,8 @@ import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 import {
   EVENT_IMAGE_UPLOAD_TOO_LARGE_ERROR,
   MAX_TOTAL_UPLOAD_BYTES,
-  isBuildPhase,
 } from "@utils/constants";
+import { isBuildPhase } from "@utils/build-phase";
 import { filterActiveEvents } from "@utils/event-helpers";
 import {
   ListEvent,

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -164,6 +164,48 @@ async function fetchEventsInternal(
 
 export const fetchEvents = cache(fetchEventsInternal);
 
+// Metadata-only reader: resolves the API origin from configuration instead of
+// request headers(), and is itself cached, so generateMetadata stays
+// prerenderable under cacheComponents. fetchEvents (above) goes through
+// fetchWithHmac, which unconditionally calls connection() — a genuine dynamic
+// API — so wrapping it in React cache() (as fetchMonthEvents does in the
+// sitemap month page) does NOT make it prerenderable; it still breaks the
+// static shell when called from generateMetadata. This variant hits the
+// internal /api/events route with a plain, tagged fetch instead. See
+// docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+export async function fetchEventsForMetadata(
+  params: FetchEventsParams,
+): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
+  "use cache";
+  cacheTag(eventsTag);
+  const fallbackResponse: PagedResponseDTO<EventSummaryResponseDTO> = {
+    content: [],
+    currentPage: params.page ?? 0,
+    pageSize: params.size ?? 12,
+    totalElements: 0,
+    totalPages: 0,
+    last: true,
+  };
+  const queryString = buildEventsQuery(params);
+  const url = await getInternalApiUrl(`/api/events?${queryString}`, {
+    preferConfiguredOrigin: true,
+  });
+  const response = await fetch(url, {
+    headers: getVercelProtectionBypassHeaders(),
+    next: { revalidate: 600, tags: [eventsTag] },
+  });
+  if (!response.ok) {
+    // Transient upstream failure — cache briefly rather than "hours" so a
+    // recovering backend doesn't leave metadata degraded for a long window.
+    cacheLife("minutes");
+    return fallbackResponse;
+  }
+  const data = await response.json();
+  const validated = parsePagedEvents(data);
+  cacheLife("hours");
+  return validated ?? fallbackResponse;
+}
+
 export async function fetchEventBySlug(
   fullSlug: string,
   options: InternalOriginOptions = {},

--- a/lib/api/places.ts
+++ b/lib/api/places.ts
@@ -2,7 +2,7 @@ import { PlaceResponseDTO } from "types/api/place";
 import { createKeyedCache, createCache } from "@lib/api/cache";
 import { getInternalApiUrl, getVercelProtectionBypassHeaders } from "@utils/api-helpers";
 import { cache } from "react";
-import { isBuildPhase } from "@utils/constants";
+import { isBuildPhase } from "@utils/build-phase";
 import {
   fetchPlaceBySlugExternal,
   fetchPlacesAggregatedExternal,

--- a/lib/api/regions.ts
+++ b/lib/api/regions.ts
@@ -9,7 +9,7 @@ import {
   fetchRegionsExternal,
   fetchRegionsOptionsExternal,
 } from "./regions-external";
-import { PHASE_PRODUCTION_BUILD } from "next/constants";
+import { isBuildPhase } from "@utils/constants";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 
 const { cache: regionsListCache, clear: clearRegionsListCache } =
@@ -53,12 +53,6 @@ export async function fetchRegions(): Promise<RegionSummaryResponseDTO[]> {
 
   // During build phase, bypass internal proxy and call external API directly
   // This ensures SSG pages (homepage, sitemap) can fetch data during next build
-  // Detection: Check if NEXT_PHASE is set, or if we're in production build context
-  // (NEXT_PHASE may not always be set, so we also check for build-time indicators)
-  const isBuildPhase =
-    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD ||
-    (process.env.NODE_ENV === "production" && !process.env.VERCEL_URL);
-
   if (isBuildPhase) {
     try {
       return await fetchRegionsExternal();
@@ -113,11 +107,6 @@ export async function fetchRegionsWithCities(): Promise<
   RegionsGroupedByCitiesResponseDTO[]
 > {
   // During build phase, bypass internal proxy
-  // Detection: Check if NEXT_PHASE is set, or if we're in production build context
-  const isBuildPhase =
-    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD ||
-    (process.env.NODE_ENV === "production" && !process.env.VERCEL_URL);
-
   if (isBuildPhase) {
     try {
       const data = await fetchRegionsOptionsExternal();

--- a/lib/api/regions.ts
+++ b/lib/api/regions.ts
@@ -9,7 +9,7 @@ import {
   fetchRegionsExternal,
   fetchRegionsOptionsExternal,
 } from "./regions-external";
-import { isBuildPhase } from "@utils/constants";
+import { isBuildPhase } from "@utils/build-phase";
 import { getSanitizedErrorMessage } from "@utils/api-error-handler";
 
 const { cache: regionsListCache, clear: clearRegionsListCache } =

--- a/lib/seo/place-expandability.ts
+++ b/lib/seo/place-expandability.ts
@@ -1,7 +1,24 @@
 import { cache } from "react";
+import { cacheLife } from "next/cache";
 import { fetchEventCountExternal } from "@lib/api/events-external";
 import { SITEMAP_MIN_EVENTS_FOR_EXPANSION } from "@utils/constants";
 import type { PlaceType } from "types/common";
+
+async function resolvePlaceExpandability(
+  slug: string,
+  type: PlaceType,
+): Promise<boolean> {
+  if (type !== "town") return true;
+  if (!slug || slug === "catalunya") return true;
+  try {
+    const count = await fetchEventCountExternal(slug);
+    return count === null || count >= SITEMAP_MIN_EVENTS_FOR_EXPANSION;
+  } catch {
+    // Fail open on unexpected errors so transient failures don't shrink
+    // sitemap or hide internal links.
+    return true;
+  }
+}
 
 /**
  * Determines whether a place has enough event depth to warrant filter
@@ -26,17 +43,19 @@ import type { PlaceType } from "types/common";
  * and API I/O; `utils/` is reserved for deterministic, side-effect-free
  * helpers.
  */
-export const getPlaceExpandability = cache(
-  async (slug: string, type: PlaceType): Promise<boolean> => {
-    if (type !== "town") return true;
-    if (!slug || slug === "catalunya") return true;
-    try {
-      const count = await fetchEventCountExternal(slug);
-      return count === null || count >= SITEMAP_MIN_EVENTS_FOR_EXPANSION;
-    } catch {
-      // Fail open on unexpected errors so transient failures don't shrink
-      // sitemap or hide internal links.
-      return true;
-    }
-  },
-);
+export const getPlaceExpandability = cache(resolvePlaceExpandability);
+
+// Metadata-only reader: wraps the same check in `"use cache"` so
+// generateMetadata stays prerenderable under cacheComponents. The underlying
+// fetchEventCountExternal call has no cache directive of its own — React
+// cache() is request memoization only and doesn't make an uncached fetch
+// prerenderable, so an outer "use cache" boundary is required here too. See
+// docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+export async function getPlaceExpandabilityForMetadata(
+  slug: string,
+  type: PlaceType,
+): Promise<boolean> {
+  "use cache";
+  cacheLife("hours");
+  return resolvePlaceExpandability(slug, type);
+}

--- a/lib/seo/place-expandability.ts
+++ b/lib/seo/place-expandability.ts
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { fetchEventCountExternal } from "@lib/api/events-external";
 import {
+  buildEventsQuery,
   getInternalApiUrl,
   getVercelProtectionBypassHeaders,
 } from "@utils/api-helpers";
@@ -33,10 +34,10 @@ async function resolvePlaceExpandability(
 // getPlaceExpandabilityForMetadata below — it would stay a resume-mismatch
 // hazard despite the "use cache" wrapper.
 async function fetchEventCountForMetadata(slug: string): Promise<number | null> {
-  const url = await getInternalApiUrl(
-    `/api/events?place=${encodeURIComponent(slug)}&size=1`,
-    { preferConfiguredOrigin: true },
-  );
+  const queryString = buildEventsQuery({ place: slug, size: 1 });
+  const url = await getInternalApiUrl(`/api/events?${queryString}`, {
+    preferConfiguredOrigin: true,
+  });
   const response = await fetch(url, {
     headers: getVercelProtectionBypassHeaders(),
     next: { revalidate: 600, tags: [eventsTag] },

--- a/lib/seo/place-expandability.ts
+++ b/lib/seo/place-expandability.ts
@@ -1,23 +1,49 @@
 import { cache } from "react";
-import { cacheLife } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { fetchEventCountExternal } from "@lib/api/events-external";
+import {
+  getInternalApiUrl,
+  getVercelProtectionBypassHeaders,
+} from "@utils/api-helpers";
+import { eventsTag } from "@lib/cache/tags";
 import { SITEMAP_MIN_EVENTS_FOR_EXPANSION } from "@utils/constants";
 import type { PlaceType } from "types/common";
 
 async function resolvePlaceExpandability(
   slug: string,
   type: PlaceType,
+  fetchCount: (slug: string) => Promise<number | null>,
 ): Promise<boolean> {
   if (type !== "town") return true;
   if (!slug || slug === "catalunya") return true;
   try {
-    const count = await fetchEventCountExternal(slug);
+    const count = await fetchCount(slug);
     return count === null || count >= SITEMAP_MIN_EVENTS_FOR_EXPANSION;
   } catch {
     // Fail open on unexpected errors so transient failures don't shrink
     // sitemap or hide internal links.
     return true;
   }
+}
+
+// Metadata-only count reader: hits the internal API route with a plain,
+// tagged `fetch()` instead of `fetchEventCountExternal` (which goes through
+// `fetchWithHmac`, and that calls `connection()` unconditionally). Calling a
+// dynamic API from inside a "use cache" scope defeats the whole point of
+// getPlaceExpandabilityForMetadata below — it would stay a resume-mismatch
+// hazard despite the "use cache" wrapper.
+async function fetchEventCountForMetadata(slug: string): Promise<number | null> {
+  const url = await getInternalApiUrl(
+    `/api/events?place=${encodeURIComponent(slug)}&size=1`,
+    { preferConfiguredOrigin: true },
+  );
+  const response = await fetch(url, {
+    headers: getVercelProtectionBypassHeaders(),
+    next: { revalidate: 600, tags: ["events"] },
+  });
+  if (!response.ok) return null;
+  const data = await response.json();
+  return typeof data?.totalElements === "number" ? data.totalElements : null;
 }
 
 /**
@@ -43,19 +69,19 @@ async function resolvePlaceExpandability(
  * and API I/O; `utils/` is reserved for deterministic, side-effect-free
  * helpers.
  */
-export const getPlaceExpandability = cache(resolvePlaceExpandability);
+export const getPlaceExpandability = cache((slug: string, type: PlaceType) =>
+  resolvePlaceExpandability(slug, type, fetchEventCountExternal),
+);
 
 // Metadata-only reader: wraps the same check in `"use cache"` so
-// generateMetadata stays prerenderable under cacheComponents. The underlying
-// fetchEventCountExternal call has no cache directive of its own — React
-// cache() is request memoization only and doesn't make an uncached fetch
-// prerenderable, so an outer "use cache" boundary is required here too. See
+// generateMetadata stays prerenderable under cacheComponents. See
 // docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
 export async function getPlaceExpandabilityForMetadata(
   slug: string,
   type: PlaceType,
 ): Promise<boolean> {
   "use cache";
+  cacheTag(eventsTag);
   cacheLife("hours");
-  return resolvePlaceExpandability(slug, type);
+  return resolvePlaceExpandability(slug, type, fetchEventCountForMetadata);
 }

--- a/lib/seo/place-expandability.ts
+++ b/lib/seo/place-expandability.ts
@@ -39,7 +39,7 @@ async function fetchEventCountForMetadata(slug: string): Promise<number | null> 
   );
   const response = await fetch(url, {
     headers: getVercelProtectionBypassHeaders(),
-    next: { revalidate: 600, tags: ["events"] },
+    next: { revalidate: 600, tags: [eventsTag] },
   });
   if (!response.ok) return null;
   const data = await response.json();
@@ -69,8 +69,9 @@ async function fetchEventCountForMetadata(slug: string): Promise<number | null> 
  * and API I/O; `utils/` is reserved for deterministic, side-effect-free
  * helpers.
  */
-export const getPlaceExpandability = cache((slug: string, type: PlaceType) =>
-  resolvePlaceExpandability(slug, type, fetchEventCountExternal),
+export const getPlaceExpandability = cache(
+  (slug: string, type: PlaceType): Promise<boolean> =>
+    resolvePlaceExpandability(slug, type, fetchEventCountExternal),
 );
 
 // Metadata-only reader: wraps the same check in `"use cache"` so

--- a/lib/seo/place-metadata.ts
+++ b/lib/seo/place-metadata.ts
@@ -64,7 +64,7 @@ export async function getPlaceTypeAndLabelForMetadata(
   place: string,
 ): Promise<PlaceTypeAndLabel> {
   "use cache";
-  cacheTag(placesTag, regionsTag);
+  cacheTag(placesTag, regionsTag, regionsOptionsTag);
   cacheLife("hours");
   return resolvePlaceTypeAndLabel(
     place,

--- a/lib/seo/place-metadata.ts
+++ b/lib/seo/place-metadata.ts
@@ -1,0 +1,74 @@
+// Metadata-only readers for place/region lookups. Kept out of lib/api/places.ts,
+// lib/api/regions.ts, and utils/location-helpers.ts because those files are
+// transitively reachable from Client Components (via utils/helpers.ts ->
+// utils/url-filters.ts -> UrlFiltersContext.tsx), and Next.js forbids defining
+// an inline `"use cache"` function in a file that can be pulled into a client
+// bundle. See docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+import { cacheLife, cacheTag } from "next/cache";
+import { PlaceResponseDTO } from "types/api/place";
+import { RegionsGroupedByCitiesResponseDTO } from "types/api/region";
+import type { PlaceTypeAndLabel } from "types/common";
+import {
+  getInternalApiUrl,
+  getVercelProtectionBypassHeaders,
+} from "@utils/api-helpers";
+import { placesTag, placeTag, regionsTag, regionsOptionsTag } from "@lib/cache/tags";
+import { resolvePlaceTypeAndLabel } from "@utils/location-helpers";
+
+// Resolves the API origin from configuration instead of request headers(), so
+// generateMetadata stays prerenderable under cacheComponents. Mirrors
+// fetchCategoriesForMetadata / getNewsBySlugForMetadata.
+export async function fetchPlaceBySlugForMetadata(
+  slug: string,
+): Promise<PlaceResponseDTO | null> {
+  "use cache";
+  cacheTag(placesTag, placeTag(slug));
+  const encodedSlug = encodeURIComponent(slug);
+  const url = await getInternalApiUrl(`/api/places/${encodedSlug}`, {
+    preferConfiguredOrigin: true,
+  });
+  const response = await fetch(url, {
+    headers: getVercelProtectionBypassHeaders(),
+    next: { revalidate: 86400, tags: ["places", `place:${slug}`] },
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch place ${slug}: HTTP ${response.status}`);
+  }
+  cacheLife("hours");
+  return response.json();
+}
+
+export async function fetchRegionsWithCitiesForMetadata(): Promise<
+  RegionsGroupedByCitiesResponseDTO[]
+> {
+  "use cache";
+  cacheTag(regionsTag, regionsOptionsTag);
+  const url = await getInternalApiUrl(`/api/regions/options`, {
+    preferConfiguredOrigin: true,
+  });
+  const response = await fetch(url, {
+    headers: getVercelProtectionBypassHeaders(),
+    next: { revalidate: 86400, tags: ["regions", "regions:options"] },
+  });
+  if (!response.ok) {
+    return [];
+  }
+  cacheLife("hours");
+  return response.json();
+}
+
+export async function getPlaceTypeAndLabelForMetadata(
+  place: string,
+): Promise<PlaceTypeAndLabel> {
+  "use cache";
+  cacheTag(placesTag, regionsTag);
+  cacheLife("hours");
+  return resolvePlaceTypeAndLabel(
+    place,
+    fetchPlaceBySlugForMetadata,
+    fetchRegionsWithCitiesForMetadata,
+  );
+}

--- a/lib/seo/place-metadata.ts
+++ b/lib/seo/place-metadata.ts
@@ -29,7 +29,7 @@ export async function fetchPlaceBySlugForMetadata(
   });
   const response = await fetch(url, {
     headers: getVercelProtectionBypassHeaders(),
-    next: { revalidate: 86400, tags: ["places", `place:${slug}`] },
+    next: { revalidate: 86400, tags: [placesTag, placeTag(slug)] },
   });
   if (response.status === 404) {
     return null;

--- a/lib/seo/place-metadata.ts
+++ b/lib/seo/place-metadata.ts
@@ -32,6 +32,11 @@ export async function fetchPlaceBySlugForMetadata(
     next: { revalidate: 86400, tags: [placesTag, placeTag(slug)] },
   });
   if (response.status === 404) {
+    // Genuine 404: cache briefly so a newly-created place isn't stuck on
+    // "not found" metadata for hours. "minutes" not "seconds" — seconds is a
+    // PPR dynamic hole and would re-break the static shell. Mirrors
+    // getNewsBySlugForMetadata / getEventBySlugForMetadata.
+    cacheLife("minutes");
     return null;
   }
   if (!response.ok) {
@@ -51,9 +56,10 @@ export async function fetchRegionsWithCitiesForMetadata(): Promise<
   });
   const response = await fetch(url, {
     headers: getVercelProtectionBypassHeaders(),
-    next: { revalidate: 86400, tags: ["regions", "regions:options"] },
+    next: { revalidate: 86400, tags: [regionsTag, regionsOptionsTag] },
   });
   if (!response.ok) {
+    cacheLife("minutes");
     return [];
   }
   cacheLife("hours");

--- a/test/build-phase.test.ts
+++ b/test/build-phase.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("isBuildPhase", () => {
+  const ENV_BACKUP = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...ENV_BACKUP };
+  });
+
+  it("is true when NEXT_PHASE is phase-production-build", async () => {
+    process.env.NEXT_PHASE = "phase-production-build";
+    const { isBuildPhase } = await import("@utils/build-phase");
+    expect(isBuildPhase).toBe(true);
+  });
+
+  it("is false when NEXT_PHASE is unset at runtime", async () => {
+    delete process.env.NEXT_PHASE;
+    const { isBuildPhase } = await import("@utils/build-phase");
+    expect(isBuildPhase).toBe(false);
+  });
+
+  it("is false in production with NEXT_PHASE unset (self-hosted runtime, no VERCEL_URL)", async () => {
+    // Regression guard for the incident this module's doc comment describes:
+    // a NODE_ENV === "production" && !VERCEL_URL fallback used to make this
+    // permanently true on self-hosted (Coolify) production, since self-hosted
+    // prod never sets VERCEL_URL either. NEXT_PHASE must be the only signal.
+    delete process.env.NEXT_PHASE;
+    delete process.env.VERCEL_URL;
+    (process.env as { NODE_ENV?: string }).NODE_ENV = "production";
+    const { isBuildPhase } = await import("@utils/build-phase");
+    expect(isBuildPhase).toBe(false);
+  });
+
+  it("is false for other NEXT_PHASE values", async () => {
+    process.env.NEXT_PHASE = "phase-development-server";
+    const { isBuildPhase } = await import("@utils/build-phase");
+    expect(isBuildPhase).toBe(false);
+  });
+});

--- a/test/generatePagesData-localization.test.ts
+++ b/test/generatePagesData-localization.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// generatePagesData is "use cache" (cacheComponents) — see
+// docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+}));
 
 import { generatePagesData } from "@components/partials/generatePagesData";
 import type { GeneratePagesDataProps, PlaceTypeAndLabel } from "types/common";

--- a/test/generatePagesData.test.ts
+++ b/test/generatePagesData.test.ts
@@ -1,4 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// generatePagesData is "use cache" (cacheComponents) so it can stay
+// prerenderable when called from generateMetadata — see
+// docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+// cacheTag/cacheLife are no-ops outside a real Next.js cacheComponents
+// runtime, which vitest doesn't provide.
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+}));
+
 import { generatePagesData } from "@components/partials/generatePagesData";
 import type {
   GeneratePagesDataProps,

--- a/test/lib/api/categories.test.ts
+++ b/test/lib/api/categories.test.ts
@@ -8,6 +8,11 @@ vi.mock("@utils/api-helpers", () => ({
   getVercelProtectionBypassHeaders: vi.fn(() => ({})),
 }));
 
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+}));
+
 vi.mock("lib/validation/category", () => ({
   parseCategories: vi.fn((data: unknown) => data),
 }));
@@ -107,5 +112,33 @@ describe("lib/api/categories", () => {
   it("clearCategoriesCaches runs without error", async () => {
     const { clearCategoriesCaches } = await import("lib/api/categories");
     expect(() => clearCategoriesCaches()).not.toThrow();
+  });
+
+  it("fetchCategoriesForMetadata makes fetch call and returns parsed data", async () => {
+    const { fetchCategoriesForMetadata } = await import("lib/api/categories");
+    const result = await fetchCategoriesForMetadata();
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveProperty("slug", "musica");
+  });
+
+  it("fetchCategoriesForMetadata degrades to an empty array on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }),
+    );
+    const { fetchCategoriesForMetadata } = await import("lib/api/categories");
+    const result = await fetchCategoriesForMetadata();
+    expect(result).toEqual([]);
+  });
+
+  it("fetchCategoriesForMetadata calls cacheTag/cacheLife (use cache boundary)", async () => {
+    const { cacheTag, cacheLife } = await import("next/cache");
+    const { fetchCategoriesForMetadata } = await import("lib/api/categories");
+    await fetchCategoriesForMetadata();
+    expect(cacheTag).toHaveBeenCalled();
+    expect(cacheLife).toHaveBeenCalledWith("hours");
   });
 });

--- a/test/lib/api/events-for-metadata.test.ts
+++ b/test/lib/api/events-for-metadata.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  connection: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@utils/api-helpers", async () => {
+  const actual = await vi.importActual<typeof import("@utils/api-helpers")>(
+    "@utils/api-helpers",
+  );
+  return {
+    ...actual,
+    getInternalApiUrl: vi.fn((path: string) =>
+      Promise.resolve(`http://localhost:3000${path}`),
+    ),
+    getVercelProtectionBypassHeaders: vi.fn(() => ({})),
+  };
+});
+
+const validEvent = {
+  id: "1",
+  hash: "abc123",
+  slug: "test-event",
+  title: "Test event",
+  type: "FREE",
+  url: "https://example.com/test-event",
+  description: "",
+  imageUrl: null,
+  startDate: "2026-01-01",
+  startTime: null,
+  endDate: null,
+  endTime: null,
+  location: "",
+  visits: 0,
+  origin: "MANUAL",
+  categories: [],
+};
+
+const pagedResponse = {
+  content: [validEvent],
+  currentPage: 0,
+  pageSize: 12,
+  totalElements: 1,
+  totalPages: 1,
+  last: true,
+};
+
+describe("fetchEventsForMetadata", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the parsed response on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(pagedResponse),
+      }),
+    );
+    const { fetchEventsForMetadata } = await import("@lib/api/events");
+    const result = await fetchEventsForMetadata({ place: "sabadell" });
+    expect(result).toEqual(pagedResponse);
+  });
+
+  it("returns null (not an empty page) on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    const { fetchEventsForMetadata } = await import("@lib/api/events");
+    const result = await fetchEventsForMetadata({ place: "sabadell" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null on a malformed 2xx payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ garbage: true }),
+      }),
+    );
+    const { fetchEventsForMetadata } = await import("@lib/api/events");
+    const result = await fetchEventsForMetadata({ place: "sabadell" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null instead of throwing on a network error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down")),
+    );
+    const { fetchEventsForMetadata } = await import("@lib/api/events");
+    const result = await fetchEventsForMetadata({ place: "sabadell" });
+    expect(result).toBeNull();
+  });
+
+  it("calls cacheTag/cacheLife on success (use cache boundary)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(pagedResponse),
+      }),
+    );
+    const { cacheTag, cacheLife } = await import("next/cache");
+    const { fetchEventsForMetadata } = await import("@lib/api/events");
+    await fetchEventsForMetadata({ place: "sabadell" });
+    expect(cacheTag).toHaveBeenCalled();
+    expect(cacheLife).toHaveBeenCalledWith("hours");
+  });
+
+  it("uses the minutes profile on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    const { cacheLife } = await import("next/cache");
+    const { fetchEventsForMetadata } = await import("@lib/api/events");
+    await fetchEventsForMetadata({ place: "sabadell" });
+    expect(cacheLife).toHaveBeenCalledWith("minutes");
+  });
+});

--- a/test/lib/seo/place-metadata.test.ts
+++ b/test/lib/seo/place-metadata.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+}));
+
+vi.mock("@utils/api-helpers", () => ({
+  getInternalApiUrl: vi.fn((path: string) =>
+    Promise.resolve(`http://localhost:3000${path}`),
+  ),
+  getVercelProtectionBypassHeaders: vi.fn(() => ({})),
+}));
+
+import {
+  fetchPlaceBySlugForMetadata,
+  fetchRegionsWithCitiesForMetadata,
+  getPlaceTypeAndLabelForMetadata,
+} from "@lib/seo/place-metadata";
+
+describe("fetchPlaceBySlugForMetadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the parsed place on success", async () => {
+    const place = { id: 1, type: "CITY", name: "Sabadell", slug: "sabadell" };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve(place),
+      }),
+    );
+    const result = await fetchPlaceBySlugForMetadata("sabadell");
+    expect(result).toEqual(place);
+  });
+
+  it("returns null on a 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 404, ok: false }),
+    );
+    const result = await fetchPlaceBySlugForMetadata("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("throws on a non-404 error response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 500, ok: false }),
+    );
+    await expect(fetchPlaceBySlugForMetadata("sabadell")).rejects.toThrow(
+      "HTTP 500",
+    );
+  });
+});
+
+describe("fetchRegionsWithCitiesForMetadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the parsed regions on success", async () => {
+    const regions = [{ id: 1, name: "Vallès Occidental", cities: [] }];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(regions),
+      }),
+    );
+    const result = await fetchRegionsWithCitiesForMetadata();
+    expect(result).toEqual(regions);
+  });
+
+  it("degrades to an empty array on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    const result = await fetchRegionsWithCitiesForMetadata();
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getPlaceTypeAndLabelForMetadata", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 404, ok: false }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns Catalunya for an empty place without any fetch", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockClear();
+    const result = await getPlaceTypeAndLabelForMetadata("");
+    expect(result).toEqual({ type: "region", label: "Catalunya" });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a dehyphenated slug when the place and regions lookups both miss", async () => {
+    const result = await getPlaceTypeAndLabelForMetadata("some-town");
+    expect(result).toEqual({ type: "town", label: "Some Town" });
+  });
+});

--- a/test/location-helpers.test.ts
+++ b/test/location-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   buildDisplayLocation,
   buildEventLocationLabels,
@@ -6,7 +6,10 @@ import {
   buildEventListLocationLabels,
   getDistance,
   deg2rad,
+  resolvePlaceTypeAndLabel,
 } from "../utils/location-helpers";
+import type { PlaceResponseDTO } from "types/api/place";
+import type { RegionsGroupedByCitiesResponseDTO } from "types/api/region";
 
 describe("buildDisplayLocation", () => {
   it("returns location when no city/region", () => {
@@ -237,5 +240,127 @@ describe("deg2rad", () => {
 
   it("converts negative degrees", () => {
     expect(deg2rad(-90)).toBeCloseTo(-Math.PI / 2);
+  });
+});
+
+describe("resolvePlaceTypeAndLabel", () => {
+  const region: RegionsGroupedByCitiesResponseDTO = {
+    id: 1,
+    name: "Vallès Occidental",
+    slug: "valles-occidental",
+    cities: [
+      { id: 10, value: "sabadell", label: "Sabadell", latitude: 0, longitude: 0 },
+    ],
+  };
+
+  it("returns Catalunya for an empty place without calling any fetcher", async () => {
+    const fetchPlace = vi.fn();
+    const fetchRegions = vi.fn();
+    const result = await resolvePlaceTypeAndLabel("", fetchPlace, fetchRegions);
+    expect(result).toEqual({ type: "region", label: "Catalunya" });
+    expect(fetchPlace).not.toHaveBeenCalled();
+    expect(fetchRegions).not.toHaveBeenCalled();
+  });
+
+  it("returns Catalunya for the virtual 'catalunya' slug without calling any fetcher", async () => {
+    const fetchPlace = vi.fn();
+    const fetchRegions = vi.fn();
+    const result = await resolvePlaceTypeAndLabel(
+      "catalunya",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({ type: "region", label: "Catalunya" });
+    expect(fetchPlace).not.toHaveBeenCalled();
+    expect(fetchRegions).not.toHaveBeenCalled();
+  });
+
+  it("resolves a CITY place and attaches its parent region", async () => {
+    const place: PlaceResponseDTO = {
+      id: 10,
+      type: "CITY",
+      name: "Sabadell",
+      slug: "sabadell",
+    };
+    const fetchPlace = vi.fn().mockResolvedValue(place);
+    const fetchRegions = vi.fn().mockResolvedValue([region]);
+    const result = await resolvePlaceTypeAndLabel(
+      "sabadell",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({
+      type: "town",
+      label: "Sabadell",
+      regionLabel: "Vallès Occidental",
+      regionSlug: "valles-occidental",
+    });
+  });
+
+  it("resolves a REGION place without a parent region lookup", async () => {
+    const place: PlaceResponseDTO = {
+      id: 1,
+      type: "REGION",
+      name: "Vallès Occidental",
+      slug: "valles-occidental",
+    };
+    const fetchPlace = vi.fn().mockResolvedValue(place);
+    const fetchRegions = vi.fn();
+    const result = await resolvePlaceTypeAndLabel(
+      "valles-occidental",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({ type: "region", label: "Vallès Occidental" });
+    expect(fetchRegions).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the regions lookup when fetchPlace returns null", async () => {
+    const fetchPlace = vi.fn().mockResolvedValue(null);
+    const fetchRegions = vi.fn().mockResolvedValue([region]);
+    const result = await resolvePlaceTypeAndLabel(
+      "sabadell",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({
+      type: "town",
+      label: "Sabadell",
+      regionLabel: "Vallès Occidental",
+      regionSlug: "valles-occidental",
+    });
+  });
+
+  it("falls through to the regions lookup when fetchPlace throws", async () => {
+    const fetchPlace = vi.fn().mockRejectedValue(new Error("network error"));
+    const fetchRegions = vi.fn().mockResolvedValue([region]);
+    const result = await resolvePlaceTypeAndLabel(
+      "valles-occidental",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({ type: "region", label: "Vallès Occidental" });
+  });
+
+  it("falls back to a dehyphenated slug when nothing matches", async () => {
+    const fetchPlace = vi.fn().mockResolvedValue(null);
+    const fetchRegions = vi.fn().mockResolvedValue([region]);
+    const result = await resolvePlaceTypeAndLabel(
+      "unknown-place",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({ type: "town", label: "Unknown Place" });
+  });
+
+  it("fails open (dehyphenated fallback) when both fetchers throw", async () => {
+    const fetchPlace = vi.fn().mockRejectedValue(new Error("boom"));
+    const fetchRegions = vi.fn().mockRejectedValue(new Error("boom"));
+    const result = await resolvePlaceTypeAndLabel(
+      "some-town",
+      fetchPlace,
+      fetchRegions,
+    );
+    expect(result).toEqual({ type: "town", label: "Some Town" });
   });
 });

--- a/test/place-expandability.test.ts
+++ b/test/place-expandability.test.ts
@@ -1,10 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@lib/api/events-external", () => ({
   fetchEventCountExternal: vi.fn(),
 }));
 
-import { getPlaceExpandability } from "@lib/seo/place-expandability";
+vi.mock("next/cache", () => ({
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
+}));
+
+vi.mock("@utils/api-helpers", () => ({
+  getInternalApiUrl: vi.fn((path: string) =>
+    Promise.resolve(`http://localhost:3000${path}`),
+  ),
+  getVercelProtectionBypassHeaders: vi.fn(() => ({})),
+}));
+
+import {
+  getPlaceExpandability,
+  getPlaceExpandabilityForMetadata,
+} from "@lib/seo/place-expandability";
 import { fetchEventCountExternal } from "@lib/api/events-external";
 
 const mockedFetchCount = vi.mocked(fetchEventCountExternal);
@@ -47,6 +62,55 @@ describe("getPlaceExpandability", () => {
   it("fails open (returns true) when the API returns null", async () => {
     mockedFetchCount.mockResolvedValueOnce(null);
     const result = await getPlaceExpandability("transient-failure", "town");
+    expect(result).toBe(true);
+  });
+});
+
+describe("getPlaceExpandabilityForMetadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true for regions without calling the internal API", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const result = await getPlaceExpandabilityForMetadata(
+      "valles-occidental",
+      "region",
+    );
+    expect(result).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns false for towns below the threshold", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ totalElements: 12 }),
+      }),
+    );
+    const result = await getPlaceExpandabilityForMetadata("begues", "town");
+    expect(result).toBe(false);
+  });
+
+  it("returns true for towns at or above the threshold", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ totalElements: 40 }),
+      }),
+    );
+    const result = await getPlaceExpandabilityForMetadata("sabadell", "town");
+    expect(result).toBe(true);
+  });
+
+  it("fails open (returns true) when the internal API returns non-ok", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    const result = await getPlaceExpandabilityForMetadata(
+      "transient-failure",
+      "town",
+    );
     expect(result).toBe(true);
   });
 });

--- a/test/place-expandability.test.ts
+++ b/test/place-expandability.test.ts
@@ -9,12 +9,18 @@ vi.mock("next/cache", () => ({
   cacheLife: vi.fn(),
 }));
 
-vi.mock("@utils/api-helpers", () => ({
-  getInternalApiUrl: vi.fn((path: string) =>
-    Promise.resolve(`http://localhost:3000${path}`),
-  ),
-  getVercelProtectionBypassHeaders: vi.fn(() => ({})),
-}));
+vi.mock("@utils/api-helpers", async () => {
+  const actual = await vi.importActual<typeof import("@utils/api-helpers")>(
+    "@utils/api-helpers",
+  );
+  return {
+    ...actual,
+    getInternalApiUrl: vi.fn((path: string) =>
+      Promise.resolve(`http://localhost:3000${path}`),
+    ),
+    getVercelProtectionBypassHeaders: vi.fn(() => ({})),
+  };
+});
 
 import {
   getPlaceExpandability,

--- a/types/common.ts
+++ b/types/common.ts
@@ -103,6 +103,26 @@ export interface GeneratePagesDataProps {
   search?: string;
 }
 
+/**
+ * Input for generatePagesData's inner cached body (components/partials/
+ * generatePagesData.ts). Excludes `search` deliberately: it's free-text user
+ * input, and "use cache" derives its cache key from the function's
+ * arguments, so including it would create one cache entry per unique search
+ * string (unbounded cardinality on the data cache).
+ */
+export interface GeneratePagesDataCachedProps
+  extends Omit<GeneratePagesDataProps, "search" | "placeTypeLabel"> {
+  placeTypeLabel: PlaceTypeAndLabel;
+  locale?: AppLocale;
+}
+
+/** Input for generatePagesData's exported, uncached wrapper. */
+export interface GeneratePagesDataPublicProps
+  extends Omit<GeneratePagesDataProps, "placeTypeLabel"> {
+  placeTypeLabel: PlaceTypeAndLabel;
+  locale?: AppLocale;
+}
+
 export interface PlaceTypeAndLabel {
   type: PlaceType;
   label: string;

--- a/utils/build-phase.ts
+++ b/utils/build-phase.ts
@@ -1,0 +1,26 @@
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
+
+/**
+ * Detects if the application is in build phase (SSG/static generation).
+ * During build phase, we bypass internal API proxy and call external API directly
+ * to avoid issues when the Next.js server isn't running.
+ *
+ * This is used to determine whether to use internal API routes (runtime) or
+ * external API calls (build time) for data fetching.
+ *
+ * NEXT_PHASE is the only reliable signal — it's set by the Next.js CLI itself
+ * during `next build`, regardless of hosting platform. A `NODE_ENV ===
+ * "production" && !VERCEL_URL` fallback used to be OR'd in here, added when
+ * this app only ran on Vercel (VERCEL_URL is always set at Vercel runtime, so
+ * its absence meant "must be the build step"). Since the Coolify migration,
+ * that assumption is false: self-hosted production never sets VERCEL_URL
+ * either, so the fallback made isBuildPhase permanently true at runtime,
+ * silently bypassing the internal API's caching/revalidation for places,
+ * regions, cities, categories, and events on every production request.
+ *
+ * Lives in its own module (not utils/constants.ts) so the API data-fetching
+ * layer (lib/api/regions.ts, cities.ts, places.ts, events.ts, categories.ts)
+ * doesn't transitively pull in next-intl/server and the full ca/es/en message
+ * bundles just to read one boolean flag.
+ */
+export const isBuildPhase = process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,4 +1,3 @@
-import { PHASE_PRODUCTION_BUILD } from "next/constants";
 import type { ByDateOption, DateRangeShortcut } from "types/common";
 import { getTranslations } from "next-intl/server";
 import type { CategorySummaryResponseDTO } from "types/api/category";
@@ -69,25 +68,10 @@ export const MAX_ORIGINAL_LIMIT_LABEL = formatMegabytesLabel(
   MAX_ORIGINAL_FILE_BYTES,
 );
 
-/**
- * Detects if the application is in build phase (SSG/static generation).
- * During build phase, we bypass internal API proxy and call external API directly
- * to avoid issues when the Next.js server isn't running.
- *
- * This is used to determine whether to use internal API routes (runtime) or
- * external API calls (build time) for data fetching.
- *
- * NEXT_PHASE is the only reliable signal — it's set by the Next.js CLI itself
- * during `next build`, regardless of hosting platform. A `NODE_ENV ===
- * "production" && !VERCEL_URL` fallback used to be OR'd in here, added when
- * this app only ran on Vercel (VERCEL_URL is always set at Vercel runtime, so
- * its absence meant "must be the build step"). Since the Coolify migration,
- * that assumption is false: self-hosted production never sets VERCEL_URL
- * either, so the fallback made isBuildPhase permanently true at runtime,
- * silently bypassing the internal API's caching/revalidation for places,
- * regions, cities, categories, and events on every production request.
- */
-export const isBuildPhase = process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;
+// isBuildPhase lives in utils/build-phase.ts, not here — the data-fetching
+// layer (lib/api/*) imports it directly from there to avoid pulling in
+// next-intl/server and the full ca/es/en message bundles below.
+export { isBuildPhase } from "./build-phase";
 
 const constantsLabelsByLocale: Record<AppLocale, any> = {
   ca: (caMessages as any).Components.Constants,

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -76,10 +76,18 @@ export const MAX_ORIGINAL_LIMIT_LABEL = formatMegabytesLabel(
  *
  * This is used to determine whether to use internal API routes (runtime) or
  * external API calls (build time) for data fetching.
+ *
+ * NEXT_PHASE is the only reliable signal — it's set by the Next.js CLI itself
+ * during `next build`, regardless of hosting platform. A `NODE_ENV ===
+ * "production" && !VERCEL_URL` fallback used to be OR'd in here, added when
+ * this app only ran on Vercel (VERCEL_URL is always set at Vercel runtime, so
+ * its absence meant "must be the build step"). Since the Coolify migration,
+ * that assumption is false: self-hosted production never sets VERCEL_URL
+ * either, so the fallback made isBuildPhase permanently true at runtime,
+ * silently bypassing the internal API's caching/revalidation for places,
+ * regions, cities, categories, and events on every production request.
  */
-export const isBuildPhase =
-  process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD ||
-  (process.env.NODE_ENV === "production" && !process.env.VERCEL_URL);
+export const isBuildPhase = process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;
 
 const constantsLabelsByLocale: Record<AppLocale, any> = {
   ca: (caMessages as any).Components.Constants,

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -44,6 +44,9 @@ export {
 } from "./category-helpers";
 
 // Location helpers
+// getPlaceTypeAndLabelForMetadata deliberately NOT re-exported here: this
+// barrel is reachable from Client Components, and its "use cache" directive
+// must live in a server-only file. Import it from @lib/seo/place-metadata.
 export {
   getPlaceTypeAndLabel,
   getPlaceTypeAndLabelCached,

--- a/utils/location-helpers.ts
+++ b/utils/location-helpers.ts
@@ -6,6 +6,8 @@ import {
   formatPlaceName,
 } from "./string-helpers";
 import type { Location, PlaceTypeAndLabel } from "types/common";
+import type { PlaceResponseDTO } from "types/api/place";
+import type { RegionsGroupedByCitiesResponseDTO } from "types/api/region";
 import type {
   BuildDisplayLocationOptions,
   EventLocationLabelOptions,
@@ -206,9 +208,21 @@ export const buildEventListLocationLabels = ({
   };
 };
 
-export const getPlaceTypeAndLabel = async (
+/**
+ * Shared resolution logic, parametrized by which place/region fetchers to
+ * use. `getPlaceTypeAndLabel` (content) and `getPlaceTypeAndLabelForMetadata`
+ * (lib/seo/place-metadata.ts, for generateMetadata) differ only in which
+ * fetchers they pass in — the content ones are React cache()-memoized only,
+ * the metadata ones are `"use cache"` and static-shell-safe. Exported so the
+ * metadata variant (which must live outside this client-reachable file — see
+ * lib/seo/place-metadata.ts) can reuse this logic. See
+ * docs/incidents/2026-06-13-cachecomponents-metadata-resume-mismatch.md.
+ */
+export async function resolvePlaceTypeAndLabel(
   place: string,
-): Promise<PlaceTypeAndLabel> => {
+  fetchPlace: (slug: string) => Promise<PlaceResponseDTO | null>,
+  fetchRegions: () => Promise<RegionsGroupedByCitiesResponseDTO[]>,
+): Promise<PlaceTypeAndLabel> {
   // Empty place means home page or Catalunya-wide view
   // Return default without making API calls
   if (!place || place === "") {
@@ -222,7 +236,7 @@ export const getPlaceTypeAndLabel = async (
   }
 
   try {
-    const placeInfo = await fetchPlaceBySlug(place);
+    const placeInfo = await fetchPlace(place);
     if (placeInfo) {
       const formattedLabel = formatPlaceName(placeInfo.name);
       const type =
@@ -237,7 +251,7 @@ export const getPlaceTypeAndLabel = async (
       // For cities, look up parent region from cached data for SEO breadcrumbs
       if (type === "town") {
         try {
-          const regionsWithCities = await fetchRegionsWithCities();
+          const regionsWithCities = await fetchRegions();
           for (const region of regionsWithCities) {
             const city = region.cities.find((c) => c.value === place);
             if (city) {
@@ -261,7 +275,7 @@ export const getPlaceTypeAndLabel = async (
   }
 
   try {
-    const regionsWithCities = await fetchRegionsWithCities();
+    const regionsWithCities = await fetchRegions();
 
     const region = regionsWithCities.find(
       (r) =>
@@ -289,10 +303,19 @@ export const getPlaceTypeAndLabel = async (
   }
 
   return { type: "town", label: formatPlaceName(place.replace(/-/g, " ")) };
-};
+}
 
-// Per-request memoized wrapper for server routes
+export const getPlaceTypeAndLabel = (place: string): Promise<PlaceTypeAndLabel> =>
+  resolvePlaceTypeAndLabel(place, fetchPlaceBySlug, fetchRegionsWithCities);
+
+// Per-request memoized wrapper for server routes (content, not metadata)
 export const getPlaceTypeAndLabelCached = cache(getPlaceTypeAndLabel);
+
+// getPlaceTypeAndLabelForMetadata lives in @lib/seo/place-metadata, not here —
+// this file is transitively reachable from Client Components (via
+// utils/helpers.ts -> utils/url-filters.ts -> UrlFiltersContext.tsx), and
+// Next.js forbids defining a `"use cache"` function inline in a file that can
+// be pulled into a client bundle.
 
 export const getDistance = (
   location1: Location,


### PR DESCRIPTION
## Summary

`generateMetadata` on six route groups was calling React `cache()`-memoized readers backed by revalidated-but-not-`"use cache"` fetches. Under `cacheComponents` (PPR), that counts as runtime I/O, so the metadata boundary can't be prerendered and lands in the resume tree instead, producing:

```
Error: Expected the resume to render <div> in this slot but instead it rendered <__next_metadata_boundary__>. The tree doesn't match so React will fallback to client rendering.
```

This is the same bug class fixed for events/news in the 2026-06-13 incident (`getEventBySlugForMetadata` / `getNewsBySlugForMetadata`), just not caught for place/region/category readers at the time.

## Fix

- Added `*ForMetadata` variants with real `"use cache"` + `cacheTag`/`cacheLife`, resolving the API origin from config instead of `headers()`:
  - `getPlaceTypeAndLabelForMetadata`, `fetchPlaceBySlugForMetadata`, `fetchRegionsWithCitiesForMetadata` (new `lib/seo/place-metadata.ts`)
  - `fetchCategoriesForMetadata` (`lib/api/categories.ts`)
  - `getPlaceExpandabilityForMetadata` (`lib/seo/place-expandability.ts`)
- Updated `generateMetadata` in `/[place]`, `/[place]/[byDate]`, `/[place]/[byDate]/[category]`, `/noticies/[place]`, `/noticies/[place]/[article]`, and both `/sitemap/[town]` routes to use the metadata-safe variants.
- `lib/seo/place-metadata.ts` is a new file rather than inlining into `lib/api/places.ts` / `lib/api/regions.ts` / `utils/location-helpers.ts`: those files are transitively reachable from `UrlFiltersContext` (a Client Component), and Next.js/Turbopack forbids defining an inline `"use cache"` function in a file that can be pulled into a client bundle. `utils/location-helpers.ts` now exports `resolvePlaceTypeAndLabel` so both the content and metadata variants share the same resolution logic.
- Extended the `generateMetadata` ESLint `no-restricted-syntax` guard to flag the non-metadata readers directly — caught 2 real violations in the sitemap pages that manual review missed.
- Fixed `isBuildPhase` (`utils/constants.ts`): it OR'd in `NODE_ENV === "production" && !VERCEL_URL`, a Vercel-era heuristic assuming production always meant Vercel runtime. Since the Coolify migration, self-hosted prod never sets `VERCEL_URL` either, so this made `isBuildPhase` permanently true at runtime, silently bypassing internal API caching for places/regions/cities/categories/events on every request. Also removed two duplicate inline reimplementations of this same broken check in `lib/api/regions.ts` and `lib/api/cities.ts`.

## Known remaining instance, deliberately out of scope

`fetchMonthEvents` in `app/[locale]/sitemap/[town]/[year]/[month]/page.tsx`'s `generateMetadata` is the same bug class — a React `cache()` wrapper around a revalidated (not `"use cache"`) `fetchEvents` call, used for `robotsOverride`. It's a locally-scoped closure so the new ESLint rule doesn't catch it. Flagging rather than expanding scope further.

## Verification

- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — 0 errors
- [x] `yarn test` — 142 files / 1922 tests passing
- [x] `yarn build` — all 6 target routes now show `◐` (Partial Prerender) instead of full dynamic, confirming the metadata boundary is now static-shell-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prerendering on place, news, and sitemap pages by replacing request-scoped readers with prerender-safe “use cache” variants, removing the PPR metadata resume-mismatch and restoring a stable static shell. Also improves caching (including a search-key cardinality fix), build-phase detection, and sitemap robots behavior under outages.

- **Bug Fixes**
  - Added metadata-safe readers with “use cache” + tags: getPlaceTypeAndLabelForMetadata, fetchCategoriesForMetadata, getPlaceExpandabilityForMetadata, fetchPlaceBySlugForMetadata, fetchRegionsWithCitiesForMetadata, fetchEventsForMetadata; updated `generateMetadata` on place/news/sitemap routes.
  - Sitemap month page now uses `fetchEventsForMetadata` for robots probing and fails open on probe errors: returns `null` on non-ok/malformed/network errors with `cacheLife("minutes")`, only sets `noindex` on confirmed empty results; place lookup and probe run in parallel; tests added.
  - `generatePagesData` split into a cached inner function that excludes `search` from the cache key, plus a thin wrapper that appends the query after caching; `placeTypeLabel` is required; added `cacheTag` and `cacheLife("hours")`; homepage now passes the Catalunya constant.
  - Place metadata readers: 404s use `cacheLife("minutes")`; fetch-level tags use bounded `placeTag(slug)` and `regionsTag`/`regionsOptionsTag`.
  - `getPlaceExpandabilityForMetadata` now reads event counts via the internal API with `eventsTag`, staying prerender-safe; standardized queries via `buildEventsQuery`.
  - Fixed build-phase detection: `isBuildPhase` moved to `utils/build-phase.ts`, now relies only on `NEXT_PHASE`; added tests; updated `lib/api/*` imports to restore runtime caching.
  - ESLint guard blocks non-metadata readers in `generateMetadata`; added `fetchMonthEvents` to catch local wrappers on sitemap pages.
  - Standardized event query building, fixed fetch-level tag constants, moved cached props types to `types/common.ts`, and parallelized sitemap month metadata fetches to avoid sequential waterfalls.
  - Proxy: skip CDN caching for RSC requests (`RSC: 1`) to prevent Cloudflare cache poisoning; added test.
  - Ops: increased Docker `HEALTHCHECK` timeouts; entrypoint clears 0-byte image-cache files; added incident docs and resource limit guidance.

<sup>Written for commit 09a17c9d4bc0b22321657e4e0f37bef903970f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Improved metadata generation for places, regions, categories, events, news, and sitemap pages.
  * Preserved canonical URLs, fallback behavior, and `noindex` handling.
  * Ensured consistent Catalunya labeling on homepage metadata and content.

* **Performance**
  * Improved caching for page data and metadata lookups, reducing unnecessary requests while keeping search-specific results accurate.

* **Reliability**
  * Added safer fallbacks when metadata or location information cannot be loaded.

* **Tests**
  * Expanded coverage for metadata, location resolution, caching, and build-time behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->