### PR TITLE
fix(e2e): match visible location instance in publish-integration test

### DIFF
--- a/app/[locale]/e/[eventId]/components/EventSidebar.tsx
+++ b/app/[locale]/e/[eventId]/components/EventSidebar.tsx
@@ -111,7 +111,7 @@ export default async function EventSidebar({
             {event.owner && creatorSlug && (
               <>
                 <hr className="border-border" />
-                <div className="flex flex-col gap-1">
+                <div className="flex flex-col gap-1" data-testid="event-created-by">
                   <h3 className="label font-semibold text-foreground-strong">
                     {t("sidebarCreatedBy")}
                   </h3>
@@ -122,6 +122,7 @@ export default async function EventSidebar({
                   <Link
                     href={`/perfil/${encodeURIComponent(creatorSlug)}`}
                     className="flex flex-col gap-1 body-small font-semibold text-primary hover:text-primary-dark transition-colors"
+                    data-testid="event-created-by-link"
                   >
                     <span className="font-normal text-primary">
                       {t("sidebarViewAllEvents")} →

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -85,29 +85,27 @@ test.describe("Publish integration (staging)", () => {
       page.getByTestId("user-avatar-button")
     ).toBeVisible({ timeout: 15_000 });
 
-    // Capture the actual authenticated identity instead of hardcoding a name/
-    // slug: whichever account E2E_STAGING_EMAIL/PASSWORD point to becomes the
-    // event's creator, and that can change independently of this test file
-    // (e.g. the test account gets rotated). Asserting against a fixed string
-    // here would silently start failing the moment the account changes,
-    // exactly as happened before this fix.
+    // Sanity check that we're logged in as *some* real account before
+    // publishing — the actual expected creator name/slug is captured further
+    // down from the created event's own `owner` field (see Step 7), not from
+    // this session data. /api/auth/me's `name` is the enrichment-merged
+    // session display name (lib/auth/enrichment.ts's three-way pick between
+    // backend displayName/name and the id_token name); the event detail page
+    // instead renders `owner.displayName ?? owner.username` from the event's
+    // own OwnerSummaryDTO (a separate backend record for that specific
+    // event). These two only agree when enrichment happens to pick the same
+    // value, so asserting the rendered creator block against /api/auth/me
+    // would flake whenever they diverge.
     const me = await page.evaluate(async () => {
       const res = await fetch("/api/auth/me");
       if (!res.ok) return null;
       const data = await res.json();
       return data?.user ?? null;
     });
-    const expectedCreatorName: string =
-      me?.name || me?.username || "";
-    const expectedCreatorSlug: string = me?.username || "";
     expect(
-      expectedCreatorName,
-      "expected /api/auth/me to return a logged-in user with a name or username"
-    ).not.toBe("");
-    expect(
-      expectedCreatorSlug,
-      "expected /api/auth/me to return a username (used for the /perfil/<username> link)"
-    ).not.toBe("");
+      me?.username,
+      "expected /api/auth/me to return a logged-in user with a username"
+    ).toBeTruthy();
 
     // ── Step 1: Navigate to publish page ──
     await page.goto("/en/publica", {
@@ -256,11 +254,31 @@ test.describe("Publish integration (staging)", () => {
     });
 
     // Creator attribution: the detail page must show "Published by <name>"
-    // with the name linked to /perfil/<username>, matched against the
-    // actual logged-in account (captured above) rather than a hardcoded
-    // name/slug. Rendered twice, same as the location block above — once
-    // inline for mobile, once in the desktop sidebar — so filter to the
-    // visible instance instead of assuming DOM order.
+    // with the name linked to /perfil/<username>. Read the expected values
+    // from the created event's own `owner` field (OwnerSummaryDTO, the same
+    // data the page renders from) rather than the auth session — see the
+    // note above Step 0's login check for why those two can diverge.
+    const eventOwner = await page.evaluate(async (slug: string) => {
+      const res = await fetch(`/api/events/${slug}`);
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data?.owner ?? null;
+    }, createdEventSlug);
+    const expectedCreatorName: string =
+      eventOwner?.displayName || eventOwner?.username || "";
+    const expectedCreatorSlug: string = eventOwner?.username || "";
+    expect(
+      expectedCreatorName,
+      "expected the created event to have an owner with a displayName or username"
+    ).not.toBe("");
+    expect(
+      expectedCreatorSlug,
+      "expected the created event's owner to have a username (used for the /perfil/<username> link)"
+    ).not.toBe("");
+
+    // Rendered twice, same as the location block above — once inline for
+    // mobile, once in the desktop sidebar — so filter to the visible
+    // instance instead of assuming DOM order.
     const creatorBlock = page
       .locator('[data-testid="event-created-by"]:visible')
       .first();

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -85,6 +85,30 @@ test.describe("Publish integration (staging)", () => {
       page.getByTestId("user-avatar-button")
     ).toBeVisible({ timeout: 15_000 });
 
+    // Capture the actual authenticated identity instead of hardcoding a name/
+    // slug: whichever account E2E_STAGING_EMAIL/PASSWORD point to becomes the
+    // event's creator, and that can change independently of this test file
+    // (e.g. the test account gets rotated). Asserting against a fixed string
+    // here would silently start failing the moment the account changes,
+    // exactly as happened before this fix.
+    const me = await page.evaluate(async () => {
+      const res = await fetch("/api/auth/me");
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data?.user ?? null;
+    });
+    const expectedCreatorName: string =
+      me?.name || me?.username || "";
+    const expectedCreatorSlug: string = me?.username || "";
+    expect(
+      expectedCreatorName,
+      "expected /api/auth/me to return a logged-in user with a name or username"
+    ).not.toBe("");
+    expect(
+      expectedCreatorSlug,
+      "expected /api/auth/me to return a username (used for the /perfil/<username> link)"
+    ).not.toBe("");
+
     // ── Step 1: Navigate to publish page ──
     await page.goto("/en/publica", {
       waitUntil: "domcontentloaded",
@@ -232,15 +256,23 @@ test.describe("Publish integration (staging)", () => {
     });
 
     // Creator attribution: the detail page must show "Published by <name>"
-    // with the name linked to /perfil/<username>. Hard-assert both the
-    // visible name AND the href, since the backend now exposes
-    // createdByUser.username (verified against the swagger).
-    const creatorBlock = page.getByTestId("event-created-by");
+    // with the name linked to /perfil/<username>, matched against the
+    // actual logged-in account (captured above) rather than a hardcoded
+    // name/slug. Rendered twice, same as the location block above — once
+    // inline for mobile, once in the desktop sidebar — so filter to the
+    // visible instance instead of assuming DOM order.
+    const creatorBlock = page
+      .locator('[data-testid="event-created-by"]:visible')
+      .first();
     await expect(creatorBlock).toBeVisible({ timeout: 10_000 });
-    await expect(creatorBlock).toContainText(/E2E Test User/);
-    await expect(
-      page.getByTestId("event-created-by-link")
-    ).toHaveAttribute("href", /\/perfil\/e2e-test-user/);
+    await expect(creatorBlock).toContainText(expectedCreatorName);
+    const creatorLinkHref = await page
+      .locator('[data-testid="event-created-by-link"]:visible')
+      .first()
+      .getAttribute("href");
+    expect(creatorLinkHref).toContain(
+      `/perfil/${encodeURIComponent(expectedCreatorSlug)}`
+    );
 
     // ── Step 8: Verify the event appears on a listing page ──
     await page.goto("/en/barcelona", {

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -221,10 +221,12 @@ test.describe("Publish integration (staging)", () => {
     // exist in the DOM at once and only one is actually visible at a given
     // viewport. `.first()` picked the mobile-only instance, which is CSS-hidden
     // at this project's desktop viewport, so the assertion always failed even
-    // though the value rendered correctly. Match only the visible instance
-    // instead of assuming DOM order.
+    // though the value rendered correctly. Match the visible instance instead
+    // of assuming DOM order; `.first()` here is just a strict-mode guard in
+    // case a hydration flicker briefly makes both match — the design only
+    // ever intends one to be visible at a time.
     await expect(
-      page.locator('p:visible:has-text("Test Venue - E2E")')
+      page.locator('p:visible:has-text("Test Venue - E2E")').first()
     ).toBeVisible({
       timeout: 15_000,
     });

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -215,8 +215,17 @@ test.describe("Publish integration (staging)", () => {
       { timeout: 15_000 }
     );
 
-    // Location we entered is rendered somewhere on the page.
-    await expect(page.getByText("Test Venue - E2E").first()).toBeVisible({
+    // Location we entered is rendered somewhere on the page. The detail page
+    // renders the location twice — once inline for mobile (`lg:hidden`) and
+    // once in the sticky sidebar for desktop (`hidden lg:block`) — so both
+    // exist in the DOM at once and only one is actually visible at a given
+    // viewport. `.first()` picked the mobile-only instance, which is CSS-hidden
+    // at this project's desktop viewport, so the assertion always failed even
+    // though the value rendered correctly. Match only the visible instance
+    // instead of assuming DOM order.
+    await expect(
+      page.locator('p:visible:has-text("Test Venue - E2E")')
+    ).toBeVisible({
       timeout: 15_000,
     });
 


### PR DESCRIPTION
## Summary

Fixes the E2E Integration workflow failure you flagged:

```
Locator:  getByText('Test Venue - E2E').first()
Expected: visible
Received: hidden
```

This surfaced right after the E2E_STAGING_EMAIL/PASSWORD staging secrets were updated — login now succeeds and the event publishes correctly, but the very next assertion (checking the location text on the detail page) was failing.

**Root cause — not an app bug.** The event detail page intentionally renders the location paragraph twice:
- `app/[locale]/e/[eventId]/page.tsx`: inline, wrapped in a `lg:hidden` container (mobile)
- `app/[locale]/e/[eventId]/components/EventSidebar.tsx`: in the sticky sidebar, `hidden lg:block` (desktop)

Both exist in the DOM simultaneously; only one is visible per viewport, by design. The mobile block comes first in DOM order, so `.first()` always matched it — and this project's Playwright config uses the default Desktop Chrome viewport (1280×720, above the `lg` breakpoint), where that block is `display: none`. The value was rendering correctly the whole time; the assertion was just checking the wrong one of the two identical elements.

## Fix

Replaced `page.getByText("Test Venue - E2E").first()` with `page.locator('p:visible:has-text("Test Venue - E2E")').first()` — matches whichever instance is actually visible in the current viewport instead of assuming DOM order. The trailing `.first()` is a defensive strict-mode guard only, in case a hydration flicker briefly makes both match.

## Verification

- Confirmed the `:visible` pseudo-class mechanism works as expected with a standalone Playwright check (two identical `<p>` elements, one `display: none`, one `display: block`) before touching the real test — `:visible` correctly resolved to the one actually visible one.
- `npx tsc --noEmit` clean.
- Can't run the actual staging-integration test locally (needs the `staging` GitHub Environment secrets), but the failure mode and fix are mechanically verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix publish-integration E2E by matching the visible location and creator attribution on desktop viewports. Adds missing test IDs and asserts creator details from the event’s own owner data to stabilize CI.

- **Bug Fixes**
  - Use `page.locator('p:visible:has-text("Test Venue - E2E")').first()` to assert the visible location; keep `.first()` as a strict-mode guard.
  - Add `data-testid="event-created-by"` and `data-testid="event-created-by-link"` to the desktop sidebar; target the visible instance in the test.
  - Read creator name and slug from `/api/events/{slug}` `owner` data and assert the `/perfil/<username>` link; keep `/api/auth/me` only as a login sanity check.

<sup>Written for commit b112f759040873f49f164bf2f934c0cce4a5b9a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage by validating event creator details against the authenticated account.
  * Updated location and creator checks to work consistently across responsive desktop and mobile layouts.
  * Added test targeting hooks for the creator profile and “view all events” link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->