### PR TITLE
feat(analytics): auth/profile/favorites tracking + doc sync

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@ Purpose: Catalan events discovery web app (Next.js 16.1 App Router + React 19 + 
 | **Creating components**       | `react-nextjs-patterns`        | Server Component by default, `"use client"` only at leaves  |
 | **Adding filters**            | `filter-system-dev`            | Add to `config/filters.ts` only                             |
 | **API endpoints**             | `api-layer-patterns`           | Three-layer proxy pattern required                          |
+| **Auth/session**              | `auth-patterns`                | Use `useAuth()` (client) or `getAccessTokenFromCookies()` (server); never call `/api/auth/*` directly |
 | **URL/routing changes**       | `url-canonicalization`         | NEVER add `searchParams` to listing pages                   |
 | **i18n/translations**         | `i18n-best-practices`          | Use `Link` from `@i18n/routing`, not `next/link`            |
 | **Styling/UI**                | `design-system-conventions`    | Use semantic classes, NEVER `gray-*` colors                 |

--- a/.github/skills/api-layer-patterns/SKILL.md
+++ b/.github/skills/api-layer-patterns/SKILL.md
@@ -484,7 +484,7 @@ const response = await fetchWithHmac(`${apiUrl}/events`, {
 });
 ```
 
-**Implementation**: `proxy.ts` allowlists public GET routes; all others require HMAC.
+**Implementation**: `proxy.ts` allowlists public GET routes and `/api/auth/*`; all other `/api/*` routes require HMAC.
 
 ---
 

--- a/.github/skills/api-layer-patterns/SKILL.md
+++ b/.github/skills/api-layer-patterns/SKILL.md
@@ -459,25 +459,28 @@ const signature = crypto.createHmac("sha256", secret).update(url).digest("hex");
 
 - `/api/visits` (POST)
 - `/api/events/*` (POST/PUT/DELETE)
-- `/api/auth/*` (POST — login, register, forgot/reset password, email verification)
+
+**Auth does not go through this pattern.** `/api/auth/*` is a Logto OIDC
+redirect flow (sign-in/callback/sign-out/me), not HMAC-signed proxy calls —
+see the `auth-patterns` skill.
 
 **IMPORTANT: `skipBodySigning: true` is required on all POST/PUT/DELETE calls.**
 The backend HMAC verification ignores the request body — it only signs `timestamp + pathAndQuery`. Without this flag, mutation requests fail with 401 "Invalid HMAC".
 
 ```typescript
 // ✅ Correct — always pass skipBodySigning for mutations
-const response = await fetchWithHmac(`${apiUrl}/auth/register`, {
+const response = await fetchWithHmac(`${apiUrl}/events`, {
   method: "POST",
   headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ email, password, name }),
+  body: JSON.stringify(eventPayload),
   skipBodySigning: true, // backend ignores body for signature
 });
 
 // ❌ Wrong — will fail with 401 "Invalid HMAC"
-const response = await fetchWithHmac(`${apiUrl}/auth/register`, {
+const response = await fetchWithHmac(`${apiUrl}/events`, {
   method: "POST",
   headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ email, password, name }),
+  body: JSON.stringify(eventPayload),
 });
 ```
 

--- a/.github/skills/auth-patterns/SKILL.md
+++ b/.github/skills/auth-patterns/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: auth-patterns
+description: Logto OIDC auth flow, useAuth() contract, session cookies, and the auth-CTA analytics convention. Use for anything touching login/logout, session state, or auth-gated pages/routes.
+---
+
+# Auth Patterns Skill
+
+## Purpose
+
+Document how authentication works in this app so new auth-gated features
+follow the existing Logto OIDC flow instead of reinventing it, and don't
+regress the session-sync and analytics conventions already in place.
+
+## The flow (server-side OIDC, not a client SDK)
+
+We integrate with Logto directly over standard OAuth 2.0 / OpenID Connect —
+no `@logto/*` SDK — to keep the client bundle untouched. All of it lives in
+`lib/auth/logto.ts` (server-only) and four route handlers:
+
+1. `GET /api/auth/sign-in` — starts Authorization Code + PKCE. Stashes
+   `state`/`codeVerifier`/`nonce`/`returnTo` in short-lived HttpOnly cookies,
+   redirects to Logto.
+2. `GET /api/auth/callback` — verifies `state`, exchanges the code for
+   tokens, verifies the `id_token`, sets session cookies, redirects to
+   `returnTo` with a one-shot `?auth_success=1` marker. On any failure,
+   redirects to `/?auth_error=<reason>` instead (never back to
+   `/iniciar-sessio`, which would auto-restart sign-in and loop).
+3. `GET /api/auth/sign-out` — clears session cookies, redirects to Logto
+   end-session.
+4. `GET /api/auth/me` — returns the current session user from the cookies;
+   `AuthProvider` calls this once on mount to hydrate client state.
+
+Entry points: `/iniciar-sessio` (proxy-rewritten to `/api/auth/sign-in` — see
+`LOGIN_ENTRY_PATTERN` in `proxy.ts`). There is currently **no working
+`/registre` route** — it's referenced from `PublishAuthGate` but nothing
+serves it. Logto's own hosted UI is where the actual login/signup choice
+happens; the app cannot distinguish login vs. signup intent client-side.
+
+## `useAuth()` — the only way client code reads session state
+
+```tsx
+const { status, user, isAuthenticated, isLoading, signIn, logout, refetchUser } = useAuth();
+```
+
+- `status`: `"loading" | "authenticated" | "unauthenticated"`.
+- `signIn(redirectTo?)` / `logout()`: both do a full `window.location.assign`
+  to a `/api/auth/*` route — this is a real navigation, not a fetch.
+- Never call `/api/auth/*` routes directly from a component; go through
+  `useAuth()`.
+
+### The hydrate-once gotcha
+
+`AuthProvider` fetches `/api/auth/me` **exactly once**, on mount. `user`
+never updates on its own after that. Any mutation that changes
+session-derived fields (profile PATCH, avatar upload/remove) **must** call
+`await refetchUser()` afterward — `router.refresh()` is not enough, it only
+re-runs Server Component data fetching, and `AuthProvider` sits above the
+router boundary. See `EditProfileForm.tsx` / `EditProfileAvatar.tsx` for the
+pattern.
+
+## Gating a page or component behind auth
+
+Server pages: check the session cookie server-side (`getAccessTokenFromCookies`
+from `@utils/auth-cookies`) and render an `*AuthGate` component when absent —
+see `PublishAuthGate.tsx`, `EditProfileAuthGate.tsx`,
+`PastFavoritesAuthGate.tsx` for the shape. Client components: use
+`useAuth().isAuthenticated` / `.status` — see `ProfileOwnerActions.tsx`,
+`ProfileClaimCta.tsx`.
+
+## Auth-CTA analytics: `data-analytics-action`
+
+Every login/logout entry point (auth gates, navbar, footer, inline nudges)
+carries `data-analytics-action="<name>"`. One delegated click listener
+(`components/analytics/AuthEventTracker.tsx`, mounted once in
+`app/[locale]/layout.tsx`) picks up **any** element with that attribute
+anywhere in the DOM and fires `auth_gate_click` with `{ action }` — no
+per-component wiring needed. When adding a new login/logout touchpoint, just
+add the attribute; don't wire a new click handler.
+
+`AuthEventTracker` also fires `auth_success` / `auth_failure` once per page
+load, reading the one-shot `auth_success` / `auth_error` query params the
+callback route sets.
+
+## Related
+
+- Full Logto instance/env setup: [`docs/logto-auth-setup.md`](../../../docs/logto-auth-setup.md)
+- Env vars: `env-variable-management` skill, "Auth (Logto) env vars" section
+- Known gotchas (service worker caching `/api/auth/me`, CSRF origin allowlist
+  on `/api/favorites`, `request.nextUrl.origin` vs. proxy headers): see
+  `LESSONS.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 | Components                | `react-nextjs-patterns`        | Server Component default                  |
 | Filters                   | `filter-system-dev`            | `config/filters.ts` only                  |
 | API calls                 | `api-layer-patterns`           | Three-layer proxy pattern                 |
+| Auth/session               | `auth-patterns`                | Use `useAuth()`, never call `/api/auth/*` directly |
 | URL/routing               | `url-canonicalization`         | NEVER add `searchParams` to listing pages |
 | i18n/translations         | `i18n-best-practices`          | Use `Link` from `@i18n/routing`           |
 | Styling/UI                | `design-system-conventions`    | Semantic classes, no `gray-*`             |
@@ -164,6 +165,7 @@ Before writing ANY new code, ALWAYS search first:
 - **CDN**: Cloudflare caches HTML pages and static assets at the edge. `_next/image` paths bypass CF cache (cache rule) to preserve format negotiation (avif/webp/jpeg via `Vary: Accept`). Origin handles image caching via Next.js 1-year `Cache-Control`.
 - Next.js App Router with server‑first rendering; client state via Zustand (`store.ts`) and client data fetching via SWR.
 - API layer: Internal proxy pattern—client libraries (`lib/api/*`) call internal Next.js API routes (`app/api/*`) which proxy to external backend via `*-external.ts` wrappers with HMAC signing.
+- Auth: Logto OIDC (Authorization Code + PKCE), session in HttpOnly cookies, client state via `useAuth()` (`lib/auth/AuthProvider.tsx`). See the `auth-patterns` skill.
 - SEO & sitemaps: `next-sitemap` runs after build; sitemap routes under `app/`; `proxy.ts` handles canonical redirects, security headers, and CSP.
 - URL canonicalization: Proxy automatically redirects legacy query params and `/tots` segments to canonical paths (301 redirects).
 
@@ -217,7 +219,7 @@ This enables Next.js fetch cache, which stores every unique URL as a separate ca
 
 - Requirements: Node 22, Yarn 4.12+ (use Corepack).
 - Install: `corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install --immutable`.
-- Env: set `HMAC_SECRET` (server‑only), `NEXT_PUBLIC_API_URL` (defaults handled), optional `NEXT_PUBLIC_GOOGLE_ANALYTICS`, `NEXT_PUBLIC_GOOGLE_ADS`, `SENTRY_DSN`.
+- Env: set `HMAC_SECRET` (server‑only), `NEXT_PUBLIC_API_URL` (defaults handled), optional `NEXT_PUBLIC_GOOGLE_ANALYTICS`, `NEXT_PUBLIC_GOOGLE_ADS`, `SENTRY_DSN`. Auth (Logto) requires `LOGTO_*` — see `docs/logto-auth-setup.md` and the `env-variable-management` skill; sign-in/profile/favorites features no-op without them.
 - Run: `yarn dev` (generates `public/sw.js` via prebuild). Build: `yarn build`.
 - Tests: `yarn test`; E2E: `yarn test:e2e` (local config starts the app).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 | Components                | `react-nextjs-patterns`        | Server Component default                  |
 | Filters                   | `filter-system-dev`            | `config/filters.ts` only                  |
 | API calls                 | `api-layer-patterns`           | Three-layer proxy pattern                 |
-| Auth/session               | `auth-patterns`                | Use `useAuth()`, never call `/api/auth/*` directly |
+| Auth/session               | `auth-patterns`                | Use `useAuth()` (client) or `getAccessTokenFromCookies()` (server); never call `/api/auth/*` directly |
 | URL/routing               | `url-canonicalization`         | NEVER add `searchParams` to listing pages |
 | i18n/translations         | `i18n-best-practices`          | Use `Link` from `@i18n/routing`           |
 | Styling/UI                | `design-system-conventions`    | Semantic classes, no `gray-*`             |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Create `.env.development` (and set in CI/hosting for others):
 - HMAC_SECRET=your-server-secret
 - NEXT_PUBLIC_API_URL=`https://api.esdeveniments.cat/api`
 - Optional: NEXT_PUBLIC_GOOGLE_ANALYTICS, NEXT_PUBLIC_GOOGLE_ADS, SENTRY_DSN, REDIS_URL
+- Auth (sign-in, profile, favorites): LOGTO_* — see `docs/logto-auth-setup.md`
 
 1. Run
 

--- a/app/GoogleScripts.tsx
+++ b/app/GoogleScripts.tsx
@@ -17,10 +17,16 @@ const FUNDING_CHOICES_SRC = FUNDING_CHOICES_PUB_ID
   ? `https://fundingchoicesmessages.google.com/i/${FUNDING_CHOICES_PUB_ID}?ers=1`
   : "";
 
-// Google Analytics gtag shim - reused across multiple Script components
-// Conditionally defines gtag only if it doesn't already exist to avoid overwriting
-// the real gtag.js implementation if it has already loaded
-const GTAG_SHIM = 'window.dataLayer=window.dataLayer||[];window.gtag=window.gtag||function(){dataLayer.push(arguments)};';
+// Google Analytics gtag shim - reused across multiple Script components.
+// Conditionally defines gtag only if it doesn't already exist (avoids
+// overwriting the real gtag.js implementation if it has already loaded), and
+// pushes the Consent Mode v2 denied default in that same guarded branch -
+// mirroring ensureGtag() in utils/analytics.ts - so whichever of the two
+// runs first (this inline script, or a tracker's ensureGtag() call on a hard
+// nav) is the only one that ever pushes the default. Consent Mode only
+// honors the first 'default' command; a second one would reset an
+// already-granted consent state back to denied.
+const GTAG_SHIM = `window.dataLayer=window.dataLayer||[];if(typeof window.gtag!=='function'){window.gtag=function(){window.dataLayer.push(arguments)};window.gtag('consent','default',${JSON.stringify(CONSENT_MODE_DEFAULTS)});}`;
 
 // Debounce tracking: store path + timestamp to allow re-visits but prevent duplicates
 // Key = path, Value = timestamp of last track
@@ -185,14 +191,12 @@ export default function GoogleScripts() {
 
   return (
     <>
-      {/* Google Analytics - Consent Mode v2 (defaults set inline to avoid race conditions) */}
+      {/* Google Analytics - Consent Mode v2 (default pushed by GTAG_SHIM, see
+          its comment above, for why this can't unconditionally re-push it) */}
       {GA_MEASUREMENT_ID && !isE2ETestMode && isProdHost && (
         <>
           <Script id="google-analytics-consent" strategy="lazyOnload">
-            {`
-              ${GTAG_SHIM}
-              gtag('consent', 'default', ${JSON.stringify(CONSENT_MODE_DEFAULTS)});
-            `}
+            {GTAG_SHIM}
           </Script>
           <Script
             id="google-analytics-gtag"

--- a/app/GoogleScripts.tsx
+++ b/app/GoogleScripts.tsx
@@ -7,7 +7,7 @@ import { useAdContext } from "@lib/context/AdContext";
 import { isE2ETestMode } from "@utils/env";
 import { isProductionHost } from "@utils/production-host";
 import { scheduleIdleCallback } from "@utils/browser";
-import { ensureGtag } from "@utils/analytics";
+import { ensureGtag, CONSENT_MODE_DEFAULTS } from "@utils/analytics";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
 const ADS_CLIENT = process.env.NEXT_PUBLIC_GOOGLE_ADS;
@@ -191,12 +191,7 @@ export default function GoogleScripts() {
           <Script id="google-analytics-consent" strategy="lazyOnload">
             {`
               ${GTAG_SHIM}
-              gtag('consent', 'default', {
-                ad_user_data: 'denied',
-                ad_personalization: 'denied',
-                ad_storage: 'denied',
-                analytics_storage: 'denied'
-              });
+              gtag('consent', 'default', ${JSON.stringify(CONSENT_MODE_DEFAULTS)});
             `}
           </Script>
           <Script

--- a/app/GoogleScripts.tsx
+++ b/app/GoogleScripts.tsx
@@ -4,10 +4,10 @@ import { useEffect, Suspense, useMemo, useState, useRef } from "react";
 import Script from "next/script";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useAdContext } from "@lib/context/AdContext";
-import type { WindowWithGtag } from "types/common";
 import { isE2ETestMode } from "@utils/env";
 import { isProductionHost } from "@utils/production-host";
 import { scheduleIdleCallback } from "@utils/browser";
+import { ensureGtag } from "@utils/analytics";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
 const ADS_CLIENT = process.env.NEXT_PUBLIC_GOOGLE_ADS;
@@ -21,21 +21,6 @@ const FUNDING_CHOICES_SRC = FUNDING_CHOICES_PUB_ID
 // Conditionally defines gtag only if it doesn't already exist to avoid overwriting
 // the real gtag.js implementation if it has already loaded
 const GTAG_SHIM = 'window.dataLayer=window.dataLayer||[];window.gtag=window.gtag||function(){dataLayer.push(arguments)};';
-
-const ensureGtag = (): WindowWithGtag | null => {
-  if (typeof window === "undefined") return null;
-  const win = window as WindowWithGtag;
-  win.dataLayer = win.dataLayer || [];
-
-  if (typeof win.gtag !== "function") {
-    win.gtag = function gtag() {
-
-      win.dataLayer.push(arguments);
-    };
-  }
-
-  return win;
-};
 
 // Debounce tracking: store path + timestamp to allow re-visits but prevent duplicates
 // Key = path, Value = timestamp of last track

--- a/app/GoogleScriptsHeavy.tsx
+++ b/app/GoogleScriptsHeavy.tsx
@@ -5,8 +5,8 @@
 
 import { useEffect, useRef } from "react";
 
-import type { WindowWithGtag } from "types/common";
 import { isE2ETestMode } from "@utils/env";
+import { ensureGtag } from "@utils/analytics";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
 const ADS_CLIENT = process.env.NEXT_PUBLIC_GOOGLE_ADS;
@@ -56,20 +56,6 @@ function classifyOutboundLinkType(hostname: string, pathname: string): string {
 
   return "external_website";
 }
-
-const ensureGtag = (): WindowWithGtag | null => {
-  if (typeof window === "undefined") return null;
-  const win = window as WindowWithGtag;
-  win.dataLayer = win.dataLayer || [];
-
-  if (typeof win.gtag !== "function") {
-    win.gtag = function gtag() {
-      win.dataLayer.push(arguments);
-    };
-  }
-
-  return win;
-};
 
 export default function GoogleScriptsHeavy({
   adsAllowed,

--- a/app/[locale]/e/[eventId]/EventClient.tsx
+++ b/app/[locale]/e/[eventId]/EventClient.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 // import useOnScreen from "components/hooks/useOnScreen";
-import { sendGoogleEvent } from "@utils/analytics";
+import { useEventAnalytics } from "./hooks/useEventAnalytics";
 
 import type { EventClientProps } from "types/props";
 import EventNotifications from "./components/EventNotifications";
@@ -44,30 +44,7 @@ export default function EventClient({
   //   onRemove,
   // } = useEventModals();
 
-  useEffect(() => {
-    const isPast = event.endDate
-      ? new Date(event.endDate) < new Date()
-      : false;
-
-    sendGoogleEvent("view_event_page", {
-      event_id: event.id,
-      event_slug: event.slug ?? "",
-      category_slug: event.categorySlug ?? "",
-      place_slug: event.placeSlug ?? "",
-      has_image: event.hasImage,
-      is_past: isPast,
-      origin: event.origin,
-    });
-  }, [
-    event.categorySlug,
-    event.endDate,
-    event.hasImage,
-    event.id,
-    event.origin,
-    event.placeSlug,
-    event.slug,
-  ]);
-
+  useEventAnalytics(event);
 
   const slug = event.slug ?? "";
   const title = event.title ?? "";

--- a/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
+++ b/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { sendGoogleEvent } from "@utils/analytics";
+import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 import type { EventClientProps } from "types/props";
 
 // Fires `view_event_page` once per event render. Extracted from EventClient
@@ -9,6 +9,7 @@ export function useEventAnalytics(event: EventClientProps["event"]): void {
   useEffect(() => {
     const isPast = event.endDate ? new Date(event.endDate) < new Date() : false;
 
+    ensureGtag();
     sendGoogleEvent("view_event_page", {
       event_id: event.id,
       event_slug: event.slug ?? "",

--- a/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
+++ b/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 import type { EventClientProps } from "types/props";
 
@@ -6,7 +6,13 @@ import type { EventClientProps } from "types/props";
 // so the event-detail page's analytics logic lives in one place, the same
 // way FavoritesPageTracker/ProfilePageTracker own their pages' tracking.
 export function useEventAnalytics(event: EventClientProps["event"]): void {
+  const hasTrackedRef = useRef(false);
+
   useEffect(() => {
+    // Guards against React Strict Mode's dev-only double-invoke, same as
+    // ProfilePageTracker/FavoritesPageTracker.
+    if (hasTrackedRef.current) return;
+
     const isPast = event.endDate ? new Date(event.endDate) < new Date() : false;
 
     ensureGtag();
@@ -19,6 +25,7 @@ export function useEventAnalytics(event: EventClientProps["event"]): void {
       is_past: isPast,
       origin: event.origin,
     });
+    hasTrackedRef.current = true;
   }, [
     event.categorySlug,
     event.endDate,

--- a/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
+++ b/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
@@ -1,4 +1,30 @@
-// Hook for analytics events on event detail page
-export function useEventAnalytics() {
-  // TODO: Implement analytics tracking logic
+import { useEffect } from "react";
+import { sendGoogleEvent } from "@utils/analytics";
+import type { EventClientProps } from "types/props";
+
+// Fires `view_event_page` once per event render. Extracted from EventClient
+// so the event-detail page's analytics logic lives in one place, the same
+// way FavoritesPageTracker/ProfilePageTracker own their pages' tracking.
+export function useEventAnalytics(event: EventClientProps["event"]): void {
+  useEffect(() => {
+    const isPast = event.endDate ? new Date(event.endDate) < new Date() : false;
+
+    sendGoogleEvent("view_event_page", {
+      event_id: event.id,
+      event_slug: event.slug ?? "",
+      category_slug: event.categorySlug ?? "",
+      place_slug: event.placeSlug ?? "",
+      has_image: event.hasImage,
+      is_past: isPast,
+      origin: event.origin,
+    });
+  }, [
+    event.categorySlug,
+    event.endDate,
+    event.hasImage,
+    event.id,
+    event.origin,
+    event.placeSlug,
+    event.slug,
+  ]);
 }

--- a/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
+++ b/app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts
@@ -6,12 +6,16 @@ import type { EventClientProps } from "types/props";
 // so the event-detail page's analytics logic lives in one place, the same
 // way FavoritesPageTracker/ProfilePageTracker own their pages' tracking.
 export function useEventAnalytics(event: EventClientProps["event"]): void {
-  const hasTrackedRef = useRef(false);
+  // Tracks the last event.id we fired for, not a plain boolean: Next.js
+  // App Router doesn't remount this component on a dynamic-segment change
+  // (e.g. client-side nav to a different /e/[eventId]), so a one-shot
+  // boolean would silently stop tracking after the first event.
+  const trackedEventIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     // Guards against React Strict Mode's dev-only double-invoke, same as
     // ProfilePageTracker/FavoritesPageTracker.
-    if (hasTrackedRef.current) return;
+    if (trackedEventIdRef.current === event.id) return;
 
     const isPast = event.endDate ? new Date(event.endDate) < new Date() : false;
 
@@ -25,7 +29,7 @@ export function useEventAnalytics(event: EventClientProps["event"]): void {
       is_past: isPast,
       origin: event.origin,
     });
-    hasTrackedRef.current = true;
+    trackedEventIdRef.current = event.id;
   }, [
     event.categorySlug,
     event.endDate,

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { routing } from "@i18n/routing";
 import GoogleScripts from "../GoogleScripts";
+import AuthEventTracker from "@components/analytics/AuthEventTracker";
 import { AdProvider } from "@lib/context/AdContext";
 import { AuthProvider } from "@lib/auth/AuthProvider";
 import BaseLayout from "@components/ui/layout/base";
@@ -203,6 +204,7 @@ export default async function LocaleLayout({
                 <Suspense fallback={null}>
                   <GoogleScripts />
                 </Suspense>
+                <AuthEventTracker />
                 <AnalyticsBootstrap />
                 <WebMcpTools locale={locale} />
                 <BaseLayout>{children}</BaseLayout>

--- a/app/[locale]/perfil/[username]/ProfilePageTracker.tsx
+++ b/app/[locale]/perfil/[username]/ProfilePageTracker.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAuth } from "@components/hooks/useAuth";
+import { sendGoogleEvent } from "@utils/analytics";
+
+/**
+ * Fires a `profile_page_view` event once when a profile page loads. Reused
+ * on /perfil/[username] (status "upcoming") and /perfil/[username]/passats
+ * (status "past") — mirrors FavoritesPageTracker's `period` prop, avoiding a
+ * near-duplicate tracker component per tab.
+ */
+export default function ProfilePageTracker({
+  username,
+  upcomingCount,
+  pastCount,
+  status,
+}: {
+  username: string;
+  upcomingCount: number | undefined;
+  pastCount: number | undefined;
+  status: "upcoming" | "past";
+}) {
+  const { user, isLoading } = useAuth();
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    // Wait for auth to resolve so `is_own_profile` isn't always false on the
+    // owner's first render (AuthProvider hydrates asynchronously).
+    if (hasTrackedRef.current || isLoading) return;
+
+    sendGoogleEvent("profile_page_view", {
+      is_own_profile: user?.username === username,
+      upcoming_count: upcomingCount ?? null,
+      past_count: pastCount ?? null,
+      status,
+    });
+    hasTrackedRef.current = true;
+  }, [username, upcomingCount, pastCount, status, user, isLoading]);
+
+  return null;
+}

--- a/app/[locale]/perfil/[username]/ProfilePageTracker.tsx
+++ b/app/[locale]/perfil/[username]/ProfilePageTracker.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { useAuth } from "@components/hooks/useAuth";
 import { sendGoogleEvent } from "@utils/analytics";
+import type { ProfilePageTrackerProps } from "types/props";
 
 /**
  * Fires a `profile_page_view` event once when a profile page loads. Reused
@@ -15,12 +16,7 @@ export default function ProfilePageTracker({
   upcomingCount,
   pastCount,
   status,
-}: {
-  username: string;
-  upcomingCount: number | undefined;
-  pastCount: number | undefined;
-  status: "upcoming" | "past";
-}) {
+}: ProfilePageTrackerProps): null {
   const { user, isLoading } = useAuth();
   const hasTrackedRef = useRef(false);
 

--- a/app/[locale]/perfil/[username]/ProfilePageTracker.tsx
+++ b/app/[locale]/perfil/[username]/ProfilePageTracker.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useAuth } from "@components/hooks/useAuth";
-import { sendGoogleEvent } from "@utils/analytics";
+import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 import type { ProfilePageTrackerProps } from "types/props";
 
 /**
@@ -25,6 +25,7 @@ export default function ProfilePageTracker({
     // owner's first render (AuthProvider hydrates asynchronously).
     if (hasTrackedRef.current || isLoading) return;
 
+    ensureGtag();
     sendGoogleEvent("profile_page_view", {
       is_own_profile: user?.username === username,
       upcoming_count: upcomingCount ?? null,

--- a/app/[locale]/perfil/[username]/page.tsx
+++ b/app/[locale]/perfil/[username]/page.tsx
@@ -12,6 +12,7 @@ import { getTranslations } from "next-intl/server";
 import { getLocaleSafely, toLocalizedUrl } from "@utils/i18n-seo";
 import { siteUrl } from "@config/index";
 import type { BreadcrumbItem } from "types/common";
+import ProfilePageTracker from "./ProfilePageTracker";
 
 // No generateStaticParams — usernames are user-generated with infinite
 // cardinality. Pages render on first request and are cached automatically.
@@ -108,6 +109,12 @@ export default async function ProfilePage({
         items={tabItems}
         active="upcoming"
         ariaLabel={tProfile("title", { name: profileDisplayName })}
+      />
+      <ProfilePageTracker
+        username={profile.username}
+        upcomingCount={profile.upcomingEventCount}
+        pastCount={profile.pastEventCount}
+        status="upcoming"
       />
       <div className="w-full mt-section-y">
         <Suspense

--- a/app/[locale]/perfil/[username]/passats/page.tsx
+++ b/app/[locale]/perfil/[username]/passats/page.tsx
@@ -9,6 +9,7 @@ import EventsGridSkeleton from "@components/ui/common/skeletons/EventsGridSkelet
 import { getTranslations } from "next-intl/server";
 import { getLocaleSafely, toLocalizedUrl } from "@utils/i18n-seo";
 import { siteUrl } from "@config/index";
+import ProfilePageTracker from "../ProfilePageTracker";
 
 // No generateStaticParams — mirrors the parent /perfil/[username] page.
 
@@ -77,6 +78,12 @@ export default async function ProfilePastEventsPage({
         items={tabItems}
         active="past"
         ariaLabel={tProfile("title", { name: displayName })}
+      />
+      <ProfilePageTracker
+        username={profile.username}
+        upcomingCount={profile.upcomingEventCount}
+        pastCount={profile.pastEventCount}
+        status="past"
       />
       <div className="w-full mt-section-y">
         <Suspense

--- a/app/[locale]/perfil/edita/EditProfileAvatar.tsx
+++ b/app/[locale]/perfil/edita/EditProfileAvatar.tsx
@@ -72,18 +72,24 @@ export default function EditProfileAvatar({
         sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
         return;
       }
-      await refetchUser();
-      sendGoogleEvent("avatar_upload_success", {});
     } catch {
       setError(t("errorUploadFailed"));
       sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
+      return;
     } finally {
       setIsUploading(false);
     }
+
+    // Mutation succeeded — fire success and resync the session outside the
+    // upload's own try/catch, so a refetchUser() failure (session resync,
+    // not the upload) can't get reported as an upload error.
+    sendGoogleEvent("avatar_upload_success", {});
+    await refetchUser();
   };
 
   const handleRemove = async (): Promise<void> => {
     setError(null);
+    sendGoogleEvent("avatar_remove_start", {});
     setIsRemoving(true);
     try {
       const response = await fetch("/api/users/me/avatar", {
@@ -95,14 +101,17 @@ export default function EditProfileAvatar({
         sendGoogleEvent("avatar_remove_error", {});
         return;
       }
-      await refetchUser();
-      sendGoogleEvent("avatar_remove_success", {});
     } catch {
       setError(t("errorRemoveFailed"));
       sendGoogleEvent("avatar_remove_error", {});
+      return;
     } finally {
       setIsRemoving(false);
     }
+
+    // Same ordering rationale as handleFileChange above.
+    sendGoogleEvent("avatar_remove_success", {});
+    await refetchUser();
   };
 
   return (

--- a/app/[locale]/perfil/edita/EditProfileAvatar.tsx
+++ b/app/[locale]/perfil/edita/EditProfileAvatar.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useAuth } from "@components/hooks/useAuth";
 import AvatarInitials from "@components/ui/common/AvatarInitials";
+import { sendGoogleEvent } from "@utils/analytics";
 import type { EditProfileAvatarProps } from "types/props";
 
 // Mirrors the caps enforced server-side in app/api/users/me/avatar/route.ts.
@@ -47,13 +48,16 @@ export default function EditProfileAvatar({
 
     if (!ALLOWED_AVATAR_TYPES.has(file.type)) {
       setError(t("errorUnsupported"));
+      sendGoogleEvent("avatar_upload_error", { reason: "unsupported_type" });
       return;
     }
     if (file.size > MAX_AVATAR_BYTES) {
       setError(t("errorTooLarge"));
+      sendGoogleEvent("avatar_upload_error", { reason: "too_large" });
       return;
     }
 
+    sendGoogleEvent("avatar_upload_start", {});
     setIsUploading(true);
     try {
       const formData = new FormData();
@@ -65,11 +69,14 @@ export default function EditProfileAvatar({
       });
       if (!response.ok) {
         setError(t("errorUploadFailed"));
+        sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
         return;
       }
       await refetchUser();
+      sendGoogleEvent("avatar_upload_success", {});
     } catch {
       setError(t("errorUploadFailed"));
+      sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
     } finally {
       setIsUploading(false);
     }
@@ -85,11 +92,14 @@ export default function EditProfileAvatar({
       });
       if (!response.ok) {
         setError(t("errorRemoveFailed"));
+        sendGoogleEvent("avatar_remove_error", {});
         return;
       }
       await refetchUser();
+      sendGoogleEvent("avatar_remove_success", {});
     } catch {
       setError(t("errorRemoveFailed"));
+      sendGoogleEvent("avatar_remove_error", {});
     } finally {
       setIsRemoving(false);
     }

--- a/app/[locale]/perfil/edita/EditProfileAvatar.tsx
+++ b/app/[locale]/perfil/edita/EditProfileAvatar.tsx
@@ -60,31 +60,35 @@ export default function EditProfileAvatar({
     sendGoogleEvent("avatar_upload_start", {});
     setIsUploading(true);
     try {
-      const formData = new FormData();
-      formData.append("avatarFile", file);
-      const response = await fetch("/api/users/me/avatar", {
-        method: "POST",
-        credentials: "include",
-        body: formData,
-      });
-      if (!response.ok) {
+      try {
+        const formData = new FormData();
+        formData.append("avatarFile", file);
+        const response = await fetch("/api/users/me/avatar", {
+          method: "POST",
+          credentials: "include",
+          body: formData,
+        });
+        if (!response.ok) {
+          setError(t("errorUploadFailed"));
+          sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
+          return;
+        }
+      } catch {
         setError(t("errorUploadFailed"));
         sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
         return;
       }
-    } catch {
-      setError(t("errorUploadFailed"));
-      sendGoogleEvent("avatar_upload_error", { reason: "upload_failed" });
-      return;
+
+      // Mutation succeeded — fire success and resync the session outside the
+      // upload's own try/catch, so a refetchUser() failure (session resync,
+      // not the upload) can't get reported as an upload error. Stays inside
+      // the outer finally so isUploading doesn't clear until the resync is
+      // done, or a second upload could race the first one's session refresh.
+      sendGoogleEvent("avatar_upload_success", {});
+      await refetchUser();
     } finally {
       setIsUploading(false);
     }
-
-    // Mutation succeeded — fire success and resync the session outside the
-    // upload's own try/catch, so a refetchUser() failure (session resync,
-    // not the upload) can't get reported as an upload error.
-    sendGoogleEvent("avatar_upload_success", {});
-    await refetchUser();
   };
 
   const handleRemove = async (): Promise<void> => {
@@ -92,26 +96,28 @@ export default function EditProfileAvatar({
     sendGoogleEvent("avatar_remove_start", {});
     setIsRemoving(true);
     try {
-      const response = await fetch("/api/users/me/avatar", {
-        method: "DELETE",
-        credentials: "include",
-      });
-      if (!response.ok) {
+      try {
+        const response = await fetch("/api/users/me/avatar", {
+          method: "DELETE",
+          credentials: "include",
+        });
+        if (!response.ok) {
+          setError(t("errorRemoveFailed"));
+          sendGoogleEvent("avatar_remove_error", {});
+          return;
+        }
+      } catch {
         setError(t("errorRemoveFailed"));
         sendGoogleEvent("avatar_remove_error", {});
         return;
       }
-    } catch {
-      setError(t("errorRemoveFailed"));
-      sendGoogleEvent("avatar_remove_error", {});
-      return;
+
+      // Same ordering and busy-state rationale as handleFileChange above.
+      sendGoogleEvent("avatar_remove_success", {});
+      await refetchUser();
     } finally {
       setIsRemoving(false);
     }
-
-    // Same ordering rationale as handleFileChange above.
-    sendGoogleEvent("avatar_remove_success", {});
-    await refetchUser();
   };
 
   return (

--- a/app/[locale]/perfil/edita/EditProfileAvatar.tsx
+++ b/app/[locale]/perfil/edita/EditProfileAvatar.tsx
@@ -45,19 +45,19 @@ export default function EditProfileAvatar({
     if (!file) return;
 
     setError(null);
+    sendGoogleEvent("avatar_upload_start", {});
 
     if (!ALLOWED_AVATAR_TYPES.has(file.type)) {
       setError(t("errorUnsupported"));
-      sendGoogleEvent("avatar_upload_error", { reason: "unsupported_type" });
+      sendGoogleEvent("avatar_upload_blocked", { reason: "unsupported_type" });
       return;
     }
     if (file.size > MAX_AVATAR_BYTES) {
       setError(t("errorTooLarge"));
-      sendGoogleEvent("avatar_upload_error", { reason: "too_large" });
+      sendGoogleEvent("avatar_upload_blocked", { reason: "too_large" });
       return;
     }
 
-    sendGoogleEvent("avatar_upload_start", {});
     setIsUploading(true);
     try {
       try {

--- a/app/[locale]/perfil/edita/EditProfileForm.tsx
+++ b/app/[locale]/perfil/edita/EditProfileForm.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "@i18n/routing";
 import { useAuth } from "@components/hooks/useAuth";
 import { validateUsername, isPlaceholderUsername } from "@utils/username-validation";
-import { sendGoogleEvent } from "@utils/analytics";
+import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 import type { EditProfileFormProps } from "types/props";
 import EditProfileAvatar from "./EditProfileAvatar";
 
@@ -43,6 +43,7 @@ export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
   const hasTrackedViewRef = useRef(false);
   useEffect(() => {
     if (hasTrackedViewRef.current) return;
+    ensureGtag();
     sendGoogleEvent("edit_profile_page_view", { is_onboarding: isOnboarding });
     hasTrackedViewRef.current = true;
   }, [isOnboarding]);

--- a/app/[locale]/perfil/edita/EditProfileForm.tsx
+++ b/app/[locale]/perfil/edita/EditProfileForm.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@i18n/routing";
 import { useAuth } from "@components/hooks/useAuth";
 import { validateUsername, isPlaceholderUsername } from "@utils/username-validation";
+import { sendGoogleEvent } from "@utils/analytics";
 import type { EditProfileFormProps } from "types/props";
 import EditProfileAvatar from "./EditProfileAvatar";
 
@@ -38,6 +39,13 @@ export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
+
+  const hasTrackedViewRef = useRef(false);
+  useEffect(() => {
+    if (hasTrackedViewRef.current) return;
+    sendGoogleEvent("edit_profile_page_view", { is_onboarding: isOnboarding });
+    hasTrackedViewRef.current = true;
+  }, [isOnboarding]);
 
   const validate = (): boolean => {
     let ok = true;
@@ -80,6 +88,7 @@ export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
 
     if (!validate()) return;
 
+    sendGoogleEvent("edit_profile_submit_attempt", { is_onboarding: isOnboarding });
     setIsSubmitting(true);
     try {
       const response = await fetch("/api/users/me/profile", {
@@ -95,18 +104,25 @@ export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
 
       if (response.status === 409) {
         setUsernameError(t("errors.usernameTaken"));
+        sendGoogleEvent("edit_profile_submit_blocked", { reason: "username_taken" });
         return;
       }
       if (response.status === 401 || response.status === 403) {
         setSubmitError(t("errors.sessionExpired"));
+        sendGoogleEvent("edit_profile_submit_blocked", { reason: "session_expired" });
         return;
       }
       if (!response.ok) {
         setSubmitError(t("errors.generic"));
+        sendGoogleEvent("edit_profile_submit_error", { reason: "generic" });
         return;
       }
 
       await refetchUser();
+      sendGoogleEvent("edit_profile_submit_success", {
+        is_onboarding: isOnboarding,
+        redirected: !!redirectTo,
+      });
       if (redirectTo) {
         router.push(redirectTo);
         return;
@@ -114,6 +130,7 @@ export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
       setSuccess(true);
     } catch {
       setSubmitError(t("errors.generic"));
+      sendGoogleEvent("edit_profile_submit_error", { reason: "generic" });
     } finally {
       setIsSubmitting(false);
     }

--- a/app/[locale]/preferits/FavoritesPageTracker.tsx
+++ b/app/[locale]/preferits/FavoritesPageTracker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { sendGoogleEvent } from "@utils/analytics";
+import type { FavoritesPageTrackerProps } from "types/props";
 
 /**
  * Fires a `favorites_page_view` event once when the favorites page loads.
@@ -13,11 +14,7 @@ export default function FavoritesPageTracker({
   favoritesCount,
   activeCount,
   period = "active",
-}: {
-  favoritesCount: number;
-  activeCount: number;
-  period?: "active" | "past";
-}) {
+}: FavoritesPageTrackerProps): null {
   const hasTrackedRef = useRef(false);
 
   useEffect(() => {

--- a/app/[locale]/preferits/FavoritesPageTracker.tsx
+++ b/app/[locale]/preferits/FavoritesPageTracker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { sendGoogleEvent } from "@utils/analytics";
+import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 import type { FavoritesPageTrackerProps } from "types/props";
 
 /**
@@ -19,6 +19,7 @@ export default function FavoritesPageTracker({
 
   useEffect(() => {
     if (!hasTrackedRef.current) {
+      ensureGtag();
       sendGoogleEvent("favorites_page_view", {
         favorites_count: favoritesCount,
         active_count: activeCount,

--- a/app/[locale]/preferits/FavoritesPageTracker.tsx
+++ b/app/[locale]/preferits/FavoritesPageTracker.tsx
@@ -5,14 +5,18 @@ import { sendGoogleEvent } from "@utils/analytics";
 
 /**
  * Fires a `favorites_page_view` event once when the favorites page loads.
- * Must be placed inside the favorites page component tree.
+ * Must be placed inside the favorites page component tree. Reused on both
+ * /preferits (period "active", default) and /preferits/passats (period
+ * "past") so the two tabs don't need near-duplicate tracker components.
  */
 export default function FavoritesPageTracker({
   favoritesCount,
   activeCount,
+  period = "active",
 }: {
   favoritesCount: number;
   activeCount: number;
+  period?: "active" | "past";
 }) {
   const hasTrackedRef = useRef(false);
 
@@ -21,10 +25,11 @@ export default function FavoritesPageTracker({
       sendGoogleEvent("favorites_page_view", {
         favorites_count: favoritesCount,
         active_count: activeCount,
+        period,
       });
       hasTrackedRef.current = true;
     }
-  }, [favoritesCount, activeCount]);
+  }, [favoritesCount, activeCount, period]);
 
   return null;
 }

--- a/app/[locale]/preferits/passats/page.tsx
+++ b/app/[locale]/preferits/passats/page.tsx
@@ -14,6 +14,7 @@ import { locale as rootLocale } from "next/root-params";
 import { getTranslations } from "next-intl/server";
 import type { AppLocale } from "types/i18n";
 import type { ProfileTranslator } from "types/props";
+import FavoritesPageTracker from "../FavoritesPageTracker";
 import PastFavoritesAuthGate from "./PastFavoritesAuthGate";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -55,6 +56,13 @@ export default async function PreferitsPassatsPage() {
   return (
     <>
       <Tabs items={tabItems} active="past" ariaLabel={t("heading")} />
+      {activeCount !== null && pastCount !== null && (
+        <FavoritesPageTracker
+          favoritesCount={activeCount + pastCount}
+          activeCount={activeCount}
+          period="past"
+        />
+      )}
       <div className="w-full mt-section-y">
         <Suspense fallback={<EventsGridSkeleton count={3} />}>
           <PastFavoritesSectionOrError accessToken={authToken} t={t} />

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -57,7 +57,12 @@ export async function GET(request: NextRequest): Promise<Response> {
     await verifyIdToken(config, tokens.id_token, flow.nonce);
 
     const returnTo = sanitizeReturnTo(flow.returnTo) ?? "/";
-    const response = NextResponse.redirect(`${origin}${returnTo}`);
+    // One-shot marker so AuthEventTracker can fire `auth_success` once the
+    // browser lands back in the app — mirrors the `auth_error` marker `fail()`
+    // already sets below on failure.
+    const returnToUrl = new URL(returnTo, origin);
+    returnToUrl.searchParams.set("auth_success", "1");
+    const response = NextResponse.redirect(returnToUrl);
     setTokenCookies(response, tokens);
     clearFlowCookies(response);
     return response;

--- a/components/analytics/AuthEventTracker.tsx
+++ b/components/analytics/AuthEventTracker.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { sendGoogleEvent } from "@utils/analytics";
+
+// Fires once per page load when the OIDC callback redirects back with a
+// one-shot `auth_success`/`auth_error` marker (set by /api/auth/callback).
+// Mirrors EventClient's `edit_suggested` one-shot-banner pattern: read the
+// param once, don't bother stripping it from the URL.
+function AuthResultTracker() {
+  const searchParams = useSearchParams();
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasTrackedRef.current) return;
+    const success = searchParams?.get("auth_success");
+    const errorReason = searchParams?.get("auth_error");
+
+    if (success) {
+      sendGoogleEvent("auth_success", {});
+      hasTrackedRef.current = true;
+    } else if (errorReason) {
+      sendGoogleEvent("auth_failure", { reason: errorReason });
+      hasTrackedRef.current = true;
+    }
+  }, [searchParams]);
+
+  return null;
+}
+
+// Delegated click tracker for any element carrying `data-analytics-action`
+// (auth gate CTAs, navbar/footer login+logout links). One document-level
+// listener covers every current and future call site without per-component
+// wiring — activates markup that already exists but was never read.
+function AuthGateClickTracker() {
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const actionEl = target.closest<HTMLElement>("[data-analytics-action]");
+      const action = actionEl?.dataset.analyticsAction;
+      if (!action) return;
+      sendGoogleEvent("auth_gate_click", { action });
+    };
+
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
+
+  return null;
+}
+
+export default function AuthEventTracker() {
+  return (
+    <>
+      <AuthGateClickTracker />
+      <Suspense fallback={null}>
+        <AuthResultTracker />
+      </Suspense>
+    </>
+  );
+}

--- a/components/analytics/AuthEventTracker.tsx
+++ b/components/analytics/AuthEventTracker.tsx
@@ -2,12 +2,15 @@
 
 import { Suspense, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import { sendGoogleEvent } from "@utils/analytics";
+import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 
 // Fires once per page load when the OIDC callback redirects back with a
 // one-shot `auth_success`/`auth_error` marker (set by /api/auth/callback).
-// Mirrors EventClient's `edit_suggested` one-shot-banner pattern: read the
-// param once, don't bother stripping it from the URL.
+// The callback landing is always a hard navigation, so GoogleScripts'
+// `lazyOnload` gtag shim hasn't necessarily run yet when this effect fires —
+// `ensureGtag()` installs the shim first so the event isn't silently
+// dropped. Strips the marker from the URL afterward (via replaceState, no
+// navigation) so a page reload doesn't double-count the same auth outcome.
 function AuthResultTracker() {
   const searchParams = useSearchParams();
   const hasTrackedRef = useRef(false);
@@ -16,14 +19,20 @@ function AuthResultTracker() {
     if (hasTrackedRef.current) return;
     const success = searchParams?.get("auth_success");
     const errorReason = searchParams?.get("auth_error");
+    if (!success && !errorReason) return;
 
+    ensureGtag();
     if (success) {
       sendGoogleEvent("auth_success", {});
-      hasTrackedRef.current = true;
     } else if (errorReason) {
       sendGoogleEvent("auth_failure", { reason: errorReason });
-      hasTrackedRef.current = true;
     }
+    hasTrackedRef.current = true;
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete("auth_success");
+    url.searchParams.delete("auth_error");
+    window.history.replaceState(window.history.state, "", url);
   }, [searchParams]);
 
   return null;
@@ -41,6 +50,7 @@ function AuthGateClickTracker() {
       const actionEl = target.closest<HTMLElement>("[data-analytics-action]");
       const action = actionEl?.dataset.analyticsAction;
       if (!action) return;
+      ensureGtag();
       sendGoogleEvent("auth_gate_click", { action });
     };
 

--- a/components/partials/FavoritesEventsSection.tsx
+++ b/components/partials/FavoritesEventsSection.tsx
@@ -3,6 +3,7 @@ import { listFavoriteEventsByPeriodExternal } from "@lib/api/favorites-external"
 import { MAX_FAVORITES_AUTHENTICATED } from "@utils/constants";
 import EventsSection from "./EventsSection";
 import type { ReactElement } from "react";
+import type { FavoritesEventsSectionProps } from "types/props";
 
 // Authenticated-only: fetches one favourites period and renders it via the
 // shared EventsSection, matching ProfileEventsSection's shape. Returns null
@@ -12,10 +13,7 @@ import type { ReactElement } from "react";
 export default async function FavoritesEventsSection({
   accessToken,
   status,
-}: {
-  accessToken: string;
-  status: "upcoming" | "past";
-}): Promise<ReactElement | null> {
+}: FavoritesEventsSectionProps): Promise<ReactElement | null> {
   const period = status === "past" ? "past" : "active";
   const [t, page] = await Promise.all([
     getTranslations("App.Favorites"),

--- a/components/ui/common/footer/index.tsx
+++ b/components/ui/common/footer/index.tsx
@@ -92,6 +92,9 @@ export default async function Footer(): Promise<JSX.Element> {
                 href={item.href}
                 key={item.name}
                 className="label font-semibold px-button-x py-button-y whitespace-nowrap hover:text-primary transition-interactive"
+                {...(item.href === "/iniciar-sessio"
+                  ? { "data-analytics-action": "footer_login" }
+                  : {})}
               >
                 {item.name}
               </ActiveLink>

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -192,6 +192,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                             type="button"
                             onClick={() => { logout(); setIsUserMenuOpen(false); }}
                             className="w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
+                            data-analytics-action="navbar_logout_desktop"
                           >
                             {labels.logout}
                           </button>
@@ -202,6 +203,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                   <ActiveLink
                     href="/iniciar-sessio"
                     className="btn-outline label font-semibold whitespace-nowrap"
+                    data-analytics-action="navbar_login_desktop"
                   >
                     {labels.login}
                   </ActiveLink>
@@ -256,6 +258,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                     activeLinkClass="text-primary bg-primary/10"
                     className="flex-center p-3 rounded-full hover:bg-muted transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 min-w-[44px] min-h-[44px]"
                     aria-label={labels.login}
+                    data-analytics-action="navbar_login_mobile_icon"
                   >
                     <UserCircleIcon className="h-6 w-6" />
                   </ActiveLink>
@@ -340,6 +343,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                       type="button"
                       onClick={() => { logout(); setIsMenuOpen(false); }}
                       className="label font-semibold px-button-x py-3 hover:bg-muted/50 rounded-lg transition-all text-center"
+                      data-analytics-action="navbar_logout_mobile"
                     >
                       {labels.logout}
                     </button>
@@ -348,6 +352,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                   <ActiveLink
                     href="/iniciar-sessio"
                     className="label font-semibold px-button-x py-3 hover:bg-muted/50 rounded-lg transition-all text-center"
+                    data-analytics-action="navbar_login_mobile_menu"
                   >
                     {labels.login}
                   </ActiveLink>

--- a/components/ui/profile/ProfileClaimCta.tsx
+++ b/components/ui/profile/ProfileClaimCta.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@components/hooks/useAuth";
 import { useTranslations } from "next-intl";
 import { Link } from "@i18n/routing";
+import useTrackedCta from "@components/hooks/useTrackedCta";
 import type { ProfileClaimCtaProps } from "types/props";
 
 export default function ProfileClaimCta({
@@ -10,15 +11,18 @@ export default function ProfileClaimCta({
 }: ProfileClaimCtaProps) {
   const { status } = useAuth();
   const t = useTranslations("Components.Profile");
+  const { ref: ctaRef, trackClick } = useTrackedCta<HTMLParagraphElement>("profile_claim_cta");
 
   if (status !== "unauthenticated") return null;
 
   return (
-    <p className="body-small text-foreground/60 mb-element-gap">
+    <p ref={ctaRef} className="body-small text-foreground/60 mb-element-gap">
       {t("claimQuestion")}{" "}
       <Link
         href={`/iniciar-sessio?redirect=/perfil/${encodeURIComponent(username)}`}
         className="text-primary font-semibold"
+        onClick={trackClick}
+        data-analytics-action="profile_claim_login"
       >
         {t("claimLogin")}
       </Link>

--- a/components/ui/profile/ProfileOwnerActions.tsx
+++ b/components/ui/profile/ProfileOwnerActions.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@components/hooks/useAuth";
 import { useTranslations } from "next-intl";
 import { Link } from "@i18n/routing";
+import useTrackedCta from "@components/hooks/useTrackedCta";
 import type { ProfileOwnerActionsProps } from "types/props";
 
 export default function ProfileOwnerActions({
@@ -10,12 +11,15 @@ export default function ProfileOwnerActions({
 }: ProfileOwnerActionsProps) {
   const { user } = useAuth();
   const t = useTranslations("Components.Profile");
+  const { ref: ctaRef, trackClick } = useTrackedCta<HTMLDivElement>("profile_edit_cta");
 
   if (user?.username !== username) return null;
 
   return (
-    <Link href="/perfil/edita" className="btn-outline btn-sm">
-      {t("editProfile")}
-    </Link>
+    <div ref={ctaRef} className="inline-block">
+      <Link href="/perfil/edita" className="btn-outline btn-sm" onClick={trackClick}>
+        {t("editProfile")}
+      </Link>
+    </div>
   );
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,8 +39,10 @@ caching, ISR/PPR, or the Coolify deploy pipeline.
   `competitor-screenshots/`.
 
 Current design tokens live in `DESIGN.md` at the repo root — read that first
-for any new UI work. The three files above are the historical record of how
-the token system got there, not the day-to-day reference.
+for any new UI work. `design-system-overview.md`, `implementation-reference.md`,
+and `reference-data.md` are the historical record of how the token system got
+there, not the day-to-day reference. `design-rationale.md` is a separate,
+still-relevant competitive-UX reference, not part of that migration history.
 
 ## Infra & Deploys
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,514 +1,69 @@
 # Project Documentation
 
-## 📚 Navigation
-
-This folder contains documentation for the design system migration and AI agent skills implementation.
-
----
-
-## 🗂️ Document Index
-
-### AI Agent Skills (NEW)
-
-#### **[`agent-skills-strategy.md`](./agent-skills-strategy.md)** 🤖 DEEP DIVE
-
-Complete strategy for leveraging GitHub Copilot Agent Skills in this codebase.
-
-- What are Agent Skills and how they work (progressive disclosure)
-- 12 recommended skills (filter system, API layer, type governance, etc.)
-- Implementation roadmap with success metrics
-- Skills vs. custom instructions division of labor
-
-**Audience**: Tech leads, senior developers  
-**Time to Read**: 30-40 minutes
-
-#### **[`agent-skills-quickstart.md`](./agent-skills-quickstart.md)** ⚡ START HERE
-
-Quick start guide to enable and use Agent Skills immediately.
-
-- 2-minute setup instructions
-- Test prompts for existing skills
-- How skills work behind the scenes
-- Troubleshooting and common issues
-
-**Audience**: All developers  
-**Time to Read**: 5 minutes
-
-#### **[`how-to-make-ai-follow-rules.md`](./how-to-make-ai-follow-rules.md)** 🎯 PRACTICAL TIPS
-
-How to prompt AI to actually follow your rules (not just read them).
-
-- Two-phase prompts (plan then implement)
-- Verification loops (ask AI to check its own work)
-- Copy-paste prompt templates
-- Common AI mistakes and prevention
-
-**Audience**: All developers  
-**Time to Read**: 5 minutes
-
----
-
-### Design & UX
-
-#### **[`design-rationale.md`](./design-rationale.md)** 🎨 DESIGN DECISIONS
-
-Why we made specific UI/UX decisions — competitive benchmarking, card redesign reasoning, and intentionally rejected patterns.
-
-- Card layout decisions (image-first, 3:2 ratio, 2-col grid, no share buttons)
-- Competitive analysis (Eventbrite, Fever, DICE, Meetup, Time Out)
-- Homepage & event detail page assessments
-- Future opportunities prioritized by impact
-- Data available on cards (what to show, what to hide)
-
-**Audience**: Designers, developers making UI changes
-**Time to Read**: 15 minutes
-
----
-
-### Design System Migration
-
-#### **[`design-system-overview.md`](./design-system-overview.md)** 🎯 START HERE
-
-### WHAT & WHY
-
-Quick overview of the project:
-
-- Current problems (typography chaos, color inconsistency, shadows, spacing)
-- Solution approach (semantic classes + professional design tokens)
-- 7-week timeline
-- Success criteria
-- FAQ
-
-**Audience**: Everyone (10 min read)
-
----
-
-### 2. **[`implementation-reference.md`](./implementation-reference.md)** 📦 CODE REFERENCE
-
-### ALL CODE & CONFIGURATION
-
-Single source of truth for all code:
-
-- Complete `tailwind.config.js` (Week 1)
-- Complete `globals.css` with semantic classes (Week 1)
-- Class reference guide (typography, buttons, cards, badges, layout)
-- Anti-patterns and migration patterns
-
-**Audience**: Developers (daily reference), AI agents
-
----
-
-### 3. **[`reference-data.md`](./reference-data.md)** 📊 LOOKUP TABLES
-
-### PURE DATA
-
-All lookup tables in one place:
-
-- Gray-to-semantic mapping table (112 instances)
-- Component inventory with priorities (88 components)
-- Per-file checklists
-- Weekly targets
-
-**Audience**: Developers (Week 3 colors), AI agents
-
----
-
-### 4. **[`.github/copilot-instructions.md`](../.github/copilot-instructions.md)** 🛡️ AI RULES
-
-### MANDATORY FOR AI AGENTS
-
-Section 20: Design System Conventions
-
-- Typography, colors, buttons, cards rules
-- Forbidden patterns
-- Examples
-
-**Audience**: AI agents (auto-enforced)
-
----
-
-## 🚀 Quick Start
-
-### For Developers Starting Migration
-
-1. Read: **design-system-overview.md** (10 min) - Understand WHAT & WHY
-2. Reference: **implementation-reference.md** (bookmark) - Get code for Week 1
-3. Lookup: **reference-data.md** - Gray mappings, component priorities
-
-### For AI Agents
-
-1. **Reference**: **implementation-reference.md** - Get all code
-2. **Lookup**: **reference-data.md** - Gray mappings, component inventory
-3. **Rules**: **..github/copilot-instructions.md** Section 20 - Mandatory design system rules
-
----
-
-## 📋 Single Source of Truth
-
-Each topic has ONE authoritative document:
-
-| Topic         | Source of Truth                 | Other Docs          |
-| ------------- | ------------------------------- | ------------------- |
-| WHAT & WHY    | design-system-overview.md       | -                   |
-| ALL CODE      | implementation-reference.md     | Others reference it |
-| LOOKUP TABLES | reference-data.md               | Others link to it   |
-| AI RULES      | .github/copilot-instructions.md | -                   |
-
-**Zero duplication**: Update one place, reflects everywhere.
-
----
-
-## 🎯 Key Metrics
-
-### Implementation Effort
-
-- **Timeline**: 7 weeks (1 week pre-flight + 6 weeks implementation)
-- **Components**: 88 components to migrate
-- **Gray Instances**: 112 to replace with semantic colors
-- **Quick Wins**: 3 hours (Week 1) for professional design
-
-### Success Criteria
-
-- ✅ 88/88 components migrated
-- ✅ 0 generic gray classes
-- ✅ All tests passing
-- ✅ 30% reduction in className length
-- ✅ Professional shadows, spacing, transitions
-- ✅ Visual quality: C+ → A
-
----
-
-## 📖 Documentation Structure
-
-```text
-docs/
-├── README.md (this file - navigation)
-│
-├── design-system-overview.md (WHAT & WHY)
-│   └── Problems, solution, timeline, FAQ
-│
-├── implementation-reference.md (ALL CODE)
-│   └── tailwind.config.js, globals.css, class reference
-│
-└── reference-data.md (LOOKUP TABLES)
-    └── Gray mappings, component inventory
-
-.github/copilot-instructions.md (AI PROCESS & RULES) - located in root .github/ directory
-    ├── Batch workflow, templates, tips
-    └── Section 20: Design system conventions
-```
-
----
-
-## 🆘 Need Help?
-
-1. **Don't know where to start?** → Read design-system-overview.md
-2. **Need Week 1 code?** → See implementation-reference.md
-3. **Looking for gray mapping?** → Check reference-data.md
-
----
-
-## ⚙️ Week 0: Pre-Flight Baseline Setup
-
-**Before starting migration**, capture baselines for metrics tracking:
-
-### Metrics to Measure
-
-- **CSS bundle size**: `yarn build` → record `.next/static/css/` total size (compare week 7: must be within 5%)
-- **Test suite baseline**: `yarn test && yarn typecheck` → both must pass (track regressions per week)
-- **Gray class count**: `grep -rE 'text-gray-|bg-gray-|border-gray-' components/ app/ | wc -l` → baseline: 112 (target week 7: 0)
-
-### Visual Regression Baselines
-
-- **Record Playwright baselines**: `yarn test:e2e` (stores screenshots in playwright-report/)
-- **Pages to baseline**: homepage, event-detail, event-list-category, event-list-place, filters-page, news-list, news-article, search-results, offline-page, error-page
-- **Usage**: CI compares future screenshots against baselines; diffs must be reviewed/approved
-
-See **design-system-overview.md Week 0 section** for exact commands and timing.
-
----
-
----
-
-**Status**: ✅ Week 2 Complete - All Typography Migrated  
-**Last Updated**: October 2025
-
-### Week 1 ✅ COMPLETED
-
-- Updated `tailwind.config.js` with complete design tokens (colors, spacing, border-radius, shadows, transitions)
-- Added semantic classes layer to `styles/globals.css`:
-  - Typography: `.heading-*`, `.body-*`, `.label`
-  - Buttons: `.btn-primary`, `.btn-neutral`, `.btn-outline`, `.btn-muted`
-  - Cards: `.card-bordered`, `.card-elevated`, `.card-body`, `.card-footer`
-  - Badges: `.badge-default`, `.badge-primary`
-  - Layout: `.flex-center`, `.flex-between`, `.flex-start`, `.stack`
-  - Forms: `.input`, `.input-lg`, `.input-error`, `.input-disabled`, `.input-readonly`
-  - Shadows: `.shadow-card`, `.shadow-card-hover`, `.shadow-modal`, `.shadow-dropdown`, `.shadow-hero`
-  - Transitions: `.transition-interactive`, `.transition-card`, `.transition-modal`, `.hover-lift`, `.hover-scale`, `.hover-glow`
-  - Focus utilities: `.focus-ring`, `.focus-ring-error`
-- All tests passing: `yarn test`, `yarn typecheck`, `yarn lint`
-- Build successful with no errors
-- Professional shadow system (7 levels), spacing tokens, transitions, validation colors added
-
-### Week 2 Phase 1 (Batch 1) ✅ COMPLETED - Typography Migration
-
-- **HybridEventsList** (`components/ui/hybridEventsList/index.tsx`)
-  - Line 56: `<h1>` → `.heading-1` (replaced 8 inline utilities)
-  - Line 69: `<p>` → `.body-large` (replaced inline utilities)
-  - Impact: Every listing page (place, category, date filters)
-
-- **Footer** (`components/ui/common/footer/index.tsx`)
-  - Navigation links → `.label font-medium`
-  - Copyright text → `.label`
-  - Removed `text-xs` class
-  - Impact: Visible on every page
-
-- **News Article Page** (`app/noticies/[place]/[article]/page.tsx`)
-  - Line 166: `<h1>` → `.heading-1` (replaced 7 inline utilities)
-  - Line 182: `<p>` → `.body-large` (replaced inline utilities)
-  - Impact: All news detail pages
-
-- **Link Components**
-  - `components/ui/common/link/index.tsx` (ActiveLink)
-  - `components/ui/common/link/ActiveNavLink.tsx`
-  - Updated default className to use `.label` instead of 5 inline utilities
-  - Impact: All navigation links throughout the app
-
-- All tests passing (114 tests)
-- Build successful, TypeScript clean, linting passed
-
-### Week 2 Phase 2 (Batch 2) ✅ COMPLETED - Card Components Typography
-
-- **NewsCard** (`components/ui/newsCard/index.tsx`)
-  - Hero variant: h2 → `.heading-1`, date/place labels → `.label`
-  - Default variant: h3 → `.heading-3`, description → `.body-small`
-  - Impact: All news listing pages
-
-- **NewsRichCard** (`components/ui/newsRichCard/index.tsx`)
-  - Horizontal variant: h3 → `.heading-2`, description → `.body-normal`
-  - Default variant: h3 → `.heading-3`, description → `.body-small`
-  - Impact: Featured news sections
-
-- **CardContent** (`components/ui/common/cardContent/index.tsx`)
-  - h3 title → `.heading-4` (replaced `uppercase`)
-  - Date, location, time info → `.body-small`
-  - Impact: All event cards in listings
-
-- Ready for verification: TypeScript, Lint, Build, Tests
-
-### Week 2 Phase 3 (Batch 3) ✅ COMPLETED - Event Detail & Description Pages
-
-- **EventHeader** (`app/e/[eventId]/components/EventHeader.tsx`)
-  - h1 → `.heading-3` (replaced `text-2xl font-bold uppercase`)
-  - Impact: Event detail page main title
-
-- **EventDetailsSection** (`app/e/[eventId]/components/EventDetailsSection.tsx`)
-  - h2 → `.heading-3`
-  - Duration info → `.body-small`
-  - Event link → `.body-normal`
-  - Impact: Event detail metadata section
-
-- **Description** (`components/ui/common/description/index.tsx`)
-  - h2 → `.heading-3` (replaced no class)
-  - Intro text → `.body-normal` (replaced `text-base leading-relaxed font-normal`)
-  - Content text → `.body-normal` (replaced inline utilities)
-  - Impact: Event and news detail descriptions
-
-- All Phase 1, 2, and 3 components migrated to semantic typography
-- Total components migrated: 14 high-traffic components
-- Total typography utilities replaced: 50+ inline classes consolidated
-
-### Week 3 (Batch 1-3) ✅ COMPLETED - Colors Migration
-
-**Target**: Replace 112 gray instances with semantic colors (`text-foreground`, `bg-muted`, `border-border`, etc.)
-
-✅ Completed (Batch 1 - High Priority Files - 52 instances):
-
-- **RestaurantPromotionForm.tsx** (21 instances → 0 gray classes)
-- **WhereToEatSection.tsx** (12 instances → 0 gray classes)
-- **locationDiscoveryWidget/index.tsx** (11 instances → 0 gray classes)
-- **WhereToEatSkeleton.tsx** (8 instances → 0 gray classes)
-
-✅ Completed (Batch 2 - Sitemap Pages - 25 instances):
-
-- **app/sitemap/page.tsx** (8 instances → 0 gray classes)
-- **app/sitemap/[town]/page.tsx** (8 instances → 0 gray classes)
-- **app/sitemap/[town]/[year]/[month]/page.tsx** (9 instances → 0 gray classes)
-
-✅ Completed (Batch 3 - Remaining Files - 35 instances):
-
-- **PromotedRestaurantCard.tsx** (3 instances → 0 gray classes)
-- **form/select/index.tsx** (2 instances → 0 gray classes - skeleton)
-- **form/multiSelect/index.tsx** (2 instances → 0 gray classes - skeleton)
-- **form/textarea/index.tsx** (4 instances → 0 gray classes)
-- **CardHorizontalServer.tsx** (3 instances → 0 gray classes)
-- **common/notification/index.tsx** (2 instances → 0 gray classes)
-- **EventForm/index.tsx** (1 instance → 0 gray classes - spinner)
-- **viewCounter/ViewCounterIsland.tsx** (2 instances → 0 gray classes - skeleton)
-- **PromotionInfoModal.tsx** (1 instance → 0 gray classes)
-- **CloudinaryUploadWidget.tsx** (2 instances → 0 gray classes)
-- **common/staticShareButtons/index.tsx** (2 instances → 0 gray classes)
-- **filters/FilterButton.tsx** (1 instance → 0 gray classes)
-- **eventsAround/EventsAroundServer.tsx** (1 instance → 0 gray classes)
-- **locationDiscoveryWidget/LocationDropdown.tsx** (1 instance → 0 gray classes)
-- **app/e/[eventId]/components/EventDescription.tsx** (1 instance → 0 gray classes)
-- **app/e/[eventId]/components/EventTags.tsx** (1 instance → 0 gray classes)
-
----
-
-**Status**: ✅ Week 2 Complete + Week 3 Complete (112/112 gray instances migrated - 100% ✅)  
-**Progress**: 100% Complete - All gray colors replaced with semantic tokens  
-**Last Updated**: October 2025
-
-### Week 4 (Batch 1-3) ✅ COMPLETED - Buttons & Cards
-
-**Target**: Replace 40+ inline button/badge patterns with semantic classes
-
-✅ Completed (Batch 1 - Card & Badge Migration - 16 instances):
-
-- **newsCard.tsx** (4 patterns → 0 inline)
-- **newsRichCard.tsx** (12 patterns → 0 inline)
-
-✅ Completed (Batch 2 - Hero & Button Components - 8 patterns):
-
-- **newsHeroEvent.tsx** (1 button → `.btn-primary`)
-- **loadMoreButton.tsx** (1 pattern → `.btn-neutral`)
-
-✅ Completed (Batch 3 - Additional Button/Badge Patterns - 4 instances):
-
-- **PromotedRestaurantCard.tsx** (1 badge → `.badge-primary`)
-- **RestaurantPromotionForm.tsx** (1 button → `.btn-primary w-full`)
-
-📋 Not Migrated (Custom Components - Left As-Is):
-
-- Modal buttons (custom styling, not standard patterns)
-- EditModal buttons (specialized delete flow styling)
-- ImageUpload icon buttons (icon-specific hover states)
-- NewsCta component (specialized CTA styling)
-- ServerEventsCategorized buttons (complex custom styling)
-
----
-
-**Status**: ✅ Week 2 Complete + Week 3 Complete + Week 4 Complete (28 patterns migrated)
-**Progress**: Weeks 1-4 Complete - Typography, Colors, Buttons & Cards fully migrated
-**Last Updated**: October 2025
-
-### Week 5 (Batch 1-3) ✅ COMPLETED - Layout & Polish
-
-**Target**: Replace repetitive flex patterns with semantic layout utilities
-
-✅ Completed (Batch 1 - Flex-Center & Flex-Between - 5 instances):
-
-- **loadMoreButton.tsx**: `flex justify-center items-center` → `.flex-center`
-- **RestaurantPromotionForm.tsx**: `flex justify-between items-center` → `.flex-between`
-- **common/form/textarea/index.tsx** (2 patterns): Header & footer controls → `.flex-between`
-
-✅ Completed (Batch 2 - Stack (Flex-Col-Gap) Patterns - 6 instances):
-
-- **PromotedRestaurantCard.tsx**, **PromotionInfoModal.tsx**, **WhereToEatSkeleton.tsx**, **WhereToEatSection.tsx**, **common/description/index.tsx**, **common/form/rangeInput/index.tsx**
-- All `flex flex-col gap-4` patterns → `.stack`
-
-✅ Completed (Batch 3 - Additional Patterns - 1 instance):
-
-- **serverEventsCategorized/index.tsx**: Ad placement layout → `.stack`
-
-📋 Not Migrated (Specialized Gaps):
-
-- `flex flex-col gap-1` patterns (gap too small for standard token)
-- Gap-2 patterns (need custom spacing review)
-
----
-
-**Status**: ✅ Weeks 1-5 Complete (40+ layout patterns consolidated)
-**Progress**: 5 weeks complete - Full design system migration achieving 240+ total patterns consolidated
-**Last Updated**: October 2025
-
----
-
-## 🔒 Guardrails (Enforcement)
-
-- CI must pass: `yarn typecheck && yarn lint && yarn test`.
-- Failure criteria:
-  - Any usage of `text-gray-*`, `bg-gray-*`, `border-gray-*` in app/components.
-  - Repetitive flex patterns not replaced by semantic utilities where available.
-  - Long button class strings instead of `.btn-*` or `<Button variant="...">`.
-- Quick checks:
-  - Count gray usage: see commands in `reference-data.md`.
-  - Count semantic usage: see commands in `reference-data.md`.
-- Phased enforcement:
-  - Week 3+: error on `gray-*` in changed files via CI grep (see `reference-data.md`).
-  - Week 7+: repo-wide enforcement; PR removes legacy aliases.
-
-## 🖼️ Visual Regression Testing
-
-- Tool: Playwright screenshots (already in repo).
-- Week 0: record baselines for 10 key pages.
-- Per PR: compare against baseline; diffs must be acknowledged or fixed.
-
-## 🧭 Decisions (Canonical)
-
-- Color tokens: `background`, `foreground`, `foreground-strong`, `muted`, `border`, `primary-foreground`.
-- Legacy aliases (during migration only): `whiteCorp`, `darkCorp`, `blackCorp`, `fullBlackCorp`, `bColor`.
-- Primary dark token: `primary-dark` (hyphen).
-- Stack spacing: `.stack = flex flex-col gap-element-gap`.
-- Border radius tokens: button 8px, card 12px, input 8px, badge full.
-
-## 🔗 Quick Links
-
-- Change tokens: `tailwind.config.js` (see `implementation-reference.md`).
-- Add semantic classes: `styles/globals.css` (see `implementation-reference.md`).
-
----
-
-### Event Detail Page Typography Audit — Completed (October 2025)
-
-- Scope: `app/e/[eventId]/page.tsx` and child components
-- Goal: Align all text sizes to semantic typography classes per design system
-- Outcome: Full coherence from navbar (`.label` via `ActiveLink`) to final sections
-
-Updated files
-
-- `app/e/[eventId]/page.tsx` (FAQ, news, ad headings/links)
-- `app/e/[eventId]/components/EventCalendar.tsx`
-- `app/e/[eventId]/components/EventDetailsSection.tsx`
-- `app/e/[eventId]/components/PastEventBanner.tsx`
-- `app/e/[eventId]/components/EventStatusDetails.tsx`
-- `app/e/[eventId]/components/EventStatusBadge.tsx`
-- `app/e/[eventId]/components/EventLocation.tsx`
-- `app/e/[eventId]/EventClient.tsx`
-- `app/e/[eventId]/components/EventTags.tsx`
-- `components/ui/restaurantPromotion/RestaurantPromotionSection.tsx`
-- `components/ui/eventsAround/EventsAroundServer.tsx` (compact layout)
-
-Rules enforced
-
-- Headings: `.heading-3` / `.heading-4`
-- Body text: `.body-normal` / `.body-small`
-- Labels/badges: `.label` / `.badge-*`
-- No arbitrary `text-[size]` or `text-md` left in changed files
-
-Known exceptions (intentional)
-
-- `PastEventBanner` CTA anchors keep custom colors/borders, with `.body-small` applied for size consistency.
-- Status badge colors keep existing hex values (to be migrated in a future color pass).
-
-Cross‑page audit checklist (next)
-
-- Navbar mobile second bar text ("Publica") → ensure `.label` if text remains visible on some breakpoints
-- Place listing pages: headings and card texts (`components/ui/card*`, `hybridEventsList`)
-- Category listing pages
-- News list/detail: verify `.heading-*`/`.body-*` on titles, descriptions, CTAs
-- Search results page
-- Publica form pages (buttons/labels are already migrated; re‑check helper texts)
-- Offline and error pages (`app/offline/page.tsx`, `app/error.tsx`, `app/global-error.tsx`)
-- Sitemap pages (already color‑migrated; verify headings/body text)
-
-Validation
-
-- Lint/type checks pass on modified files
-- Visual check preserves heading hierarchy; body sizes consistent
-
-Reference
-
-- Design system code: `docs/implementation-reference.md`
-- Enforced rules: `.github/copilot-instructions.md` §20
+Index of `docs/`. For AI agent skills (the day-to-day "how do I build X in
+this codebase" guides), see `.github/skills/*/SKILL.md` — indexed from
+`AGENTS.md`'s skill table, not here.
+
+## Auth & Profiles
+
+- [`logto-auth-setup.md`](./logto-auth-setup.md) — Logto instance/env setup,
+  the `LOGTO_*` var table, CI guard. Also see the `auth-patterns` skill for
+  the OIDC flow and `useAuth()` contract.
+- [`api-spec-profiles.md`](./api-spec-profiles.md) — backend profile API
+  contract (fields, endpoints) the frontend integrates against.
+- [`plans/2026-05-26-user-favorites-sync.md`](./plans/2026-05-26-user-favorites-sync.md)
+  — guest-to-account favorites migration design.
+- [`plans/2026-07-30-profile-events-split.md`](./plans/2026-07-30-profile-events-split.md)
+  — the active/past events tab split on profile pages.
+
+## Incidents
+
+[`incidents/README.md`](./incidents/README.md) indexes postmortems —
+Cloudflare RSC cache poisoning, Coolify PR-preview empty HTML, AI-bot CDN
+cache mixing, Redis stale prerenders, Cache Components metadata mismatch,
+Places API cost, PR-review-loop missed threads. Read before touching CDN
+caching, ISR/PPR, or the Coolify deploy pipeline.
+
+## Design
+
+- [`design-system-overview.md`](./design-system-overview.md) — the semantic
+  design-token system (typography, color, buttons, cards, spacing) and how
+  it replaced ad-hoc Tailwind classes.
+- [`implementation-reference.md`](./implementation-reference.md) — the full
+  code reference for those tokens (`tailwind.config.js`, `globals.css`,
+  class-by-class migration notes).
+- [`reference-data.md`](./reference-data.md) — lookup tables from that
+  migration (gray→semantic color mapping, component inventory).
+- [`design-rationale.md`](./design-rationale.md) — competitive UI/UX
+  benchmarking and card/layout decisions. Screenshots in
+  `competitor-screenshots/`.
+
+Current design tokens live in `DESIGN.md` at the repo root — read that first
+for any new UI work. The three files above are the historical record of how
+the token system got there, not the day-to-day reference.
+
+## Infra & Deploys
+
+- [`ci-build-push-migration.md`](./ci-build-push-migration.md) — build in CI,
+  deploy a prebuilt image to Coolify.
+- [`self-hosted-resource-limits.md`](./self-hosted-resource-limits.md) —
+  Coolify/Hetzner box resource limits.
+- [`streaming-refactor-findings-2026-04.md`](./streaming-refactor-findings-2026-04.md)
+  — notes from the streaming/PPR refactor.
+
+## Product / Growth
+
+- [`restaurant-promotion-implementation.md`](./restaurant-promotion-implementation.md)
+  and [`restaurant-promotion-schema.md`](./restaurant-promotion-schema.md) —
+  restaurant promotion feature implementation + DB schema.
+- [`strategy-pricing.md`](./strategy-pricing.md) — self-service sponsor
+  banner system.
+- [`seo-audit-2026-03-09.md`](./seo-audit-2026-03-09.md),
+  [`seo-audit-2026-05-18.md`](./seo-audit-2026-05-18.md) — SEO/GSC audits.
+- [`performance-assessment-2026-03.md`](./performance-assessment-2026-03.md)
+  — Core Web Vitals / performance audit.
+
+## Design specs (in-flight work)
+
+`superpowers/specs/` holds dated design docs written before implementation
+(spec → plan → build). Check there for the most recent feature designs.

--- a/docs/superpowers/specs/2026-08-02-auth-profile-analytics-and-docs-design.md
+++ b/docs/superpowers/specs/2026-08-02-auth-profile-analytics-and-docs-design.md
@@ -1,0 +1,138 @@
+# Auth/profile/favorites-tabs analytics + doc sync — design
+
+Date: 2026-08-02
+Status: approved, implementing
+
+## Context
+
+Between commits `dcda2d6b`..`b263bad8` on `develop`, the app grew a full Logto-based
+auth system, a profile page with tabs, an edit-profile/avatar flow, and a
+past-favourites tab. None of it has analytics instrumentation, and none of it
+is documented in the top-level project docs. This spec covers closing both
+gaps in one pass.
+
+Verified gaps (not assumed):
+
+- 6 auth-gate components carry `data-analytics-action="..."` attributes that
+  look wired but are read by nothing in the codebase (dead markup).
+- Login is also reachable from the navbar (3 spots) and the footer (1 spot),
+  none instrumented.
+- Login/logout is a server-side OIDC redirect (Logto) — no client-side event
+  fires on success or failure. The callback route already produces
+  `?auth_error=reason` on failure, but nothing consumes it.
+- Profile page, edit-profile page, avatar upload, and the two new past-tabs
+  have zero custom events. Tab switches themselves are ordinary route
+  navigations, so the existing generic GA `page_view` already covers them —
+  not a gap.
+- `app/[locale]/e/[eventId]/hooks/useEventAnalytics.ts` is fully dead code
+  (zero call sites anywhere), pre-existing and unrelated to this feature
+  work, folded into this pass per user decision.
+- `README.md` / `AGENTS.md` have zero mention of Logto/auth/profile/favorites-tabs.
+  `AGENTS.md`'s skill table has no auth entry. `api-layer-patterns/SKILL.md`
+  documents a stale pre-Logto `POST /api/auth/register` HMAC pattern.
+  `docs/README.md` indexes an unrelated, finished Oct-2025 design-migration
+  project.
+- `/registre` is linked from `PublishAuthGate` but has no route/rewrite
+  serving it — likely a dead signup link. **Flagged, not fixed** — unrelated
+  to analytics/docs.
+- No client-visible UI currently reacts to `auth_error` — this spec only adds
+  the analytics event, not an error toast. **Flagged, not fixed.**
+- Logto's hosted UI doesn't let the app distinguish login vs. signup intent,
+  so `auth_success`/`auth_failure` can't be split into separate funnels.
+
+## A. Auth click + funnel tracking
+
+One new client component, `components/analytics/AuthEventTracker.tsx`,
+mounted once in `app/[locale]/layout.tsx` next to `<GoogleScripts />`.
+
+1. **Delegated click listener** (mount-once `document` click listener):
+   `event.target.closest("[data-analytics-action]")` → fires
+   `sendGoogleEvent("auth_gate_click", { action })`. Activates the 6 existing
+   dead attributes with no changes to those files. Extends the same
+   attribute (new, this spec) to:
+   - Navbar: `navbar_login_desktop`, `navbar_login_mobile_icon`,
+     `navbar_login_mobile_menu`, `navbar_logout_desktop`,
+     `navbar_logout_mobile`.
+   - Footer: `footer_login`.
+2. **Success/failure one-shot tracker**: reads `auth_success` / `auth_error`
+   from `useSearchParams()` once (same one-shot-URL-marker pattern as
+   `edit_suggested=true` on the event page), fires `sendGoogleEvent("auth_success", {})`
+   or `sendGoogleEvent("auth_failure", { reason })`, then strips the param via
+   `router.replace`. Needs a `Suspense` boundary (same reason
+   `GoogleAnalyticsPageview` has one).
+   - `app/api/auth/callback/route.ts`: add `auth_success=1` to the success
+     redirect URL (mirrors the existing `fail()` helper's `auth_error=reason`).
+
+## B. Page-view + funnel events
+
+- `FavoritesPageTracker.tsx`: add optional `period?: "active" | "past"` prop
+  (default `"active"`), included in the `favorites_page_view` payload. Reused
+  on `/preferits` (existing) and `/preferits/passats` (new) — no duplicate
+  component.
+- New trackers, same shape as `FavoritesPageTracker`:
+  - `app/[locale]/perfil/[username]/ProfilePageTracker.tsx` →
+    `profile_page_view` (`username`, `is_own_profile`, `upcoming_count`).
+  - `app/[locale]/perfil/[username]/passats/PastEventsPageTracker.tsx` →
+    `profile_past_events_page_view` (`username`, `is_own_profile`, `past_count`).
+  - `app/[locale]/perfil/edita/EditProfilePageTracker.tsx` →
+    `edit_profile_page_view` (`is_onboarding`).
+- `EditProfileForm.tsx` (`onSubmit`): `edit_profile_submit_attempt` →
+  `edit_profile_submit_blocked` (`reason: "username_taken" | "session_expired"`)
+  / `edit_profile_submit_error` (`reason: "generic"`) /
+  `edit_profile_submit_success` (`is_onboarding`, `redirected`).
+- `EditProfileAvatar.tsx`: `avatar_upload_start` → `avatar_upload_error`
+  (`reason: "unsupported_type" | "too_large" | "upload_failed"`) /
+  `avatar_upload_success`; `avatar_remove_success` / `avatar_remove_error`.
+
+## C. CTA session tracking (existing `cta_session` mechanism, reused)
+
+Add `"profile_edit_cta"` and `"profile_claim_cta"` to `TRACKED_CTA_IDS` in
+`types/analytics.ts`. Wire `useTrackedCta` into `ProfileOwnerActions.tsx` and
+`ProfileClaimCta.tsx`, same shape as `FavoriteButton`/`HeroCTA`/`CalendarList`
+(wrap the `Link` in a `<div ref={ctaRef}>`, call `trackClick()` on click). No
+new event name.
+
+## D. `useEventAnalytics.ts`
+
+Move the `view_event_page` tracking effect (currently inline in
+`EventClient.tsx`) into `useEventAnalytics(event)`. `EventClient.tsx` calls
+the hook instead of running the effect inline. Behavior-identical; the hook
+stops being orphaned.
+
+## E. Docs
+
+- New `.github/skills/auth-patterns/SKILL.md`: Logto OIDC flow, `useAuth()`
+  contract, the hydrate-once/`refetchUser()` gotcha (from `LESSONS.md`), the
+  4 auth routes, the `data-analytics-action` convention this spec
+  establishes. Added to `AGENTS.md`'s skill table.
+- `api-layer-patterns/SKILL.md`: remove the stale `POST /api/auth/register`
+  HMAC example; point to `auth-patterns` instead.
+- `AGENTS.md`: `LOGTO_*` in Local Setup env vars; one line on auth
+  architecture under Architecture Overview.
+- `README.md`: `LOGTO_*` in the Environment section.
+- `docs/README.md`: rewritten as a real index of the current `docs/` folder
+  (Auth & Profiles, Incidents, Design, Plans). The Oct-2025 migration content
+  is not deleted — it already lives in full in `design-system-overview.md` /
+  `implementation-reference.md`; this file stops being their stale front door.
+
+## Testing
+
+- Unit tests (Vitest + RTL), mocking `sendGoogleEvent` and asserting call
+  args — same style as `test/publica-analytics.test.tsx`:
+  - `AuthEventTracker`: delegated click fires `auth_gate_click` with the
+    right `action`; ignores clicks without the attribute; `auth_success` /
+    `auth_failure` fire once and strip the query param.
+  - `FavoritesPageTracker`'s new `period` prop.
+  - `EditProfileForm` / `EditProfileAvatar` funnel events.
+  - `useEventAnalytics` still fires `view_event_page` (adapt existing
+    coverage from `EventClient`'s current inline test, if any).
+- `yarn lint && yarn typecheck && yarn test` before opening the PR.
+- GA only fires on `isProdHost` / non-E2E, so no live-browser GA
+  verification is possible in dev — same limitation `GoogleScripts.tsx`
+  already documents. Verification is via unit tests, not manual browsing.
+
+## Out of scope (flagged only)
+
+- `/registre` dead signup route.
+- Missing UI reaction to `auth_error` (toast/message).
+- Login vs. signup funnel split (not possible with current Logto wiring).

--- a/docs/superpowers/specs/2026-08-02-auth-profile-analytics-and-docs-design.md
+++ b/docs/superpowers/specs/2026-08-02-auth-profile-analytics-and-docs-design.md
@@ -1,7 +1,13 @@
 # Auth/profile/favorites-tabs analytics + doc sync — design
 
 Date: 2026-08-02
-Status: approved, implementing
+Status: implemented
+
+Note: the "Verified gaps" and "D." sections below describe the state
+*before* this spec was implemented (e.g. `useEventAnalytics.ts` had zero
+call sites at the time this was written). Both are now fixed by this PR —
+left in the past-tense-implied wording it was authored with, as a record
+of what the plan set out to fix, not the current state of the code.
 
 ## Context
 

--- a/lib/api/favorites-external.ts
+++ b/lib/api/favorites-external.ts
@@ -10,6 +10,7 @@ import type {
   FavoritePeriodCounts,
   MutationResultDTO,
 } from "types/api/favorites";
+import type { FavoritesPeriod } from "types/api/event";
 
 function authHeaders(accessToken: string): Record<string, string> {
   return { Authorization: `Bearer ${accessToken}` };
@@ -39,7 +40,7 @@ function favoritesBaseUrl(): string | null {
 async function fetchFavoritesPeriod(
   base: string,
   accessToken: string,
-  period: "active" | "past",
+  period: FavoritesPeriod,
   page: number,
   size: number
 ): Promise<FavoriteEventsPageDTO | null> {
@@ -103,7 +104,7 @@ export async function listFavoriteEventsExternal(
 
 export async function listFavoriteEventsByPeriodExternal(
   accessToken: string,
-  period: "active" | "past",
+  period: FavoritesPeriod,
   page = 0,
   size = 50
 ): Promise<FavoriteEventsPageDTO | null> {
@@ -118,7 +119,7 @@ export async function listFavoriteEventsByPeriodExternal(
 // tab's count on /preferits and /preferits/passats.
 export async function countFavoritesByPeriodExternal(
   accessToken: string,
-  period: "active" | "past"
+  period: FavoritesPeriod
 ): Promise<number | null> {
   const page = await listFavoriteEventsByPeriodExternal(accessToken, period, 0, 1);
   return page?.totalElements ?? null;

--- a/lib/api/users-external.ts
+++ b/lib/api/users-external.ts
@@ -12,7 +12,9 @@ import type {
 } from "types/api/user";
 import type {
   EventSummaryResponseDTO,
+  FavoritesPeriod,
   PagedResponseDTO,
+  ProfileEventStatus,
 } from "types/api/event";
 
 // Strip control characters (incl. newlines, C1 controls, and the Unicode
@@ -341,7 +343,10 @@ export async function deleteUserAvatarExternal(
 // this plan was drafted against. `active` includes upcoming + in-progress
 // events. Kept as a domain-named `status` param at this function's boundary
 // (see ProfileEventsSectionProps) so only this translation needed to change.
-const PERIOD_BY_STATUS = { upcoming: "active", past: "past" } as const;
+const PERIOD_BY_STATUS: Record<ProfileEventStatus, FavoritesPeriod> = {
+  upcoming: "active",
+  past: "past",
+};
 
 /**
  * Public listing of a user's events: GET /api/users/{username}/events.
@@ -358,7 +363,7 @@ export async function getUserEventsExternal(
   username: string,
   page = 0,
   size = 20,
-  status: "upcoming" | "past" = "upcoming",
+  status: ProfileEventStatus = "upcoming",
 ): Promise<PagedResponseDTO<EventSummaryResponseDTO>> {
   const empty: PagedResponseDTO<EventSummaryResponseDTO> = {
     content: [],

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ensureGtag, sendGoogleEvent, CONSENT_MODE_DEFAULTS } from "@utils/analytics";
+import type { WindowWithGtag } from "types/common";
+
+function win(): WindowWithGtag {
+  return window as unknown as WindowWithGtag;
+}
+
+describe("ensureGtag", () => {
+  beforeEach(() => {
+    delete (window as unknown as { gtag?: unknown }).gtag;
+    delete (window as unknown as { dataLayer?: unknown }).dataLayer;
+  });
+
+  it("initializes dataLayer and a queueing gtag shim", () => {
+    ensureGtag();
+    expect(Array.isArray(win().dataLayer)).toBe(true);
+    expect(typeof win().gtag).toBe("function");
+  });
+
+  it("pushes the consent default as the first dataLayer entry", () => {
+    ensureGtag();
+    expect(Array.from(win().dataLayer[0] as ArrayLike<unknown>)).toEqual([
+      "consent",
+      "default",
+      CONSENT_MODE_DEFAULTS,
+    ]);
+  });
+
+  it("is idempotent: does not overwrite an existing gtag or re-push consent default", () => {
+    const existingGtag = () => {};
+    win().dataLayer = [];
+    win().gtag = existingGtag;
+
+    ensureGtag();
+
+    expect(win().gtag).toBe(existingGtag);
+    expect(win().dataLayer).toEqual([]);
+  });
+});
+
+describe("sendGoogleEvent", () => {
+  beforeEach(() => {
+    delete (window as unknown as { gtag?: unknown }).gtag;
+    delete (window as unknown as { dataLayer?: unknown }).dataLayer;
+  });
+
+  it("no-ops when gtag was never installed", () => {
+    expect(() => sendGoogleEvent("test_event", {})).not.toThrow();
+  });
+
+  it("forwards to gtag when it has been installed", () => {
+    ensureGtag();
+    sendGoogleEvent("test_event", { foo: "bar" });
+    expect(Array.from(win().dataLayer.at(-1) as ArrayLike<unknown>)).toEqual([
+      "event",
+      "test_event",
+      { foo: "bar" },
+    ]);
+  });
+});

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -37,6 +37,21 @@ describe("ensureGtag", () => {
     expect(win().gtag).toBe(existingGtag);
     expect(win().dataLayer).toEqual([]);
   });
+
+  it("never re-pushes the default once another caller already installed the shim", () => {
+    // Simulates GoogleScripts' inline GTAG_SHIM script (or a real gtag.js
+    // load) winning the race and installing the shim first: ensureGtag()
+    // must not push a second 'default' command, which would reset an
+    // already-granted consent state back to denied.
+    win().dataLayer = [["consent", "default", CONSENT_MODE_DEFAULTS]];
+    win().gtag = function gtag() {
+      win().dataLayer.push(arguments);
+    };
+
+    ensureGtag();
+
+    expect(win().dataLayer).toHaveLength(1);
+  });
 });
 
 describe("sendGoogleEvent", () => {

--- a/test/auth-callback-route.test.ts
+++ b/test/auth-callback-route.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@lib/auth/logto", () => ({
+  exchangeAuthorizationCode: vi.fn().mockResolvedValue({ id_token: "id-token" }),
+  getLogtoConfig: vi.fn().mockReturnValue({}),
+  getRequestOrigin: vi.fn().mockReturnValue("https://www.esdeveniments.cat"),
+  sanitizeReturnTo: vi.fn((value: string | null | undefined) =>
+    typeof value === "string" && value.startsWith("/") ? value : null,
+  ),
+  verifyIdToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@utils/auth-cookies", () => ({
+  clearFlowCookies: vi.fn(),
+  readFlowCookies: vi.fn().mockReturnValue({
+    state: "state-123",
+    codeVerifier: "verifier-123",
+    nonce: "nonce-123",
+    returnTo: "/publica",
+  }),
+  setTokenCookies: vi.fn(),
+}));
+
+import { GET } from "../app/api/auth/callback/route";
+
+describe("GET /api/auth/callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds the one-shot auth_success marker to the success redirect", async () => {
+    const request = new NextRequest(
+      "https://www.esdeveniments.cat/api/auth/callback?code=abc&state=state-123",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.pathname).toBe("/publica");
+    expect(location.searchParams.get("auth_success")).toBe("1");
+  });
+
+  it("still sets auth_error, not auth_success, when the state check fails", async () => {
+    const request = new NextRequest(
+      "https://www.esdeveniments.cat/api/auth/callback?code=abc&state=wrong-state",
+    );
+
+    const response = await GET(request);
+
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("auth_error")).toBe("state");
+    expect(location.searchParams.get("auth_success")).toBeNull();
+  });
+});

--- a/test/auth-event-tracker.test.tsx
+++ b/test/auth-event-tracker.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+
+const { sendGoogleEventMock } = vi.hoisted(() => ({
+  sendGoogleEventMock: vi.fn<
+    (event: string, obj: Record<string, unknown>) => void
+  >(),
+}));
+
+let searchParamsMock = new URLSearchParams();
+
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: sendGoogleEventMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsMock,
+}));
+
+import AuthEventTracker from "@components/analytics/AuthEventTracker";
+
+describe("AuthEventTracker", () => {
+  beforeEach(() => {
+    sendGoogleEventMock.mockReset();
+    searchParamsMock = new URLSearchParams();
+  });
+
+  it("fires auth_gate_click with the action from a clicked data-analytics-action element", () => {
+    render(
+      <div>
+        <AuthEventTracker />
+        <button type="button" data-analytics-action="publish_gate_login">
+          Login
+        </button>
+      </div>,
+    );
+
+    fireEvent.click(document.querySelector("button")!);
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_gate_click", {
+      action: "publish_gate_login",
+    });
+  });
+
+  it("ignores clicks on elements without data-analytics-action", () => {
+    render(
+      <div>
+        <AuthEventTracker />
+        <button type="button">Not tracked</button>
+      </div>,
+    );
+
+    fireEvent.click(document.querySelector("button")!);
+
+    expect(sendGoogleEventMock).not.toHaveBeenCalled();
+  });
+
+  it("attributes a click on a nested icon to the ancestor's data-analytics-action", () => {
+    render(
+      <div>
+        <AuthEventTracker />
+        <button type="button" data-analytics-action="navbar_login_mobile_icon">
+          <span data-testid="icon">icon</span>
+        </button>
+      </div>,
+    );
+
+    fireEvent.click(document.querySelector('[data-testid="icon"]')!);
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_gate_click", {
+      action: "navbar_login_mobile_icon",
+    });
+  });
+
+  it("fires auth_success once when the URL carries the one-shot marker", () => {
+    searchParamsMock = new URLSearchParams("auth_success=1");
+    render(<AuthEventTracker />);
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_success", {});
+  });
+
+  it("fires auth_failure with the reason when the URL carries auth_error", () => {
+    searchParamsMock = new URLSearchParams("auth_error=denied");
+    render(<AuthEventTracker />);
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_failure", {
+      reason: "denied",
+    });
+  });
+
+  it("fires neither auth_success nor auth_failure when no marker is present", () => {
+    render(<AuthEventTracker />);
+
+    expect(sendGoogleEventMock).not.toHaveBeenCalledWith(
+      "auth_success",
+      expect.anything(),
+    );
+    expect(sendGoogleEventMock).not.toHaveBeenCalledWith(
+      "auth_failure",
+      expect.anything(),
+    );
+  });
+});

--- a/test/auth-event-tracker.test.tsx
+++ b/test/auth-event-tracker.test.tsx
@@ -11,6 +11,7 @@ let searchParamsMock = new URLSearchParams();
 
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: sendGoogleEventMock,
+  ensureGtag: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -37,6 +38,7 @@ describe("AuthEventTracker", () => {
 
     fireEvent.click(document.querySelector("button")!);
 
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
     expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_gate_click", {
       action: "publish_gate_login",
     });
@@ -72,20 +74,26 @@ describe("AuthEventTracker", () => {
     });
   });
 
-  it("fires auth_success once when the URL carries the one-shot marker", () => {
-    searchParamsMock = new URLSearchParams("auth_success=1");
+  it("fires auth_success once and strips the marker from the URL, keeping other params", () => {
+    window.history.pushState({}, "", "/en?auth_success=1&other=1");
+    searchParamsMock = new URLSearchParams("auth_success=1&other=1");
     render(<AuthEventTracker />);
 
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
     expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_success", {});
+    expect(window.location.search).toBe("?other=1");
   });
 
-  it("fires auth_failure with the reason when the URL carries auth_error", () => {
+  it("fires auth_failure with the reason once and strips auth_error from the URL", () => {
+    window.history.pushState({}, "", "/en?auth_error=denied");
     searchParamsMock = new URLSearchParams("auth_error=denied");
     render(<AuthEventTracker />);
 
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
     expect(sendGoogleEventMock).toHaveBeenCalledWith("auth_failure", {
       reason: "denied",
     });
+    expect(window.location.search).toBe("");
   });
 
   it("fires neither auth_success nor auth_failure when no marker is present", () => {

--- a/test/edit-profile-avatar.test.tsx
+++ b/test/edit-profile-avatar.test.tsx
@@ -12,6 +12,11 @@ const baseUser: AuthUser = {
 
 let authUser: AuthUser = baseUser;
 const mockRefetchUser = vi.fn();
+const { sendGoogleEventMock } = vi.hoisted(() => ({
+  sendGoogleEventMock: vi.fn<
+    (event: string, obj: Record<string, unknown>) => void
+  >(),
+}));
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -19,6 +24,10 @@ vi.mock("next-intl", () => ({
 
 vi.mock("@components/hooks/useAuth", () => ({
   useAuth: () => ({ user: authUser, refetchUser: mockRefetchUser }),
+}));
+
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: sendGoogleEventMock,
 }));
 
 import EditProfileAvatar from "@app/[locale]/perfil/edita/EditProfileAvatar";
@@ -32,6 +41,7 @@ describe("EditProfileAvatar", () => {
   beforeEach(() => {
     authUser = baseUser;
     mockRefetchUser.mockReset().mockResolvedValue(undefined);
+    sendGoogleEventMock.mockReset();
     vi.stubGlobal("fetch", vi.fn());
   });
 
@@ -61,6 +71,9 @@ describe("EditProfileAvatar", () => {
 
     expect(await screen.findByText("errorUnsupported")).toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalled();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_error", {
+      reason: "unsupported_type",
+    });
   });
 
   it("rejects an oversized file locally, without uploading", async () => {
@@ -71,6 +84,9 @@ describe("EditProfileAvatar", () => {
 
     expect(await screen.findByText("errorTooLarge")).toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalled();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_error", {
+      reason: "too_large",
+    });
   });
 
   it("uploads a valid file with the avatarFile field and refetches the session", async () => {
@@ -91,6 +107,8 @@ describe("EditProfileAvatar", () => {
     expect((init as RequestInit).method).toBe("POST");
     const body = (init as RequestInit).body as FormData;
     expect(body.get("avatarFile")).toBe(file);
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_start", {});
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_success", {});
   });
 
   it("removes the avatar and refetches the session", async () => {
@@ -109,6 +127,7 @@ describe("EditProfileAvatar", () => {
       "/api/users/me/avatar",
       expect.objectContaining({ method: "DELETE", credentials: "include" }),
     );
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_remove_success", {});
   });
 
   it("surfaces an upload failure without refetching", async () => {
@@ -125,5 +144,8 @@ describe("EditProfileAvatar", () => {
 
     expect(await screen.findByText("errorUploadFailed")).toBeInTheDocument();
     expect(mockRefetchUser).not.toHaveBeenCalled();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_error", {
+      reason: "upload_failed",
+    });
   });
 });

--- a/test/edit-profile-avatar.test.tsx
+++ b/test/edit-profile-avatar.test.tsx
@@ -71,7 +71,8 @@ describe("EditProfileAvatar", () => {
 
     expect(await screen.findByText("errorUnsupported")).toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalled();
-    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_error", {
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_start", {});
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_blocked", {
       reason: "unsupported_type",
     });
   });
@@ -84,7 +85,8 @@ describe("EditProfileAvatar", () => {
 
     expect(await screen.findByText("errorTooLarge")).toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalled();
-    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_error", {
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_start", {});
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("avatar_upload_blocked", {
       reason: "too_large",
     });
   });

--- a/test/edit-profile-form.test.tsx
+++ b/test/edit-profile-form.test.tsx
@@ -15,6 +15,11 @@ let authUser: AuthUser = baseUser;
 
 const mockRefetchUser = vi.fn();
 const mockPush = vi.fn();
+const { sendGoogleEventMock } = vi.hoisted(() => ({
+  sendGoogleEventMock: vi.fn<
+    (event: string, obj: Record<string, unknown>) => void
+  >(),
+}));
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -28,6 +33,10 @@ vi.mock("@components/hooks/useAuth", () => ({
   useAuth: () => ({ user: authUser, refetchUser: mockRefetchUser }),
 }));
 
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: sendGoogleEventMock,
+}));
+
 vi.mock("@app/[locale]/perfil/edita/EditProfileAvatar", () => ({
   default: () => <div data-testid="edit-profile-avatar" />,
 }));
@@ -39,7 +48,16 @@ describe("EditProfileForm", () => {
     authUser = baseUser;
     mockRefetchUser.mockReset().mockResolvedValue(undefined);
     mockPush.mockReset();
+    sendGoogleEventMock.mockReset();
     vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("fires edit_profile_page_view once on mount, with is_onboarding", () => {
+    authUser = { ...baseUser, profileCompleted: false };
+    render(<EditProfileForm />);
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("edit_profile_page_view", {
+      is_onboarding: true,
+    });
   });
 
   it("prefills fields from the current user", () => {
@@ -166,6 +184,14 @@ describe("EditProfileForm", () => {
     );
     expect(await screen.findByText("success")).toBeInTheDocument();
     expect(mockPush).not.toHaveBeenCalled();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "edit_profile_submit_attempt",
+      { is_onboarding: false },
+    );
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "edit_profile_submit_success",
+      { is_onboarding: false, redirected: false },
+    );
   });
 
   it("redirects instead of showing the success banner when redirectTo is set", async () => {
@@ -180,6 +206,10 @@ describe("EditProfileForm", () => {
 
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/publica"));
     expect(screen.queryByText("success")).toBeNull();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "edit_profile_submit_success",
+      { is_onboarding: false, redirected: true },
+    );
   });
 
   it("surfaces a 409 as a username-taken field error", async () => {
@@ -195,6 +225,10 @@ describe("EditProfileForm", () => {
     expect(
       await screen.findByText("errors.usernameTaken"),
     ).toBeInTheDocument();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "edit_profile_submit_blocked",
+      { reason: "username_taken" },
+    );
   });
 
   it("surfaces a 401 as a session-expired banner", async () => {
@@ -210,6 +244,10 @@ describe("EditProfileForm", () => {
     expect(
       await screen.findByText("errors.sessionExpired"),
     ).toBeInTheDocument();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "edit_profile_submit_blocked",
+      { reason: "session_expired" },
+    );
   });
 
   it("surfaces any other failure as a generic error", async () => {
@@ -223,5 +261,9 @@ describe("EditProfileForm", () => {
     fireEvent.submit(screen.getByRole("button", { name: "submitLabel" }));
 
     expect(await screen.findByText("errors.generic")).toBeInTheDocument();
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "edit_profile_submit_error",
+      { reason: "generic" },
+    );
   });
 });

--- a/test/edit-profile-form.test.tsx
+++ b/test/edit-profile-form.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@components/hooks/useAuth", () => ({
 
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: sendGoogleEventMock,
+  ensureGtag: vi.fn(),
 }));
 
 vi.mock("@app/[locale]/perfil/edita/EditProfileAvatar", () => ({

--- a/test/favorites-page-tracker.test.tsx
+++ b/test/favorites-page-tracker.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+const { sendGoogleEventMock } = vi.hoisted(() => ({
+  sendGoogleEventMock: vi.fn<
+    (event: string, obj: Record<string, unknown>) => void
+  >(),
+}));
+
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: sendGoogleEventMock,
+}));
+
+import FavoritesPageTracker from "@app/[locale]/preferits/FavoritesPageTracker";
+
+describe("FavoritesPageTracker", () => {
+  beforeEach(() => {
+    sendGoogleEventMock.mockReset();
+  });
+
+  it("defaults to period 'active' when not passed", () => {
+    render(<FavoritesPageTracker favoritesCount={3} activeCount={2} />);
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("favorites_page_view", {
+      favorites_count: 3,
+      active_count: 2,
+      period: "active",
+    });
+  });
+
+  it("reports period 'past' when rendered on the past-favourites tab", () => {
+    render(
+      <FavoritesPageTracker
+        favoritesCount={5}
+        activeCount={2}
+        period="past"
+      />,
+    );
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("favorites_page_view", {
+      favorites_count: 5,
+      active_count: 2,
+      period: "past",
+    });
+  });
+
+  it("fires only once across re-renders with the same props", () => {
+    const { rerender } = render(
+      <FavoritesPageTracker favoritesCount={3} activeCount={2} />,
+    );
+    rerender(<FavoritesPageTracker favoritesCount={3} activeCount={2} />);
+
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/favorites-page-tracker.test.tsx
+++ b/test/favorites-page-tracker.test.tsx
@@ -9,6 +9,7 @@ const { sendGoogleEventMock } = vi.hoisted(() => ({
 
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: sendGoogleEventMock,
+  ensureGtag: vi.fn(),
 }));
 
 import FavoritesPageTracker from "@app/[locale]/preferits/FavoritesPageTracker";

--- a/test/profile-cta-tracking.test.tsx
+++ b/test/profile-cta-tracking.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const trackClickMock = vi.fn();
+const trackedCtaMock = vi.fn(() => ({
+  ref: vi.fn(),
+  trackClick: trackClickMock,
+}));
+
+let authState: { user: { username: string } | null; status: string } = {
+  user: null,
+  status: "unauthenticated",
+};
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@i18n/routing", () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@components/hooks/useAuth", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@components/hooks/useTrackedCta", () => ({
+  default: (...args: unknown[]) => trackedCtaMock(...(args as [])),
+}));
+
+import ProfileOwnerActions from "@components/ui/profile/ProfileOwnerActions";
+import ProfileClaimCta from "@components/ui/profile/ProfileClaimCta";
+
+describe("ProfileOwnerActions", () => {
+  beforeEach(() => {
+    trackClickMock.mockReset();
+    trackedCtaMock.mockClear();
+    authState = { user: null, status: "unauthenticated" };
+  });
+
+  it("renders nothing for a visitor who isn't the profile owner", () => {
+    authState = { user: { username: "someoneElse" }, status: "authenticated" };
+    render(<ProfileOwnerActions username="alex91" />);
+    expect(screen.queryByText("editProfile")).toBeNull();
+  });
+
+  it("registers the profile_edit_cta id and tracks a click for the owner", () => {
+    authState = { user: { username: "alex91" }, status: "authenticated" };
+    render(<ProfileOwnerActions username="alex91" />);
+
+    expect(trackedCtaMock).toHaveBeenCalledWith("profile_edit_cta");
+    fireEvent.click(screen.getByText("editProfile"));
+    expect(trackClickMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ProfileClaimCta", () => {
+  beforeEach(() => {
+    trackClickMock.mockReset();
+    trackedCtaMock.mockClear();
+    authState = { user: null, status: "unauthenticated" };
+  });
+
+  it("renders nothing once authenticated", () => {
+    authState = { user: { username: "alex91" }, status: "authenticated" };
+    render(<ProfileClaimCta username="alex91" />);
+    expect(screen.queryByText("claimLogin")).toBeNull();
+  });
+
+  it("registers the profile_claim_cta id, tracks a click, and carries the auth-gate action for a visitor", () => {
+    render(<ProfileClaimCta username="alex91" />);
+
+    expect(trackedCtaMock).toHaveBeenCalledWith("profile_claim_cta");
+    const link = screen.getByText("claimLogin");
+    expect(link).toHaveAttribute("data-analytics-action", "profile_claim_login");
+    fireEvent.click(link);
+    expect(trackClickMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/profile-page-tracker.test.tsx
+++ b/test/profile-page-tracker.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { AuthUser } from "types/auth";
+
+const { sendGoogleEventMock } = vi.hoisted(() => ({
+  sendGoogleEventMock: vi.fn<
+    (event: string, obj: Record<string, unknown>) => void
+  >(),
+}));
+
+let authUser: AuthUser | null = null;
+let authLoading = false;
+
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: sendGoogleEventMock,
+}));
+
+vi.mock("@components/hooks/useAuth", () => ({
+  useAuth: () => ({ user: authUser, isLoading: authLoading }),
+}));
+
+import ProfilePageTracker from "@app/[locale]/perfil/[username]/ProfilePageTracker";
+
+describe("ProfilePageTracker", () => {
+  beforeEach(() => {
+    sendGoogleEventMock.mockReset();
+    authUser = null;
+    authLoading = false;
+  });
+
+  it("does not fire while auth is still resolving", () => {
+    authLoading = true;
+    render(
+      <ProfilePageTracker
+        username="alex91"
+        upcomingCount={3}
+        pastCount={1}
+        status="upcoming"
+      />,
+    );
+
+    expect(sendGoogleEventMock).not.toHaveBeenCalled();
+  });
+
+  it("fires with is_own_profile false for a visitor", () => {
+    authUser = {
+      id: "u2",
+      email: "b@b.com",
+      name: "Someone Else",
+      username: "someoneElse",
+    };
+    render(
+      <ProfilePageTracker
+        username="alex91"
+        upcomingCount={3}
+        pastCount={1}
+        status="upcoming"
+      />,
+    );
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("profile_page_view", {
+      is_own_profile: false,
+      upcoming_count: 3,
+      past_count: 1,
+      status: "upcoming",
+    });
+  });
+
+  it("fires with is_own_profile true for the profile's owner, on the past tab", () => {
+    authUser = {
+      id: "u1",
+      email: "a@a.com",
+      name: "Alex",
+      username: "alex91",
+    };
+    render(
+      <ProfilePageTracker
+        username="alex91"
+        upcomingCount={undefined}
+        pastCount={4}
+        status="past"
+      />,
+    );
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("profile_page_view", {
+      is_own_profile: true,
+      upcoming_count: null,
+      past_count: 4,
+      status: "past",
+    });
+  });
+});

--- a/test/profile-page-tracker.test.tsx
+++ b/test/profile-page-tracker.test.tsx
@@ -13,6 +13,7 @@ let authLoading = false;
 
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: sendGoogleEventMock,
+  ensureGtag: vi.fn(),
 }));
 
 vi.mock("@components/hooks/useAuth", () => ({

--- a/test/use-event-analytics.test.tsx
+++ b/test/use-event-analytics.test.tsx
@@ -77,4 +77,22 @@ describe("useEventAnalytics", () => {
 
     expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
   });
+
+  it("fires again when the event changes without unmounting (no key remount)", () => {
+    const { rerender } = renderHook(
+      (event: EventClientProps["event"]) => useEventAnalytics(event),
+      { initialProps: makeEvent({ id: "evt-1" }) },
+    );
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
+
+    rerender(makeEvent({ id: "evt-1" }));
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
+
+    rerender(makeEvent({ id: "evt-2", slug: "fira-artesans" }));
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(2);
+    expect(sendGoogleEventMock).toHaveBeenLastCalledWith(
+      "view_event_page",
+      expect.objectContaining({ event_id: "evt-2" }),
+    );
+  });
 });

--- a/test/use-event-analytics.test.tsx
+++ b/test/use-event-analytics.test.tsx
@@ -10,6 +10,7 @@ const { sendGoogleEventMock } = vi.hoisted(() => ({
 
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: sendGoogleEventMock,
+  ensureGtag: vi.fn(),
 }));
 
 import { useEventAnalytics } from "@app/[locale]/e/[eventId]/hooks/useEventAnalytics";

--- a/test/use-event-analytics.test.tsx
+++ b/test/use-event-analytics.test.tsx
@@ -38,6 +38,7 @@ describe("useEventAnalytics", () => {
   it("fires view_event_page once on mount with the event's fields", () => {
     renderHook(() => useEventAnalytics(makeEvent()));
 
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
     expect(sendGoogleEventMock).toHaveBeenCalledWith("view_event_page", {
       event_id: "evt-1",
       event_slug: "concert-jazz",

--- a/test/use-event-analytics.test.tsx
+++ b/test/use-event-analytics.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { EventClientProps } from "types/props";
+
+const { sendGoogleEventMock } = vi.hoisted(() => ({
+  sendGoogleEventMock: vi.fn<
+    (event: string, obj: Record<string, unknown>) => void
+  >(),
+}));
+
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: sendGoogleEventMock,
+}));
+
+import { useEventAnalytics } from "@app/[locale]/e/[eventId]/hooks/useEventAnalytics";
+
+function makeEvent(
+  overrides: Partial<EventClientProps["event"]> = {},
+): EventClientProps["event"] {
+  return {
+    id: "evt-1",
+    slug: "concert-jazz",
+    title: "Concert de Jazz",
+    categorySlug: "musica",
+    placeSlug: "barcelona",
+    hasImage: true,
+    origin: "MANUAL",
+    endDate: "2999-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("useEventAnalytics", () => {
+  beforeEach(() => {
+    sendGoogleEventMock.mockReset();
+  });
+
+  it("fires view_event_page once on mount with the event's fields", () => {
+    renderHook(() => useEventAnalytics(makeEvent()));
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith("view_event_page", {
+      event_id: "evt-1",
+      event_slug: "concert-jazz",
+      category_slug: "musica",
+      place_slug: "barcelona",
+      has_image: true,
+      is_past: false,
+      origin: "MANUAL",
+    });
+  });
+
+  it("marks the event as past when endDate is before now", () => {
+    renderHook(() =>
+      useEventAnalytics(makeEvent({ endDate: "2000-01-01T00:00:00.000Z" })),
+    );
+
+    expect(sendGoogleEventMock).toHaveBeenCalledWith(
+      "view_event_page",
+      expect.objectContaining({ is_past: true }),
+    );
+  });
+});

--- a/test/use-event-analytics.test.tsx
+++ b/test/use-event-analytics.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import type { EventClientProps } from "types/props";
 
 const { sendGoogleEventMock } = vi.hoisted(() => ({
@@ -60,5 +61,20 @@ describe("useEventAnalytics", () => {
       "view_event_page",
       expect.objectContaining({ is_past: true }),
     );
+  });
+
+  it("fires once even under StrictMode's dev-only double-invoke", () => {
+    function Harness() {
+      useEventAnalytics(makeEvent());
+      return null;
+    }
+
+    render(
+      <StrictMode>
+        <Harness />
+      </StrictMode>,
+    );
+
+    expect(sendGoogleEventMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/types/analytics.ts
+++ b/types/analytics.ts
@@ -16,6 +16,8 @@ export const TRACKED_CTA_IDS = [
   "favorite_button",
   "add_to_calendar",
   "card_share",
+  "profile_edit_cta",
+  "profile_claim_cta",
 ] as const;
 
 export type TrackedCtaId = (typeof TRACKED_CTA_IDS)[number];

--- a/types/api/event.ts
+++ b/types/api/event.ts
@@ -6,6 +6,19 @@ import type { ProfileSummaryResponseDTO } from "./profile";
 export type EventType = "FREE" | "PAID";
 export type EventOrigin = "SCRAPE" | "RSS" | "MANUAL" | "MIGRATION";
 
+// Domain-level split for a user's own events (ProfileEventsSection,
+// FavoritesEventsSection, profile/favorites page trackers). Distinct from
+// `FavoritesPeriod` below — do not conflate them. See LESSONS.md: "The
+// profile events endpoint takes period=active|past, not status=upcoming|past".
+export type ProfileEventStatus = "upcoming" | "past";
+
+// Wire-level query param for /api/users/{username}/events and
+// /api/users/me/favorites/events. `getUserEventsExternal` translates
+// `ProfileEventStatus` to this at the API-layer boundary (`PERIOD_BY_STATUS`)
+// rather than renaming the domain-level `status` everywhere it's threaded
+// through — see LESSONS.md for why.
+export type FavoritesPeriod = "active" | "past";
+
 // Use the canonical CitySummaryResponseDTO from types/api/city
 export interface RegionSummaryResponseDTO {
   id: number;

--- a/types/props.ts
+++ b/types/props.ts
@@ -57,7 +57,12 @@ import {
   Href,
   NavigationItem,
 } from "types/common";
-import { EventSummaryResponseDTO, ListEvent } from "types/api/event";
+import {
+  EventSummaryResponseDTO,
+  ListEvent,
+  ProfileEventStatus,
+  FavoritesPeriod,
+} from "types/api/event";
 import { CategorySummaryResponseDTO } from "types/api/category";
 import { RegionsGroupedByCitiesResponseDTO } from "types/api/region";
 import { RouteSegments, URLQueryParams } from "types/url-filters";
@@ -537,7 +542,12 @@ export interface AvatarInitialsProps {
 
 export interface ProfileEventsSectionProps {
   username: string;
-  status: "upcoming" | "past";
+  status: ProfileEventStatus;
+}
+
+export interface FavoritesEventsSectionProps {
+  accessToken: string;
+  status: ProfileEventStatus;
 }
 
 export interface HybridEventsListProps {
@@ -871,6 +881,21 @@ export interface ProfileVisitsStatProps {
 // Profile claim CTA client island props
 export interface ProfileClaimCtaProps {
   username: string;
+}
+
+// /perfil/[username] and /perfil/[username]/passats — fires profile_page_view
+export interface ProfilePageTrackerProps {
+  username: string;
+  upcomingCount: number | undefined;
+  pastCount: number | undefined;
+  status: ProfileEventStatus;
+}
+
+// /preferits and /preferits/passats — fires favorites_page_view
+export interface FavoritesPageTrackerProps {
+  favoritesCount: number;
+  activeCount: number;
+  period?: FavoritesPeriod;
 }
 
 // /perfil/edita — shown to anonymous visitors, mirrors PublishAuthGate

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,4 +1,4 @@
-import { GoogleAnalyticsEvent } from "../types/common";
+import { GoogleAnalyticsEvent, WindowWithGtag } from "../types/common";
 import { isE2ETestMode } from "./env";
 
 export const sendGoogleEvent = (
@@ -9,4 +9,26 @@ export const sendGoogleEvent = (
   if (typeof window !== "undefined" && typeof window.gtag === "function") {
     window.gtag("event", event, obj);
   }
+};
+
+/**
+ * Installs the gtag dataLayer-queueing shim if it isn't there yet, so
+ * `sendGoogleEvent` calls that fire before GoogleScripts' own `lazyOnload`
+ * scripts run (e.g. on a hard navigation, like the OIDC callback landing)
+ * don't silently no-op. Safe to call anywhere: it only ever queues into
+ * `dataLayer` — whether that queue ever reaches Google still depends on
+ * GoogleScripts' existing prod-host/consent gating for the real gtag.js load.
+ */
+export const ensureGtag = (): WindowWithGtag | null => {
+  if (typeof window === "undefined") return null;
+  const win = window as WindowWithGtag;
+  win.dataLayer = win.dataLayer || [];
+
+  if (typeof win.gtag !== "function") {
+    win.gtag = function gtag() {
+      win.dataLayer.push(arguments);
+    };
+  }
+
+  return win;
 };

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -11,9 +11,9 @@ export const sendGoogleEvent = (
   }
 };
 
-// Consent Mode v2 baseline. Mirrored (via JSON.stringify) into GoogleScripts'
-// inline `google-analytics-consent` script so both code paths push the same
-// values — see the comment on `ensureGtag` for why this needs to exist here.
+// Consent Mode v2 baseline, pushed once by ensureGtag() below. Exported so
+// test/analytics.test.ts can assert against it without duplicating the
+// literal.
 export const CONSENT_MODE_DEFAULTS = {
   ad_user_data: "denied",
   ad_personalization: "denied",
@@ -29,11 +29,11 @@ export const CONSENT_MODE_DEFAULTS = {
  * `dataLayer` — whether that queue ever reaches Google still depends on
  * GoogleScripts' existing prod-host/consent gating for the real gtag.js load.
  *
- * Pushes the Consent Mode v2 denied default in the same branch as the shim
- * install, so whichever caller gets here first (a tracker on a hard nav, or
- * GoogleScripts' own consent-update effect) guarantees the default is queued
- * before any event this or later callers push - not just relying on the
- * lazyOnload consent script to have run first.
+ * Pushes the Consent Mode v2 denied default in the same guarded branch as
+ * the shim install, mirroring GoogleScripts' inline GTAG_SHIM script (see
+ * its comment there) - so whichever of the two runs first is the only one
+ * that pushes the default, guaranteeing it's queued before any event either
+ * side sends, without ever double-pushing it.
  */
 export const ensureGtag = (): WindowWithGtag | null => {
   if (typeof window === "undefined") return null;

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -11,6 +11,16 @@ export const sendGoogleEvent = (
   }
 };
 
+// Consent Mode v2 baseline. Mirrored (via JSON.stringify) into GoogleScripts'
+// inline `google-analytics-consent` script so both code paths push the same
+// values — see the comment on `ensureGtag` for why this needs to exist here.
+export const CONSENT_MODE_DEFAULTS = {
+  ad_user_data: "denied",
+  ad_personalization: "denied",
+  ad_storage: "denied",
+  analytics_storage: "denied",
+} as const;
+
 /**
  * Installs the gtag dataLayer-queueing shim if it isn't there yet, so
  * `sendGoogleEvent` calls that fire before GoogleScripts' own `lazyOnload`
@@ -18,6 +28,12 @@ export const sendGoogleEvent = (
  * don't silently no-op. Safe to call anywhere: it only ever queues into
  * `dataLayer` — whether that queue ever reaches Google still depends on
  * GoogleScripts' existing prod-host/consent gating for the real gtag.js load.
+ *
+ * Pushes the Consent Mode v2 denied default in the same branch as the shim
+ * install, so whichever caller gets here first (a tracker on a hard nav, or
+ * GoogleScripts' own consent-update effect) guarantees the default is queued
+ * before any event this or later callers push - not just relying on the
+ * lazyOnload consent script to have run first.
  */
 export const ensureGtag = (): WindowWithGtag | null => {
   if (typeof window === "undefined") return null;
@@ -28,6 +44,7 @@ export const ensureGtag = (): WindowWithGtag | null => {
     win.gtag = function gtag() {
       win.dataLayer.push(arguments);
     };
+    win.gtag("consent", "default", CONSENT_MODE_DEFAULTS);
   }
 
   return win;


### PR DESCRIPTION
## Summary

The recent auth/profile/favorites-tabs work (Logto sign-in, profile page, edit-profile, avatar upload, past-favourites/past-events tabs) shipped with no analytics and no docs, unlike the rest of the app (the `/publica` flow alone has 10+ tracked events). This PR closes both gaps.

**Analytics**
- Activates 6 existing `data-analytics-action` attributes that were dead markup (nothing read them), via one delegated click listener (`AuthEventTracker`, mounted once in the root layout). Extends the same attribute to the 5 navbar login/logout touchpoints and 1 footer login link — previously none tracked.
- `auth_success` / `auth_failure` fire once per page load from a one-shot query-param marker the OIDC callback route now sets on success (mirroring the `auth_error` marker it already set on failure).
- `profile_page_view`, `edit_profile_page_view`, and a `period` prop on `FavoritesPageTracker` (reused instead of duplicating) cover the new pages that had zero tracking.
- `EditProfileForm`/`EditProfileAvatar` get the same submit/upload funnel depth already built for `/publica` (attempt → blocked/error/success).
- `ProfileOwnerActions`/`ProfileClaimCta` wired into the existing `cta_session` batching mechanism (`useTrackedCta`) — no new event name.
- Fixed `useEventAnalytics.ts`: it was a dead no-op stub (`// TODO`, zero call sites); the `view_event_page` tracking that lived inline in `EventClient.tsx` now lives in the hook instead.

**Docs**
- New `.github/skills/auth-patterns/SKILL.md` — Logto OIDC flow, `useAuth()` contract, the hydrate-once/`refetchUser()` gotcha, the `data-analytics-action` convention. Added to `AGENTS.md`'s skill table (had no entry).
- Removed a stale pre-Logto `POST /api/auth/register` HMAC example from `api-layer-patterns/SKILL.md` that no longer describes how auth works.
- `AGENTS.md`/`README.md`: documented `LOGTO_*` env vars (were missing from Local Setup).
- `docs/README.md` rewritten — it indexed a finished Oct-2025 design-migration project and mentioned nothing built since.

**Flagged, not fixed** (out of scope): `/registre` is linked from `PublishAuthGate` but has no route serving it; no UI currently reacts to `auth_error`; login vs. signup funnels can't be split (Logto's hosted UI doesn't expose that distinction to the app).

Design doc: `docs/superpowers/specs/2026-08-02-auth-profile-analytics-and-docs-design.md`

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — 0 errors (pre-existing warnings only)
- [x] `yarn test` — 189/189 files, 2293/2293 tests passing (up from 2255 baseline)
- [x] Verified empirically (not just via typecheck) that `data-analytics-action` on navbar/footer `ActiveLink`s actually reaches the rendered `<a>` through `ActiveLink → PressableLink → next/link`, with a throwaway test that didn't mock that chain (removed before commit)
- [ ] GA only fires on the production host / non-E2E builds (existing constraint, see `GoogleScripts.tsx`), so live-browser GA verification isn't possible in dev — covered by unit tests instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds analytics for auth outcomes, profile/favorites pages, and edit-profile funnels, with resilient GA init on hard navigations and safe Consent Mode defaults. Also fixes Strict Mode double-fires, tracks event views across client-side navs, and syncs docs with the Logto OIDC flow.

- **New Features**
  - Auth: `AuthEventTracker` ensures `gtag` (Consent Mode v2 defaults) before firing; delegates `data-analytics-action` clicks across auth gates + navbar/footer; strips `auth_success`/`auth_error` from the URL; `/api/auth/callback` now redirects with `?auth_success=1`.
  - Pages: `useEventAnalytics(event)` owns `view_event_page`, tracks last `event.id` (Strict Mode-safe, fires on client navs); `ProfilePageTracker`; `FavoritesPageTracker` adds `period` and is reused on `/preferits/passats`. All call `ensureGtag()` before first event.
  - Edit profile: `edit_profile_page_view`; `avatar_upload_start` precedes validation; added `avatar_upload_blocked` for type/size; kept `avatar_remove_start`; isolated `refetchUser()` from upload/remove error reporting and held busy state through session resync; form fires attempt/blocked/error/success with `is_onboarding` and `redirected`.
  - CTAs: `ProfileOwnerActions` and `ProfileClaimCta` use `useTrackedCta`; added `data-analytics-action="profile_claim_login"`; extended `TRACKED_CTA_IDS` with `profile_edit_cta` and `profile_claim_cta`.
  - Infra: Centralized `ensureGtag` and `CONSENT_MODE_DEFAULTS` in `@utils/analytics`; consent default is pushed only when the shim installs (no double-push that could reset granted consent); `GoogleScripts`/`GoogleScriptsHeavy` now use the shared helper.
  - Types: Introduced `ProfileEventStatus` and `FavoritesPeriod` in `types/api/event.ts`; adopted across props and `lib/api`.

- **Docs**
  - New `auth-patterns` skill; linked from `.github/copilot-instructions.md` and `AGENTS.md`; clarified `/api/auth/*` is OIDC redirects (not HMAC).
  - `README.md` and `docs/README.md` updated with `LOGTO_*` envs and a current docs index; synced API layer docs to remove stale pre-Logto examples.

<sup>Written for commit 73bc2b21073e983aa9980b2162d98719434ae63b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for authentication outcomes, event and profile views, favorites tabs, profile editing, avatar updates, and key calls to action.
  * Improved authentication redirects with clearer success and error indicators.
  * Added shared analytics consent initialization for more reliable event reporting.
* **Documentation**
  * Updated authentication setup guidance, environment variables, repository references, and documentation navigation.
* **Bug Fixes**
  * Improved consistency and reliability of event, profile, and analytics tracking.
* **Tests**
  * Added coverage for authentication flows, analytics events, profile actions, favorites, and avatar updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->