### PR TITLE
feat(profile): show verified badge on user profile page

### DIFF
--- a/components/ui/profile/ProfileHeader.tsx
+++ b/components/ui/profile/ProfileHeader.tsx
@@ -73,7 +73,11 @@ export default async function ProfileHeader({ profile }: ProfileHeaderProps) {
 
         <div className="flex items-center gap-2 mb-2 flex-wrap">
           <h1 className="heading-1 text-foreground">{displayName}</h1>
-          <VerifiedBadge role={profile.role} verified={profile.verified} />
+          <VerifiedBadge
+            role={profile.role}
+            verified={profile.verified}
+            organizerVerified={profile.organizerVerified}
+          />
           <ProfileOwnerActions username={profile.username} />
         </div>
 

--- a/components/ui/profile/ProfileHeader.tsx
+++ b/components/ui/profile/ProfileHeader.tsx
@@ -1,5 +1,6 @@
 import ProfileOwnerActions from "@components/ui/profile/ProfileOwnerActions";
 import ProfileVisitsStat from "@components/ui/profile/ProfileVisitsStat";
+import VerifiedBadge from "@components/ui/profile/VerifiedBadge";
 import AvatarInitials from "@components/ui/common/AvatarInitials";
 import { getTranslations } from "next-intl/server";
 import { getLocaleSafely } from "@utils/i18n-seo";
@@ -72,6 +73,7 @@ export default async function ProfileHeader({ profile }: ProfileHeaderProps) {
 
         <div className="flex items-center gap-2 mb-2 flex-wrap">
           <h1 className="heading-1 text-foreground">{displayName}</h1>
+          <VerifiedBadge role={profile.role} verified={profile.verified} />
           <ProfileOwnerActions username={profile.username} />
         </div>
 

--- a/components/ui/profile/VerifiedBadge.tsx
+++ b/components/ui/profile/VerifiedBadge.tsx
@@ -2,12 +2,20 @@ import { CheckBadgeIcon, ShieldCheckIcon } from "@heroicons/react/24/solid";
 import { useTranslations } from "next-intl";
 import type { VerifiedBadgeProps } from "types/props";
 
-export default function VerifiedBadge({ role, verified }: VerifiedBadgeProps) {
+export default function VerifiedBadge({
+  role,
+  verified,
+  organizerVerified,
+}: VerifiedBadgeProps) {
   const t = useTranslations("Components.Profile");
 
-  if (!verified) return null;
+  // `verified` undefined means the backend hasn't cut over yet — fall back
+  // to the legacy organizerVerified flag so already-verified organizers
+  // don't lose their badge mid-transition.
+  const isVerified = verified ?? organizerVerified;
+  if (!isVerified) return null;
 
-  const isOrganizer = role === "ORGANIZATION";
+  const isOrganizer = role ? role === "ORGANIZATION" : organizerVerified === true;
   const Icon = isOrganizer ? ShieldCheckIcon : CheckBadgeIcon;
   const label = isOrganizer ? t("verifiedOrganizer") : t("verified");
 

--- a/components/ui/profile/VerifiedBadge.tsx
+++ b/components/ui/profile/VerifiedBadge.tsx
@@ -1,0 +1,22 @@
+import { CheckBadgeIcon, ShieldCheckIcon } from "@heroicons/react/24/solid";
+import { useTranslations } from "next-intl";
+import type { VerifiedBadgeProps } from "types/props";
+
+export default function VerifiedBadge({ role, verified }: VerifiedBadgeProps) {
+  const t = useTranslations("Components.Profile");
+
+  if (!verified) return null;
+
+  const isOrganizer = role === "ORGANIZATION";
+  const Icon = isOrganizer ? ShieldCheckIcon : CheckBadgeIcon;
+  const label = isOrganizer ? t("verifiedOrganizer") : t("verified");
+
+  return (
+    <Icon
+      className="w-5 h-5 text-primary flex-shrink-0"
+      role="img"
+      aria-hidden="false"
+      aria-label={label}
+    />
+  );
+}

--- a/lib/validation/user.ts
+++ b/lib/validation/user.ts
@@ -13,6 +13,11 @@ export const UserPublicResponseDTOSchema = z.object({
   bio: z.string().nullish().transform((v) => v ?? undefined),
   avatarUrl: z.string().nullish().transform((v) => v ?? undefined),
   organizerVerified: z.boolean().nullish().transform((v) => v ?? undefined),
+  role: z
+    .enum(["USER", "ADMIN", "ORGANIZATION"])
+    .nullish()
+    .transform((v) => v ?? undefined),
+  verified: z.boolean().nullish().transform((v) => v ?? undefined),
   eventCount: z.number().nullish().transform((v) => v ?? undefined),
   totalEventVisits: z.number().nullish().transform((v) => v ?? undefined),
   upcomingEventCount: z.number().nullish().transform((v) => v ?? undefined),

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -405,6 +405,7 @@
       "metaDescription": "Descobreix els esdeveniments de {name}. Consulta els seus propers esdeveniments, concerts, exposicions i molt més.",
       "events": "Esdeveniments",
       "verified": "Verificat",
+      "verifiedOrganizer": "Organitzador verificat",
       "joinedDate": "Des de {date}",
       "noEvents": "Encara no hi ha esdeveniments",
       "website": "Lloc web",

--- a/messages/en.json
+++ b/messages/en.json
@@ -405,6 +405,7 @@
       "metaDescription": "Discover events by {name}. Browse their upcoming events, concerts, exhibitions and more.",
       "events": "Events",
       "verified": "Verified",
+      "verifiedOrganizer": "Verified organizer",
       "joinedDate": "Joined {date}",
       "noEvents": "No events yet",
       "website": "Website",

--- a/messages/es.json
+++ b/messages/es.json
@@ -405,6 +405,7 @@
       "metaDescription": "Descubre los eventos de {name}. Consulta sus próximos eventos, conciertos, exposiciones y mucho más.",
       "events": "Eventos",
       "verified": "Verificado",
+      "verifiedOrganizer": "Organizador verificado",
       "joinedDate": "Desde {date}",
       "noEvents": "Aún no hay eventos",
       "website": "Sitio web",

--- a/test/profile-header.test.tsx
+++ b/test/profile-header.test.tsx
@@ -171,4 +171,15 @@ describe("ProfileHeader", () => {
       screen.getByRole("img", { name: "Organitzador verificat" }),
     ).toBeInTheDocument();
   });
+
+  it("falls back to the legacy organizerVerified badge when verified/role are absent", async () => {
+    const profile: ProfileDetailResponseDTO = {
+      ...baseProfile,
+      organizerVerified: true,
+    };
+    await renderHeader(profile);
+    expect(
+      screen.getByRole("img", { name: "Organitzador verificat" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/test/profile-header.test.tsx
+++ b/test/profile-header.test.tsx
@@ -145,4 +145,30 @@ describe("ProfileHeader", () => {
     await renderHeader(baseProfile);
     expect(screen.getByTestId("profile-header")).toBeInTheDocument();
   });
+
+  it("does not render a verified badge when verified is absent", async () => {
+    await renderHeader(baseProfile);
+    expect(screen.queryByRole("img", { name: "Verificat" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "Organitzador verificat" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the user verified badge when verified is true and role is not ORGANIZATION", async () => {
+    const profile: ProfileDetailResponseDTO = { ...baseProfile, verified: true };
+    await renderHeader(profile);
+    expect(screen.getByRole("img", { name: "Verificat" })).toBeInTheDocument();
+  });
+
+  it("renders the organizer verified badge when verified is true and role is ORGANIZATION", async () => {
+    const profile: ProfileDetailResponseDTO = {
+      ...baseProfile,
+      verified: true,
+      role: "ORGANIZATION",
+    };
+    await renderHeader(profile);
+    expect(
+      screen.getByRole("img", { name: "Organitzador verificat" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/types/api/user.ts
+++ b/types/api/user.ts
@@ -24,6 +24,8 @@ export interface UserPublicResponseDTO {
   bio?: string;
   avatarUrl?: string;
   organizerVerified?: boolean;
+  role?: AuthRole;
+  verified?: boolean;
   eventCount?: number;
   totalEventVisits?: number;
   upcomingEventCount?: number;

--- a/types/props.ts
+++ b/types/props.ts
@@ -512,6 +512,7 @@ export interface ProfileHeaderProps {
 export interface VerifiedBadgeProps {
   role?: import("types/auth").AuthRole;
   verified?: boolean;
+  organizerVerified?: boolean;
 }
 
 // Route-based tab strip (e.g. profile/favourites Propers/Passats). Each item

--- a/types/props.ts
+++ b/types/props.ts
@@ -509,6 +509,11 @@ export interface ProfileHeaderProps {
   profile: import("types/api/profile").ProfileDetailResponseDTO;
 }
 
+export interface VerifiedBadgeProps {
+  role?: import("types/auth").AuthRole;
+  verified?: boolean;
+}
+
 // Route-based tab strip (e.g. profile/favourites Propers/Passats). Each item
 // is a navigable Link, not a client-side tabpanel switch — see components/ui/common/tabs.
 export interface TabItem {


### PR DESCRIPTION
## Summary
- Adds `role`/`verified` to `UserPublicResponseDTO` (additive, dual-shape pattern already used for the 2026-07-25 backend handoff) so the frontend can distinguish a verified user from a verified organization
- New `VerifiedBadge` component renders `CheckBadgeIcon` + "Verificat" for regular verified users, `ShieldCheckIcon` + "Organitzador verificat" for `role === "ORGANIZATION"`, mirroring X's per-role checkmark treatment
- Wired into `ProfileHeader` next to the display name
- Reuses the existing (previously unused) `Profile.verified` translation key; adds `Profile.verifiedOrganizer` across ca/en/es

## Test plan
- [x] `yarn typecheck` clean
- [x] `yarn lint` — zero new warnings
- [x] `test/profile-header.test.tsx` — 16/16 passing (3 new cases: no badge when unverified, user badge, organizer badge)
- [x] Full suite run — only pre-existing pool-contention flakes on unrelated files (confirmed passing in isolation), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a verified badge in profile headers with distinct icons for users vs organizations. Adds `role` and `verified` to the user payload, with fallback to `organizerVerified` during the backend cutover.

- **New Features**
  - New `VerifiedBadge` component using `@heroicons/react` and `next-intl`; icon-only next to the display name.
  - Badge shows when `verified` is true; shield for `role === "ORGANIZATION"`, checkmark otherwise; falls back to `organizerVerified` if `verified`/`role` are missing.
  - Added ca/en/es strings and tests for no badge, user badge, organizer badge, and fallback.

<sup>Written for commit f2bcae08397fcb1853f568fa731fdd8426258345. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification badges to profile headers.
  * Displays distinct badges for verified users and verified organizations.
  * Added accessible labels and localized text in English, Spanish, and Catalan.
  * Supports existing organizer verification information for compatibility.

* **Bug Fixes**
  * Profiles without verification status no longer display a badge.

* **Tests**
  * Added coverage for user, organization, missing, and legacy verification states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->