### PR TITLE
feat(promote): event promotion checkout via post-publish upsell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,10 @@ CLOUDFLARE_ZONE_ID=
 CLOUDFLARE_API_TOKEN=
 CLOUDFRONT_DISTRIBUTION_ID=
 LHCI_GITHUB_APP_TOKEN=
+
+# ── Feature flags ───────────────────────────────────────────────────
+# Gates lib/api/promotedEvents.ts's active-promotions fetch (homepage +
+# listing-page "Promoted events" carousel). Keep false/unset until the
+# backend's GET /events/promotions/active endpoint exists — while off,
+# getActivePromotedEvents short-circuits with no network call at all.
+PROMOTED_EVENTS_ENABLED=false

--- a/app/[locale]/e/[eventId]/EventClient.tsx
+++ b/app/[locale]/e/[eventId]/EventClient.tsx
@@ -61,7 +61,7 @@ export default function EventClient({
   // /promote page, which 404s for them. isOwner is undefined (not false)
   // while the auth session is still resolving, so the modal only ever shows
   // once ownership is positively confirmed — never as a flash-then-hide.
-  const isOwner = user?.id === event.ownerId;
+  const isOwner = Boolean(event.ownerId) && user?.id === event.ownerId;
   const initialShowPromoteUpsell = searchParams.get("promote") === "1";
   const [dismissed, setDismissed] = useState(false);
   // Derived, not stored state: isOwner/initialShowPromoteUpsell already fully

--- a/app/[locale]/e/[eventId]/EventClient.tsx
+++ b/app/[locale]/e/[eventId]/EventClient.tsx
@@ -73,9 +73,15 @@ export default function EventClient({
   const handlePromoteUpsellOpenChange = (open: boolean) => {
     setShowPromoteUpsell(open);
     if (!open) {
-      // Strip the one-time marker so a refresh or shared link doesn't
-      // re-trigger the modal.
-      router.replace(pathname, { scroll: false });
+      // Strip only the one-time marker so a refresh or shared link doesn't
+      // re-trigger the modal — preserve any other existing query params
+      // (e.g. edit_suggested) rather than dropping the whole query string.
+      const remainingParams = new URLSearchParams(searchParams.toString());
+      remainingParams.delete("promote");
+      const query = remainingParams.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
     }
   };
 

--- a/app/[locale]/e/[eventId]/EventClient.tsx
+++ b/app/[locale]/e/[eventId]/EventClient.tsx
@@ -1,6 +1,8 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
+import { useRouter, usePathname } from "@i18n/routing";
 // import useOnScreen from "components/hooks/useOnScreen";
 import { useEventAnalytics } from "./hooks/useEventAnalytics";
 
@@ -12,13 +14,25 @@ import { MegaphoneIcon as SpeakerphoneIcon } from "@heroicons/react/24/outline";
 import AdArticle from "components/ui/adArticle";
 import SectionHeading from "@components/ui/common/SectionHeading";
 import { useTranslations } from "next-intl";
+import { sendGoogleEvent } from "@utils/analytics";
 
 // computeTemporalStatus now imported from utils/event-status for reuse & testability
+
+// Lazy load the post-publish promote upsell modal — every event detail page
+// view goes through this component, but the modal is only ever relevant
+// right after the owner published (see the `promote=1` marker below), so it
+// shouldn't ship in every page view's bundle.
+const PromoteUpsellModal = dynamic(
+  () => import("./components/PromoteUpsellModal"),
+  { ssr: false },
+);
 
 export default function EventClient({
   event,
 }: EventClientProps) {
   const t = useTranslations("Components.EventPage");
+  const router = useRouter();
+  const pathname = usePathname();
   // const editModalRef = useRef<HTMLDivElement>(null);
 
   // const isEditModalVisible = useOnScreen(
@@ -32,6 +46,38 @@ export default function EventClient({
   const newEvent = searchParams.get("newEvent");
   const edit_suggested = searchParams.get("edit_suggested") === "true";
   const [showThankYouBanner, setShowThankYouBanner] = useState(edit_suggested);
+
+  // Post-publish promote upsell: publica/page.tsx redirects here with
+  // ?promote=1 right after a successful publish (see design doc's "Modal"
+  // section — the modal lives on the event's own detail page, not on the
+  // publish form). Same one-time-marker convention as newEvent/edit_suggested
+  // above, not a new mechanism.
+  const initialShowPromoteUpsell = searchParams.get("promote") === "1";
+  const [showPromoteUpsell, setShowPromoteUpsell] = useState(
+    initialShowPromoteUpsell,
+  );
+
+  useEffect(() => {
+    if (initialShowPromoteUpsell) {
+      sendGoogleEvent("promote_modal_shown", {
+        event_slug: event.slug ?? "",
+        source: "event_detail",
+      });
+    }
+    // initialShowPromoteUpsell and event.slug are both stable for this
+    // component's lifetime (the component fully remounts on navigation to a
+    // different event), so this still only ever fires once despite the
+    // complete dependency list.
+  }, [initialShowPromoteUpsell, event.slug]);
+
+  const handlePromoteUpsellOpenChange = (open: boolean) => {
+    setShowPromoteUpsell(open);
+    if (!open) {
+      // Strip the one-time marker so a refresh or shared link doesn't
+      // re-trigger the modal.
+      router.replace(pathname, { scroll: false });
+    }
+  };
 
   // const {
   //   openModal,
@@ -58,6 +104,14 @@ export default function EventClient({
         showThankYouBanner={!!showThankYouBanner}
         setShowThankYouBanner={setShowThankYouBanner}
       />
+
+      {showPromoteUpsell && (
+        <PromoteUpsellModal
+          open={showPromoteUpsell}
+          setOpen={handlePromoteUpsellOpenChange}
+          slug={slug}
+        />
+      )}
 
       {/* Ad Section */}
       <div className="w-full h-full min-h-[250px]">

--- a/app/[locale]/e/[eventId]/EventClient.tsx
+++ b/app/[locale]/e/[eventId]/EventClient.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
 import { useRouter, usePathname } from "@i18n/routing";
 // import useOnScreen from "components/hooks/useOnScreen";
+import { useAuth } from "@components/hooks/useAuth";
 import { useEventAnalytics } from "./hooks/useEventAnalytics";
 
 import type { EventClientProps } from "types/props";
@@ -33,6 +34,7 @@ export default function EventClient({
   const t = useTranslations("Components.EventPage");
   const router = useRouter();
   const pathname = usePathname();
+  const { user } = useAuth();
   // const editModalRef = useRef<HTMLDivElement>(null);
 
   // const isEditModalVisible = useOnScreen(
@@ -52,37 +54,44 @@ export default function EventClient({
   // section — the modal lives on the event's own detail page, not on the
   // publish form). Same one-time-marker convention as newEvent/edit_suggested
   // above, not a new mechanism.
+  //
+  // Gated on ownership: the marker is just a URL query param, so anyone could
+  // append ?promote=1 to any event's URL. Without this check, a non-owner
+  // visitor would see the upsell and its CTA would lead to the owner-only
+  // /promote page, which 404s for them. isOwner is undefined (not false)
+  // while the auth session is still resolving, so the modal only ever shows
+  // once ownership is positively confirmed — never as a flash-then-hide.
+  const isOwner = user?.id === event.ownerId;
   const initialShowPromoteUpsell = searchParams.get("promote") === "1";
-  const [showPromoteUpsell, setShowPromoteUpsell] = useState(
-    initialShowPromoteUpsell,
-  );
+  const [dismissed, setDismissed] = useState(false);
+  // Derived, not stored state: isOwner/initialShowPromoteUpsell already fully
+  // determine visibility each render, so there's nothing to sync from an
+  // effect here (that was the earlier react-hooks/set-state-in-effect error).
+  const showPromoteUpsell = initialShowPromoteUpsell && isOwner && !dismissed;
 
+  const hasFiredShownEvent = useRef(false);
   useEffect(() => {
-    if (initialShowPromoteUpsell) {
+    if (showPromoteUpsell && !hasFiredShownEvent.current) {
+      hasFiredShownEvent.current = true;
       sendGoogleEvent("promote_modal_shown", {
         event_slug: event.slug ?? "",
         source: "event_detail",
       });
     }
-    // initialShowPromoteUpsell and event.slug are both stable for this
-    // component's lifetime (the component fully remounts on navigation to a
-    // different event), so this still only ever fires once despite the
-    // complete dependency list.
-  }, [initialShowPromoteUpsell, event.slug]);
+  }, [showPromoteUpsell, event.slug]);
 
   const handlePromoteUpsellOpenChange = (open: boolean) => {
-    setShowPromoteUpsell(open);
-    if (!open) {
-      // Strip only the one-time marker so a refresh or shared link doesn't
-      // re-trigger the modal — preserve any other existing query params
-      // (e.g. edit_suggested) rather than dropping the whole query string.
-      const remainingParams = new URLSearchParams(searchParams.toString());
-      remainingParams.delete("promote");
-      const query = remainingParams.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname, {
-        scroll: false,
-      });
-    }
+    if (open) return;
+    setDismissed(true);
+    // Strip only the one-time marker so a refresh or shared link doesn't
+    // re-trigger the modal — preserve any other existing query params
+    // (e.g. edit_suggested) rather than dropping the whole query string.
+    const remainingParams = new URLSearchParams(searchParams.toString());
+    remainingParams.delete("promote");
+    const query = remainingParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
   };
 
   // const {

--- a/app/[locale]/e/[eventId]/components/EventDetailsSection.tsx
+++ b/app/[locale]/e/[eventId]/components/EventDetailsSection.tsx
@@ -5,11 +5,18 @@ import type { EventDetailsSectionProps } from "types/props";
 import PressableAnchor from "@components/ui/primitives/PressableAnchor";
 import { Link } from "@i18n/routing";
 import { useTranslations } from "next-intl";
+import EventPromoteAction from "./EventPromoteAction";
 
 /**
  * Renders ancillary event details: duration + external link + creator info.
  * Status badge and date/time info are intentionally NOT shown here
  * to avoid duplication (they already appear in EventHeader and EventCalendar).
+ *
+ * Also renders the owner-only Promote action. EventSidebar (desktop, lg:block)
+ * already renders it, but that sidebar is hidden below the lg breakpoint —
+ * without this mobile-visible counterpart, an owner on a phone or tablet
+ * would have no persistent way to reach the promote page at all (only the
+ * one-time post-publish upsell modal).
  */
 const EventDetailsSection: React.FC<EventDetailsSectionProps> = ({ event }) => {
   const t = useTranslations("Components.EventDetailsSection");
@@ -86,6 +93,10 @@ const EventDetailsSection: React.FC<EventDetailsSectionProps> = ({ event }) => {
                 })}
               </span>
             </div>
+          )}
+
+          {owner && (
+            <EventPromoteAction ownerId={owner.id} slug={event.slug ?? ""} />
           )}
 
         </div>

--- a/app/[locale]/e/[eventId]/components/EventPromoteAction.tsx
+++ b/app/[locale]/e/[eventId]/components/EventPromoteAction.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link } from "@i18n/routing";
+import { MegaphoneIcon } from "@heroicons/react/24/outline";
+import { useAuth } from "@components/hooks/useAuth";
+import type { EventPromoteActionProps } from "types/props";
+
+/**
+ * Owner-only promote link for the event detail sidebar. Client-side check
+ * (not a server-side getCurrentUser() call) so a page view doesn't pay for
+ * a backend enrichment round-trip just to decide whether to show this link —
+ * mirrors EventEditAction exactly.
+ */
+export default function EventPromoteAction({
+  ownerId,
+  slug,
+}: EventPromoteActionProps) {
+  const { user } = useAuth();
+  const t = useTranslations("Components.EventPage");
+
+  if (!ownerId || user?.id !== ownerId) return null;
+
+  return (
+    <Link
+      href={`/e/${slug}/promote`}
+      className="inline-flex items-center gap-2 btn-outline btn-sm"
+      data-testid="event-promote-link"
+    >
+      <MegaphoneIcon className="w-4 h-4" aria-hidden="true" />
+      {t("promoteEvent")}
+    </Link>
+  );
+}

--- a/app/[locale]/e/[eventId]/components/EventSidebar.tsx
+++ b/app/[locale]/e/[eventId]/components/EventSidebar.tsx
@@ -14,6 +14,7 @@ import { getTranslations } from "next-intl/server";
 import { getLocaleSafely } from "@utils/i18n-seo";
 import { getProfileSlug } from "@utils/user-helpers";
 import EventEditAction from "./EventEditAction";
+import EventPromoteAction from "./EventPromoteAction";
 import type { EventSidebarProps } from "types/props";
 
 /**
@@ -134,6 +135,7 @@ export default async function EventSidebar({
 
             {/* Owner-only edit action */}
             <EventEditAction ownerId={event.owner?.id} slug={event.slug ?? ""} />
+            <EventPromoteAction ownerId={event.owner?.id} slug={event.slug ?? ""} />
 
           </div>
         </div>

--- a/app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx
+++ b/app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useRouter } from "@i18n/routing";
+import { useSearchParams } from "next/navigation";
+import { useRouter, usePathname } from "@i18n/routing";
 import { RocketLaunchIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Modal from "@components/ui/common/modal";
 import Button from "@components/ui/common/button";
@@ -18,11 +19,23 @@ export default function PromoteUpsellModal({
   // instead of duplicating the same three strings under a second namespace.
   const tPromote = useTranslations("App.EventPromote");
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams() ?? new URLSearchParams();
 
   const handlePromote = () => {
     sendGoogleEvent("promote_modal_cta_click", {
       event_slug: slug,
       source: "event_detail",
+    });
+    // Strip the one-time ?promote=1 marker from the *current* history entry
+    // before navigating away, so a later browser-back to this event doesn't
+    // re-open the modal (the marker would otherwise still be sitting in the
+    // event detail page's URL even though the user already engaged with it).
+    const remainingParams = new URLSearchParams(searchParams.toString());
+    remainingParams.delete("promote");
+    const query = remainingParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
     });
     router.push(`/e/${slug}/promote`);
     // Explicitly returning false stops Modal's own setOpen(false) from racing

--- a/app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx
+++ b/app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useSearchParams } from "next/navigation";
-import { useRouter, usePathname } from "@i18n/routing";
+import { useRouter } from "@i18n/routing";
 import { RocketLaunchIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Modal from "@components/ui/common/modal";
 import Button from "@components/ui/common/button";
@@ -19,8 +18,6 @@ export default function PromoteUpsellModal({
   // instead of duplicating the same three strings under a second namespace.
   const tPromote = useTranslations("App.EventPromote");
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams() ?? new URLSearchParams();
 
   const handlePromote = () => {
     sendGoogleEvent("promote_modal_cta_click", {
@@ -29,14 +26,14 @@ export default function PromoteUpsellModal({
     });
     // Strip the one-time ?promote=1 marker from the *current* history entry
     // before navigating away, so a later browser-back to this event doesn't
-    // re-open the modal (the marker would otherwise still be sitting in the
-    // event detail page's URL even though the user already engaged with it).
-    const remainingParams = new URLSearchParams(searchParams.toString());
-    remainingParams.delete("promote");
-    const query = remainingParams.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, {
-      scroll: false,
-    });
+    // re-open the modal. Uses a raw history replace (not router.replace) —
+    // mirrors AuthEventTracker's marker-stripping — because a router.replace
+    // immediately followed by the router.push below can have the push cancel
+    // the replace's pending navigation in the App Router, leaving the marker
+    // in place despite this call.
+    const url = new URL(window.location.href);
+    url.searchParams.delete("promote");
+    window.history.replaceState(window.history.state, "", url);
     router.push(`/e/${slug}/promote`);
     // Explicitly returning false stops Modal's own setOpen(false) from racing
     // this navigation — see the design doc's "Modal" section for why this

--- a/app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx
+++ b/app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "@i18n/routing";
+import { RocketLaunchIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Modal from "@components/ui/common/modal";
 import Button from "@components/ui/common/button";
 import { sendGoogleEvent } from "@utils/analytics";
@@ -13,12 +14,15 @@ export default function PromoteUpsellModal({
   slug,
 }: PromoteUpsellModalProps) {
   const t = useTranslations("App.Publish.promoteUpsell");
+  // Reuses the promote page's own benefit copy (App.EventPromote.benefit1-3)
+  // instead of duplicating the same three strings under a second namespace.
+  const tPromote = useTranslations("App.EventPromote");
   const router = useRouter();
 
   const handlePromote = () => {
     sendGoogleEvent("promote_modal_cta_click", {
       event_slug: slug,
-      source: "publica",
+      source: "event_detail",
     });
     router.push(`/e/${slug}/promote`);
     // Explicitly returning false stops Modal's own setOpen(false) from racing
@@ -30,10 +34,9 @@ export default function PromoteUpsellModal({
   const handleKeepFree = () => {
     sendGoogleEvent("promote_modal_dismiss", {
       event_slug: slug,
-      source: "publica",
+      source: "event_detail",
     });
     setOpen(false);
-    router.push(`/e/${slug}`);
   };
 
   return (
@@ -46,7 +49,28 @@ export default function PromoteUpsellModal({
       testId="promote-upsell-modal"
     >
       <div className="flex flex-col gap-4 py-4">
-        <p className="body-normal text-foreground/80">{t("description")}</p>
+        <div className="flex justify-center">
+          <div className="flex-center w-14 h-14 rounded-full bg-primary/10 text-primary">
+            <RocketLaunchIcon className="w-8 h-8" aria-hidden="true" />
+          </div>
+        </div>
+        <p className="body-normal text-foreground/80 text-center">
+          {t("description")}
+        </p>
+        <ul className="flex flex-col gap-2 body-small text-foreground/80">
+          <li className="flex items-center gap-2">
+            <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" aria-hidden="true" />
+            {tPromote("benefit1")}
+          </li>
+          <li className="flex items-center gap-2">
+            <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" aria-hidden="true" />
+            {tPromote("benefit2")}
+          </li>
+          <li className="flex items-center gap-2">
+            <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" aria-hidden="true" />
+            {tPromote("benefit3")}
+          </li>
+        </ul>
         <Button
           type="button"
           variant="neutral"

--- a/app/[locale]/e/[eventId]/page.tsx
+++ b/app/[locale]/e/[eventId]/page.tsx
@@ -160,6 +160,7 @@ async function EventPageContent({
     placeSlug: citySlug ?? regionSlug,
     hasImage: Boolean(event.imageUrl),
     origin: event.origin,
+    ownerId: event.owner?.id,
   };
   const explorePlaceHref = `/${primaryPlaceSlug}`;
   const exploreCategoryHref = primaryCategorySlug

--- a/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
+++ b/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
@@ -54,7 +54,11 @@ export default function PromoteEventClient({
           event_slug: slug,
           reason: result.reason ?? "action-failed",
         });
-        setError(t("errorGeneric"));
+        setError(
+          result.reason === "stale-session"
+            ? t("errorStaleSession")
+            : t("errorGeneric"),
+        );
         return;
       }
 

--- a/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
+++ b/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link } from "@i18n/routing";
 import { ArrowLeftIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Button from "@components/ui/common/button";
 import { getEventPromotionOptions } from "@config/pricing";
-import { sendGoogleEvent } from "@utils/analytics";
+import { sendGoogleEvent, ensureGtag } from "@utils/analytics";
 import type { AppLocale } from "types/i18n";
 import type { PromoteEventClientProps } from "types/props";
 import { createPromotionCheckoutAction } from "./actions";
@@ -35,10 +35,14 @@ export default function PromoteEventClient({
   // (e.g. no tier available for this event yet).
   const [promotionOption] = getEventPromotionOptions();
 
+  const hasTrackedPageViewRef = useRef(false);
   useEffect(() => {
+    // Guards against React Strict Mode's dev-only double-invoke, same as
+    // FavoritesPageTracker/ProfilePageTracker.
+    if (hasTrackedPageViewRef.current) return;
+    ensureGtag();
     sendGoogleEvent("promote_page_view", { event_slug: slug });
-    // slug is stable for this component's lifetime (a new event means a full
-    // remount), so this still only ever fires once despite the dependency.
+    hasTrackedPageViewRef.current = true;
   }, [slug]);
 
   const handleConfirm = async () => {

--- a/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
+++ b/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link } from "@i18n/routing";
 import { ArrowLeftIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Button from "@components/ui/common/button";
 import { getEventPromotionOptions } from "@config/pricing";
+import { sendGoogleEvent } from "@utils/analytics";
 import type { AppLocale } from "types/i18n";
 import type { PromoteEventClientProps } from "types/props";
 import { createPromotionCheckoutAction } from "./actions";
@@ -29,29 +30,59 @@ export default function PromoteEventClient({
   // MVP: exactly one option today. Rendered from a list (not a single
   // constant) so this component doesn't change shape when Gerard adds real
   // duration/geo-scope tiers later — only getEventPromotionOptions' return
-  // value grows.
+  // value grows. Guarded (not a bare destructure) since a future
+  // implementation of that function could legitimately return zero options
+  // (e.g. no tier available for this event yet).
   const [promotionOption] = getEventPromotionOptions();
+
+  useEffect(() => {
+    sendGoogleEvent("promote_page_view", { event_slug: slug });
+    // slug is stable for this component's lifetime (a new event means a full
+    // remount), so this still only ever fires once despite the dependency.
+  }, [slug]);
 
   const handleConfirm = async () => {
     setError(null);
     setIsSubmitting(true);
+    sendGoogleEvent("promote_checkout_click", { event_slug: slug });
 
-    const result = await createPromotionCheckoutAction(eventId, slug, locale);
+    try {
+      const result = await createPromotionCheckoutAction(eventId, slug, locale);
 
-    if (!result.success) {
+      if (!result.success) {
+        sendGoogleEvent("promote_checkout_error", {
+          event_slug: slug,
+          reason: result.reason ?? "action-failed",
+        });
+        setError(t("errorGeneric"));
+        return;
+      }
+
+      if (!isValidCheckoutUrl(result.url)) {
+        console.error("PromoteEventClient: invalid checkout url", result.url);
+        sendGoogleEvent("promote_checkout_error", {
+          event_slug: slug,
+          reason: "invalid-url",
+        });
+        setError(t("errorGeneric"));
+        return;
+      }
+
+      sendGoogleEvent("promote_checkout_redirect", { event_slug: slug });
+      window.location.href = result.url;
+    } catch (checkoutError) {
+      console.error(
+        "PromoteEventClient: checkout action rejected",
+        checkoutError,
+      );
+      sendGoogleEvent("promote_checkout_error", {
+        event_slug: slug,
+        reason: "unexpected-rejection",
+      });
       setError(t("errorGeneric"));
+    } finally {
       setIsSubmitting(false);
-      return;
     }
-
-    if (!isValidCheckoutUrl(result.url)) {
-      console.error("PromoteEventClient: invalid checkout url", result.url);
-      setError(t("errorGeneric"));
-      setIsSubmitting(false);
-      return;
-    }
-
-    window.location.href = result.url;
   };
 
   return (
@@ -93,13 +124,30 @@ export default function PromoteEventClient({
           </ul>
         </div>
 
-        <div className="card-bordered card-body flex items-center justify-between">
-          <span className="body-normal text-foreground/70">{t("priceLabel")}</span>
-          <span className="heading-2 text-foreground-strong">
-            {promotionOption.priceEur}€
-          </span>
-        </div>
-        <p className="body-small text-foreground/60 -mt-4">{t("priceNote")}</p>
+        {promotionOption ? (
+          <>
+            <div className="card-bordered card-body flex items-center justify-between">
+              <span className="body-normal text-foreground/70">
+                {t("priceLabel")}
+              </span>
+              <span className="heading-2 text-foreground-strong">
+                {promotionOption.priceEur}€
+              </span>
+            </div>
+            <p className="body-small text-foreground/60 -mt-4">
+              {t("priceNote")}
+            </p>
+          </>
+        ) : (
+          <div
+            className="w-full px-4 py-3 bg-error/10 border border-error rounded-lg"
+            role="alert"
+          >
+            <p className="text-sm font-medium text-error">
+              {t("errorGeneric")}
+            </p>
+          </div>
+        )}
 
         {error && (
           <div
@@ -114,7 +162,7 @@ export default function PromoteEventClient({
           type="button"
           variant="primary"
           className="w-full min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={isSubmitting}
+          disabled={isSubmitting || !promotionOption}
           data-testid="promote-confirm-button"
           onClick={handleConfirm}
         >

--- a/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
+++ b/app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { Link } from "@i18n/routing";
+import { ArrowLeftIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import Button from "@components/ui/common/button";
+import { getEventPromotionOptions } from "@config/pricing";
+import type { AppLocale } from "types/i18n";
+import type { PromoteEventClientProps } from "types/props";
+import { createPromotionCheckoutAction } from "./actions";
+
+function isValidCheckoutUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export default function PromoteEventClient({
+  eventId,
+  slug,
+}: PromoteEventClientProps) {
+  const t = useTranslations("App.EventPromote");
+  const locale = useLocale() as AppLocale;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // MVP: exactly one option today. Rendered from a list (not a single
+  // constant) so this component doesn't change shape when Gerard adds real
+  // duration/geo-scope tiers later — only getEventPromotionOptions' return
+  // value grows.
+  const [promotionOption] = getEventPromotionOptions();
+
+  const handleConfirm = async () => {
+    setError(null);
+    setIsSubmitting(true);
+
+    const result = await createPromotionCheckoutAction(eventId, slug, locale);
+
+    if (!result.success) {
+      setError(t("errorGeneric"));
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (!isValidCheckoutUrl(result.url)) {
+      console.error("PromoteEventClient: invalid checkout url", result.url);
+      setError(t("errorGeneric"));
+      setIsSubmitting(false);
+      return;
+    }
+
+    window.location.href = result.url;
+  };
+
+  return (
+    // max-w-[520px] matches DESIGN.md's `containers.detail` token (520px) —
+    // this is a single-focus confirmation flow like the event detail page,
+    // not a multi-field form (which would use the wider `container` class,
+    // as /publica and /edita do). Tailwind's config only customizes the
+    // generic `container` utility, not a named "detail" width, so the literal
+    // value is the correct concrete implementation of that design token today.
+    <div className="max-w-[520px] mx-auto py-section-y px-section-x">
+      <Link
+        href={`/e/${slug}`}
+        className="inline-flex items-center gap-1 body-small text-foreground/70 hover:text-foreground mb-4"
+      >
+        <ArrowLeftIcon className="w-4 h-4" />
+        {t("backToEvent")}
+      </Link>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2 text-center">
+          <h1 className="heading-1 text-foreground-strong">{t("heading")}</h1>
+          <p className="body-large text-foreground/80">{t("subheading")}</p>
+        </div>
+
+        <div className="card-bordered card-body space-y-3">
+          <ul className="flex flex-col gap-2 body-normal text-foreground/80">
+            <li className="flex items-center gap-2">
+              <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" />
+              {t("benefit1")}
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" />
+              {t("benefit2")}
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" />
+              {t("benefit3")}
+            </li>
+          </ul>
+        </div>
+
+        <div className="card-bordered card-body flex items-center justify-between">
+          <span className="body-normal text-foreground/70">{t("priceLabel")}</span>
+          <span className="heading-2 text-foreground-strong">
+            {promotionOption.priceEur}€
+          </span>
+        </div>
+        <p className="body-small text-foreground/60 -mt-4">{t("priceNote")}</p>
+
+        {error && (
+          <div
+            className="w-full px-4 py-3 bg-error/10 border border-error rounded-lg"
+            role="alert"
+          >
+            <p className="text-sm font-medium text-error">{error}</p>
+          </div>
+        )}
+
+        <Button
+          type="button"
+          variant="primary"
+          className="w-full min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={isSubmitting}
+          data-testid="promote-confirm-button"
+          onClick={handleConfirm}
+        >
+          {isSubmitting ? t("confirmButtonLoading") : t("confirmButton")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/e/[eventId]/promote/actions.ts
+++ b/app/[locale]/e/[eventId]/promote/actions.ts
@@ -50,6 +50,18 @@ export async function createPromotionCheckoutAction(
     return { success: true, url };
   } catch (error) {
     console.error("createPromotionCheckoutAction: checkout failed", error);
+    // requireMutationAuth (inside createPromotionCheckout) throws a tagged
+    // 401 when the backend Bearer token is missing/expired — surface that as
+    // a distinct, actionable reason instead of the generic message, mirroring
+    // createEventAction's own 401 handling for the same underlying cause.
+    const status = (error as { status?: number })?.status;
+    if (status === 401) {
+      return {
+        success: false,
+        error: "Your session has expired. Please sign in again.",
+        reason: "stale-session",
+      };
+    }
     return {
       success: false,
       error: "Something went wrong. Please try again.",

--- a/app/[locale]/e/[eventId]/promote/actions.ts
+++ b/app/[locale]/e/[eventId]/promote/actions.ts
@@ -1,0 +1,58 @@
+"use server";
+import { createPromotionCheckout, fetchEventBySlug } from "@lib/api/events";
+import { getCurrentUser } from "@lib/auth/session";
+import { siteUrl } from "@config/index";
+import { withLocalePath } from "@utils/i18n-seo";
+import type { AppLocale } from "types/i18n";
+import type { PromotionCheckoutResult } from "types/event";
+
+/**
+ * Resolves the event by slug and verifies the caller-provided eventId matches
+ * — same double-check as editEvent (app/[locale]/e/[eventId]/edita/actions.ts)
+ * to prevent a client passing a slug it owns alongside a different eventId.
+ */
+export async function createPromotionCheckoutAction(
+  eventId: string,
+  slug: string,
+  locale: AppLocale,
+): Promise<PromotionCheckoutResult> {
+  const [currentUser, event] = await Promise.all([
+    getCurrentUser(),
+    fetchEventBySlug(slug),
+  ]);
+
+  if (!event) {
+    return { success: false, error: "Event not found" };
+  }
+
+  if (event.id !== eventId) {
+    return {
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    };
+  }
+
+  const isCreator = Boolean(
+    currentUser?.id && event.owner?.id && currentUser.id === event.owner.id,
+  );
+  if (!isCreator) {
+    return {
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    };
+  }
+
+  const successUrl = `${siteUrl}${withLocalePath(`/e/${slug}/promote/success`, locale)}`;
+  const cancelUrl = `${siteUrl}${withLocalePath(`/e/${slug}/promote/cancel`, locale)}`;
+
+  try {
+    const { url } = await createPromotionCheckout(event.id, successUrl, cancelUrl);
+    return { success: true, url };
+  } catch (error) {
+    console.error("createPromotionCheckoutAction: checkout failed", error);
+    return {
+      success: false,
+      error: "Something went wrong. Please try again.",
+    };
+  }
+}

--- a/app/[locale]/e/[eventId]/promote/cancel/page.tsx
+++ b/app/[locale]/e/[eventId]/promote/cancel/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { locale as rootLocale } from "next/root-params";
+import type { AppLocale } from "types/i18n";
+import { Link } from "@i18n/routing";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = (await rootLocale()) as AppLocale;
+  const t = await getTranslations({ locale, namespace: "App.EventPromote.cancelPage" });
+  return {
+    title: t("title"),
+    description: t("subtitle"),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function PromoteCancelPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId: slug } = await params;
+  const locale = (await rootLocale()) as AppLocale;
+  setRequestLocale(locale);
+  const t = await getTranslations("App.EventPromote.cancelPage");
+
+  return (
+    // max-w-3xl matches /patrocina/cancelled exactly — same reasoning as the
+    // success page above.
+    <main className="min-h-screen bg-background py-section-y px-section-x">
+      <div className="max-w-3xl mx-auto text-center space-y-6">
+        <h1 className="heading-1">{t("title")}</h1>
+        <p className="body-large text-foreground/80">{t("subtitle")}</p>
+
+        <div className="flex justify-center">
+          <Link href={`/e/${slug}`} className="btn-outline">
+            {t("backToEvent")}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/[locale]/e/[eventId]/promote/page.tsx
+++ b/app/[locale]/e/[eventId]/promote/page.tsx
@@ -1,0 +1,48 @@
+import { notFound } from "next/navigation";
+import { locale as rootLocale } from "next/root-params";
+import { getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
+import { siteUrl } from "@config/index";
+import { withLocalePath } from "@utils/i18n-seo";
+import type { AppLocale } from "types/i18n";
+import { fetchEventBySlug } from "lib/api/events";
+import { getCurrentUser } from "@lib/auth/session";
+import PromoteEventClient from "./PromoteEventClient";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}): Promise<Metadata> {
+  const { eventId } = await params;
+  const locale = (await rootLocale()) as AppLocale;
+  const t = await getTranslations({ locale, namespace: "App.EventPromote" });
+  const canonical = `${siteUrl}${withLocalePath(`/e/${eventId}/promote`, locale)}`;
+  return {
+    title: t("title"),
+    description: t("description"),
+    robots: "noindex, nofollow",
+    alternates: { canonical },
+  };
+}
+
+export default async function PromotePage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const slug = (await params).eventId;
+  const [event, currentUser] = await Promise.all([
+    fetchEventBySlug(slug),
+    getCurrentUser(),
+  ]);
+
+  // Only the event creator may promote it. Treat missing/unknown ownership as
+  // 404 to avoid leaking the existence of the promote page — same convention
+  // as the edita page's ownership gate.
+  const currentUserId = currentUser?.id;
+  const isCreator = Boolean(currentUserId) && currentUserId === event?.owner?.id;
+  if (!event || !isCreator) return notFound();
+
+  return <PromoteEventClient eventId={event.id} slug={event.slug} />;
+}

--- a/app/[locale]/e/[eventId]/promote/success/page.tsx
+++ b/app/[locale]/e/[eventId]/promote/success/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { locale as rootLocale } from "next/root-params";
+import type { AppLocale } from "types/i18n";
+import { Link } from "@i18n/routing";
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = (await rootLocale()) as AppLocale;
+  const t = await getTranslations({ locale, namespace: "App.EventPromote.successPage" });
+  return {
+    title: t("title"),
+    description: t("subtitle"),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function PromoteSuccessPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId: slug } = await params;
+  const locale = (await rootLocale()) as AppLocale;
+  setRequestLocale(locale);
+  const t = await getTranslations("App.EventPromote.successPage");
+
+  return (
+    // max-w-3xl matches the existing /patrocina/success precedent exactly
+    // (app/[locale]/patrocina/success/page.tsx) — same return-page pattern,
+    // reused verbatim rather than picking a new width for no reason.
+    <main className="min-h-screen bg-background py-section-y px-section-x">
+      <div className="max-w-3xl mx-auto text-center space-y-6">
+        <div className="flex justify-center">
+          <CheckCircleIcon className="h-16 w-16 text-success" />
+        </div>
+        <h1 className="heading-1">{t("title")}</h1>
+        <p className="body-large text-foreground/80">{t("subtitle")}</p>
+
+        <div className="flex justify-center">
+          <Link href={`/e/${slug}`} className="btn-primary">
+            {t("backToEvent")}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/[locale]/publica/PromoteUpsellModal.tsx
+++ b/app/[locale]/publica/PromoteUpsellModal.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useRouter } from "@i18n/routing";
+import Modal from "@components/ui/common/modal";
+import Button from "@components/ui/common/button";
+import { sendGoogleEvent } from "@utils/analytics";
+import type { PromoteUpsellModalProps } from "types/props";
+
+export default function PromoteUpsellModal({
+  open,
+  setOpen,
+  slug,
+}: PromoteUpsellModalProps) {
+  const t = useTranslations("App.Publish.promoteUpsell");
+  const router = useRouter();
+
+  const handlePromote = () => {
+    sendGoogleEvent("promote_modal_cta_click", {
+      event_slug: slug,
+      source: "publica",
+    });
+    router.push(`/e/${slug}/promote`);
+    // Explicitly returning false stops Modal's own setOpen(false) from racing
+    // this navigation — see the design doc's "Modal" section for why this
+    // matters (Modal calls setOpen(false) automatically unless told not to).
+    return false;
+  };
+
+  const handleKeepFree = () => {
+    sendGoogleEvent("promote_modal_dismiss", {
+      event_slug: slug,
+      source: "publica",
+    });
+    setOpen(false);
+    router.push(`/e/${slug}`);
+  };
+
+  return (
+    <Modal
+      open={open}
+      setOpen={setOpen}
+      title={t("title")}
+      actionButton={t("promoteButton")}
+      onActionButtonClick={handlePromote}
+      testId="promote-upsell-modal"
+    >
+      <div className="flex flex-col gap-4 py-4">
+        <p className="body-normal text-foreground/80">{t("description")}</p>
+        <Button
+          type="button"
+          variant="neutral"
+          className="btn-outline w-full"
+          data-testid="promote-modal-keep-free"
+          onClick={handleKeepFree}
+        >
+          {t("keepFreeButton")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/app/[locale]/publica/page.tsx
+++ b/app/[locale]/publica/page.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useState, useMemo, useTransition, useCallback, useRef, useEffect } from "react";
 import dynamic from "next/dynamic";
-import { Link, useRouter } from "@i18n/routing";
+import { Link } from "@i18n/routing";
 import { addBreadcrumb, captureException } from "@sentry/nextjs";
 import { getRegionValue, formDataToBackendDTO, getTownValue } from "@utils/helpers";
 import { generateCityOptionsWithRegionMap } from "@utils/options-helpers";
@@ -51,6 +51,13 @@ const PreviewContent = dynamic(
     ),
   }
 );
+
+// Lazy load the post-publish upsell modal — same reasoning as PreviewContent
+// above: it only renders after a successful publish, so it shouldn't ship in
+// the initial /publica bundle.
+const PromoteUpsellModal = dynamic(() => import("./PromoteUpsellModal"), {
+  ssr: false,
+});
 
 const getDefaultEventDates = () => {
   const now = new Date();
@@ -121,7 +128,6 @@ const buildFileSignature = (file: File) =>
 const PublishForm = () => {
   const t = useTranslations("App.Publish");
   const tForm = useTranslations("Components.EventForm");
-  const router = useRouter();
   const [form, setForm] = useState<FormData>(defaultForm);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
@@ -133,6 +139,7 @@ const PublishForm = () => {
   // the same CompleteProfileGate here instead of a generic error, so the
   // user has an actual way forward.
   const [showCompleteProfileGate, setShowCompleteProfileGate] = useState(false);
+  const [publishedSlug, setPublishedSlug] = useState<string | null>(null);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
@@ -622,7 +629,11 @@ const PublishForm = () => {
         });
 
         submittedRef.current = true;
-        router.push(`/e/${slug}`);
+        sendGoogleEvent("promote_modal_shown", {
+          event_slug: slug,
+          source: "publica",
+        });
+        setPublishedSlug(slug);
       } catch (error) {
         console.error("Submission error:", error);
 
@@ -828,6 +839,15 @@ const PublishForm = () => {
           </div>
         </div>
       </div>
+      {publishedSlug && (
+        <PromoteUpsellModal
+          open={Boolean(publishedSlug)}
+          setOpen={(open) => {
+            if (!open) setPublishedSlug(null);
+          }}
+          slug={publishedSlug}
+        />
+      )}
     </>
   );
 };

--- a/app/[locale]/publica/page.tsx
+++ b/app/[locale]/publica/page.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useState, useMemo, useTransition, useCallback, useRef, useEffect } from "react";
 import dynamic from "next/dynamic";
-import { Link } from "@i18n/routing";
+import { Link, useRouter } from "@i18n/routing";
 import { addBreadcrumb, captureException } from "@sentry/nextjs";
 import { getRegionValue, formDataToBackendDTO, getTownValue } from "@utils/helpers";
 import { generateCityOptionsWithRegionMap } from "@utils/options-helpers";
@@ -51,13 +51,6 @@ const PreviewContent = dynamic(
     ),
   }
 );
-
-// Lazy load the post-publish upsell modal — same reasoning as PreviewContent
-// above: it only renders after a successful publish, so it shouldn't ship in
-// the initial /publica bundle.
-const PromoteUpsellModal = dynamic(() => import("./PromoteUpsellModal"), {
-  ssr: false,
-});
 
 const getDefaultEventDates = () => {
   const now = new Date();
@@ -128,6 +121,7 @@ const buildFileSignature = (file: File) =>
 const PublishForm = () => {
   const t = useTranslations("App.Publish");
   const tForm = useTranslations("Components.EventForm");
+  const router = useRouter();
   const [form, setForm] = useState<FormData>(defaultForm);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
@@ -139,7 +133,6 @@ const PublishForm = () => {
   // the same CompleteProfileGate here instead of a generic error, so the
   // user has an actual way forward.
   const [showCompleteProfileGate, setShowCompleteProfileGate] = useState(false);
-  const [publishedSlug, setPublishedSlug] = useState<string | null>(null);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
@@ -629,11 +622,12 @@ const PublishForm = () => {
         });
 
         submittedRef.current = true;
-        sendGoogleEvent("promote_modal_shown", {
-          event_slug: slug,
-          source: "publica",
-        });
-        setPublishedSlug(slug);
+        // The promote upsell modal is shown on the event detail page itself
+        // (EventClient.tsx), not here — this marker tells that page to show
+        // it once, right after landing there. Following the existing
+        // newEvent/edit_suggested query-param convention in that file rather
+        // than inventing a new cross-page signaling mechanism.
+        router.push(`/e/${slug}?promote=1`);
       } catch (error) {
         console.error("Submission error:", error);
 
@@ -839,15 +833,6 @@ const PublishForm = () => {
           </div>
         </div>
       </div>
-      {publishedSlug && (
-        <PromoteUpsellModal
-          open={Boolean(publishedSlug)}
-          setOpen={(open) => {
-            if (!open) setPublishedSlug(null);
-          }}
-          slug={publishedSlug}
-        />
-      )}
     </>
   );
 };

--- a/components/partials/PlacePageShell.tsx
+++ b/components/partials/PlacePageShell.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { JSX } from "react";
 import dynamic from "next/dynamic";
 import HybridEventsList from "@components/ui/hybridEventsList";
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
 import JsonLdServer from "./JsonLdServer";
 import { EventsListSkeleton } from "@components/ui/common/skeletons";
 import { FilterLoadingProvider } from "@components/context/FilterLoadingContext";
@@ -351,6 +352,14 @@ async function PlacePageContent({
       ))}
 
       <FilterLoadingGate>
+        {placeTypeLabel.type && (
+          <Suspense fallback={null}>
+            <PromotedEventsSection
+              scope={{ type: placeTypeLabel.type, slug: place }}
+            />
+          </Suspense>
+        )}
+
         <HybridEventsList
           initialEvents={events}
           placeTypeLabel={placeTypeLabel}

--- a/components/ui/EventForm/index.tsx
+++ b/components/ui/EventForm/index.tsx
@@ -55,6 +55,17 @@ export const EventForm: React.FC<EventFormProps> = ({
   const [step, setStep] = useState(0);
   const canPublishRef = useRef(false);
   const publishArmTimeoutRef = useRef<number | null>(null);
+  const publishReadyRef = useRef(false);
+  const publishButtonRef = useRef<HTMLButtonElement>(null);
+  const setPublishButtonRef = (button: HTMLButtonElement | null) => {
+    publishButtonRef.current = button;
+    if (button) {
+      button.setAttribute(
+        "data-publish-ready",
+        publishReadyRef.current ? "true" : "false",
+      );
+    }
+  };
   const [hasInteracted, setHasInteracted] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [touchedFields, setTouchedFields] = useState<Set<string>>(new Set());
@@ -114,6 +125,8 @@ export const EventForm: React.FC<EventFormProps> = ({
 
   useEffect(() => {
     canPublishRef.current = false;
+    publishReadyRef.current = false;
+    publishButtonRef.current?.setAttribute("data-publish-ready", "false");
     if (publishArmTimeoutRef.current !== null) {
       window.clearTimeout(publishArmTimeoutRef.current);
       publishArmTimeoutRef.current = null;
@@ -124,6 +137,8 @@ export const EventForm: React.FC<EventFormProps> = ({
       // submit button during a step transition (can happen under CI timing/layout shifts).
       publishArmTimeoutRef.current = window.setTimeout(() => {
         canPublishRef.current = true;
+        publishReadyRef.current = true;
+        publishButtonRef.current?.setAttribute("data-publish-ready", "true");
         publishArmTimeoutRef.current = null;
       }, 250);
     }
@@ -555,6 +570,7 @@ export const EventForm: React.FC<EventFormProps> = ({
               variant="primary"
               disabled={formState.isDisabled || isLoading}
               className="min-h-[44px] px-6 w-full sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+              ref={setPublishButtonRef}
               data-testid="publish-button"
               data-analytics-event-name={
                 analyticsContext === "publica" ? "publish_submit_click" : undefined

--- a/components/ui/cardHorizontal/CardHorizontalServer.tsx
+++ b/components/ui/cardHorizontal/CardHorizontalServer.tsx
@@ -12,11 +12,15 @@ const CardHorizontalServer = async ({
   event,
   isPriority = false,
   initialIsFavorite,
+  isPromoted = false,
 }: CardHorizontalServerProps) => {
   const locale = await getLocaleSafely();
   const tCard = await getTranslations({ locale, namespace: "Components.CardContent" });
   const tTime = await getTranslations({ locale, namespace: "Utils.EventTime" });
   const tCategories = await getTranslations({ locale, namespace: "Config.Categories" });
+  const tPromoted = isPromoted
+    ? await getTranslations({ locale, namespace: "Components.PromotedEvents" })
+    : null;
 
   const {
     title,
@@ -81,6 +85,9 @@ const CardHorizontalServer = async ({
       </div>
 
       <div className="flex-1 flex flex-col px-3.5 pt-2.5 pb-3.5 pointer-events-none">
+        {isPromoted && tPromoted && (
+          <span className="badge-primary mb-1 w-fit">{tPromoted("badge")}</span>
+        )}
         <CategoryBadge label={categoryLabel} />
 
         <p className="text-xs text-muted-foreground mb-1 truncate">

--- a/components/ui/eventsAround/EventsAroundServer.tsx
+++ b/components/ui/eventsAround/EventsAroundServer.tsx
@@ -43,6 +43,7 @@ async function EventsAroundServer({
   showJsonLd = false,
   jsonLdId,
   title,
+  isPromoted = false,
 }: EventsAroundServerProps) {
   const locale = await getLocaleSafely();
   const uniqueEvents = dedupeEvents(events);
@@ -141,6 +142,7 @@ async function EventsAroundServer({
                 <CardHorizontalServer
                   event={event}
                   isPriority={usePriority && index <= 2}
+                  isPromoted={isPromoted}
                 />
               </div>
             ))}

--- a/components/ui/promotedEvents/PromotedEventsSection.tsx
+++ b/components/ui/promotedEvents/PromotedEventsSection.tsx
@@ -1,0 +1,52 @@
+import { getTranslations } from "next-intl/server";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import SectionHeading from "@components/ui/common/SectionHeading";
+import { getActivePromotedEvents } from "@lib/api/promotedEvents";
+import { getLocaleSafely } from "@utils/i18n-seo";
+import type { PromotionScope } from "types/event";
+
+function scopeKey(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}`;
+}
+
+function scopePlaceSlug(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : scope.slug;
+}
+
+export default async function PromotedEventsSection({
+  scope,
+}: {
+  scope: PromotionScope;
+}) {
+  const promotedEvents = await getActivePromotedEvents(scope);
+  if (promotedEvents.length === 0) {
+    return null;
+  }
+
+  const locale = await getLocaleSafely();
+  const t = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  const key = scopeKey(scope);
+
+  return (
+    <div className="container content-auto-section">
+      <section className="py-section-y border-b">
+        <SectionHeading title={t("title")} titleClassName="heading-2 text-foreground" />
+        <div
+          data-analytics-container="true"
+          data-analytics-context="promoted_carousel"
+          data-analytics-place-slug={scopePlaceSlug(scope)}
+        >
+          <EventsAroundServer
+            events={promotedEvents}
+            layout="horizontal"
+            usePriority={false}
+            isPromoted
+            showJsonLd
+            title={t("title")}
+            jsonLdId={`promoted-events-${key}`}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/ui/promotedEvents/PromotedEventsSection.tsx
+++ b/components/ui/promotedEvents/PromotedEventsSection.tsx
@@ -1,9 +1,11 @@
 import { getTranslations } from "next-intl/server";
+import type { JSX } from "react";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
 import SectionHeading from "@components/ui/common/SectionHeading";
 import { getActivePromotedEvents } from "@lib/api/promotedEvents";
 import { getLocaleSafely } from "@utils/i18n-seo";
 import type { PromotionScope } from "types/event";
+import type { PromotedEventsSectionProps } from "types/props";
 
 function scopeKey(scope: PromotionScope): string {
   return scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}`;
@@ -15,9 +17,7 @@ function scopePlaceSlug(scope: PromotionScope): string {
 
 export default async function PromotedEventsSection({
   scope,
-}: {
-  scope: PromotionScope;
-}) {
+}: PromotedEventsSectionProps): Promise<JSX.Element | null> {
   const promotedEvents = await getActivePromotedEvents(scope);
   if (promotedEvents.length === 0) {
     return null;

--- a/components/ui/serverEventsCategorized/index.tsx
+++ b/components/ui/serverEventsCategorized/index.tsx
@@ -34,6 +34,7 @@ import { FeaturedPlaceSection } from "./FeaturedPlaceSection";
 import { CategoryEventsSection } from "./CategoryEventsSection";
 import { createDateFilterBadgeLabels } from "./DateFilterBadges";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
 import HeroSectionSkeleton from "../hero/HeroSectionSkeleton";
 import { getLocaleSafely } from "@utils/i18n-seo";
 import { DEFAULT_LOCALE } from "types/i18n";
@@ -508,6 +509,10 @@ export async function ServerEventsCategorizedContent({
 
   return (
     <>
+      <Suspense fallback={null}>
+        <PromotedEventsSection scope={{ type: "homepage" }} />
+      </Suspense>
+
       {/* Popular Now Section — derived from existing data, zero extra API calls */}
       {popularEvents.length > 0 && (
         <div className="container content-auto-section">

--- a/components/ui/serverEventsCategorized/index.tsx
+++ b/components/ui/serverEventsCategorized/index.tsx
@@ -470,7 +470,14 @@ export async function ServerEventsCategorizedContent({
     categorySectionsToRender.length > 0 || featuredSections.length > 0;
 
   if (!hasEvents) {
-    return <NoEventsFound />;
+    return (
+      <>
+        <Suspense fallback={null}>
+          <PromotedEventsSection scope={{ type: "homepage" }} />
+        </Suspense>
+        <NoEventsFound />
+      </>
+    );
   }
 
   const tCategory = await getTranslations({

--- a/config/pricing.ts
+++ b/config/pricing.ts
@@ -160,3 +160,20 @@ export const DISPLAY_PRICES_EUR: Record<
   region: buildDisplayPricesForScope("region"),
   country: buildDisplayPricesForScope("country"),
 };
+
+export interface EventPromotionOption {
+  id: string;
+  priceEur: number;
+}
+
+/**
+ * MVP: exactly one flat-fee option for event promotion checkout. Structured
+ * as a list (not a single constant) so the promote page already renders
+ * "whatever this returns" rather than a hardcoded line — when Gerard defines
+ * real duration/geo-scope tiers (methodology still undecided — see the
+ * design doc and the message sent to him), this function's implementation
+ * changes, not its callers.
+ */
+export function getEventPromotionOptions(): EventPromotionOption[] {
+  return [{ id: "standard", priceEur: 5 }];
+}

--- a/config/pricing.ts
+++ b/config/pricing.ts
@@ -10,6 +10,7 @@ import {
   type GeoScope,
   type SponsorDuration,
 } from "types/sponsor";
+import type { EventPromotionOption } from "types/event";
 
 /**
  * @deprecated Use GeoScope from types/sponsor.ts instead
@@ -160,11 +161,6 @@ export const DISPLAY_PRICES_EUR: Record<
   region: buildDisplayPricesForScope("region"),
   country: buildDisplayPricesForScope("country"),
 };
-
-export interface EventPromotionOption {
-  id: string;
-  priceEur: number;
-}
 
 /**
  * MVP: exactly one flat-fee option for event promotion checkout. Structured

--- a/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
+++ b/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
@@ -45,13 +45,15 @@ Design doc: `docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.m
 
 **Files:**
 - Modify: `types/props.ts` (append new prop interfaces)
+- Modify: `types/event.ts` (append the Server Action result type)
 - Test: none (pure type additions; verified via `yarn typecheck` in later tasks)
 
 **Interfaces:**
-- Produces: `PromotionCheckoutResult`, `PromoteEventClientProps`,
-  `PromoteUpsellModalProps`, `EventPromoteActionProps` — used by every later task.
+- Produces: `PromotionCheckoutResult` (in `types/event.ts`), `PromoteEventClientProps`,
+  `PromoteUpsellModalProps`, `EventPromoteActionProps` (in `types/props.ts`) — used by
+  every later task.
 
-- [ ] **Step 1: Add the new prop/result types to `types/props.ts`**
+- [ ] **Step 1: Add the prop types to `types/props.ts`**
 
 Find the block containing `EventEditActionProps` (around line 979) and add these new
 interfaces immediately after it:
@@ -68,12 +70,6 @@ export interface PromoteEventClientProps {
   slug: string;
 }
 
-// Discriminated result returned by createPromotionCheckoutAction — mirrors
-// EditEventResult's shape (no thrown errors reach the client).
-export type PromotionCheckoutResult =
-  | { success: true; url: string }
-  | { success: false; error: string };
-
 export interface PromoteUpsellModalProps {
   open: boolean;
   setOpen: (open: boolean) => void;
@@ -81,15 +77,36 @@ export interface PromoteUpsellModalProps {
 }
 ```
 
-- [ ] **Step 2: Verify the file still compiles**
+- [ ] **Step 2: Add the Server Action result type to `types/event.ts`, not `types/props.ts`**
+
+`PromotionCheckoutResult` is a Server Action return type, not a component prop — it
+belongs next to the two existing precedents it's modeled on, `EditEventResult` (line 350)
+and `CreateEventActionResult` (line 365), both in `types/event.ts`. Putting it in
+`types/props.ts` would break the file's own convention (props only) that the other two
+already establish. Find `CreateEventActionResult` (around line 365-367) and add
+immediately after it:
+
+```ts
+/**
+ * Result returned by createPromotionCheckoutAction. A discriminated union
+ * (not a thrown error) — same convention as EditEventResult and
+ * CreateEventActionResult above: the client always gets a value it can
+ * branch on, never an opaque Server Action rejection.
+ */
+export type PromotionCheckoutResult =
+  | { success: true; url: string }
+  | { success: false; error: string };
+```
+
+- [ ] **Step 3: Verify the files still compile**
 
 Run: `yarn typecheck`
-Expected: PASS (no errors related to `types/props.ts`)
+Expected: PASS (no errors related to `types/props.ts` or `types/event.ts`)
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add types/props.ts
+git add types/props.ts types/event.ts
 git commit -m "feat(promote): add types for event promotion checkout"
 ```
 
@@ -446,7 +463,7 @@ import { getCurrentUser } from "@lib/auth/session";
 import { siteUrl } from "@config/index";
 import { withLocalePath } from "@utils/i18n-seo";
 import type { AppLocale } from "types/i18n";
-import type { PromotionCheckoutResult } from "types/props";
+import type { PromotionCheckoutResult } from "types/event";
 
 /**
  * Resolves the event by slug and verifies the caller-provided eventId matches
@@ -673,17 +690,38 @@ git commit -m "feat(promote): add i18n messages for event promotion"
 ## Task 5: Promote page (Server Component gate + client component)
 
 **Files:**
+- Modify: `config/pricing.ts` (add the MVP flat-fee constant)
 - Create: `app/[locale]/e/[eventId]/promote/page.tsx`
 - Create: `app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx`
 - Test: Create `test/promote-event-client.test.tsx`
 
 **Interfaces:**
 - Consumes: `fetchEventBySlug`, `getCurrentUser` (existing), `createPromotionCheckoutAction`
-  (Task 3), `PromoteEventClientProps` (Task 1).
+  (Task 3), `PromoteEventClientProps` (Task 1), `EVENT_PROMOTION_FLAT_FEE_EUR`
+  (`config/pricing.ts`, this task).
 - Produces: the `/e/[eventId]/promote` route, rendered `PromoteEventClient` component
   used by Task 7's E2E flow.
 
-- [ ] **Step 1: Write the failing test for `PromoteEventClient`**
+- [ ] **Step 1: Add the flat-fee constant to `config/pricing.ts`**
+
+This repo already centralizes all promotion/sponsor pricing in `config/pricing.ts`
+(`BASE_PRICES_CENTS`, `DISPLAY_PRICES_EUR`) specifically so a price never lives loose in
+a component. Even as an MVP placeholder, the event-promotion fee belongs there, not
+inline in JSX. Add this at the end of `config/pricing.ts`, after `DISPLAY_PRICES_EUR`:
+
+```ts
+/**
+ * MVP flat fee for event promotion checkout (in EUR, not cents — this is a
+ * display-only value passed straight to the confirm button, not used in any
+ * server-side pricing calculation). The real backend pricing methodology is
+ * still undecided (per-day vs. start-to-event-date) — see the design doc.
+ * This constant is a placeholder until that's settled and the backend
+ * exposes it via its own endpoint.
+ */
+export const EVENT_PROMOTION_FLAT_FEE_EUR = 5;
+```
+
+- [ ] **Step 2: Write the failing test for `PromoteEventClient`**
 
 Create `test/promote-event-client.test.tsx`:
 
@@ -768,12 +806,12 @@ describe("PromoteEventClient", () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Run test to verify it fails**
 
 Run: `yarn test test/promote-event-client.test.tsx`
 Expected: FAIL (module not found: `PromoteEventClient`)
 
-- [ ] **Step 3: Implement `PromoteEventClient`**
+- [ ] **Step 4: Implement `PromoteEventClient`**
 
 Create `app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx`:
 
@@ -785,13 +823,10 @@ import { useLocale, useTranslations } from "next-intl";
 import { Link } from "@i18n/routing";
 import { ArrowLeftIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Button from "@components/ui/common/button";
+import { EVENT_PROMOTION_FLAT_FEE_EUR } from "@config/pricing";
 import type { AppLocale } from "types/i18n";
 import type { PromoteEventClientProps } from "types/props";
 import { createPromotionCheckoutAction } from "./actions";
-
-// MVP flat fee — static per design doc; a real pricing config is a follow-up
-// once the backend's pricing methodology is decided.
-const FLAT_FEE_EUR = 5;
 
 function isValidCheckoutUrl(url: string): boolean {
   try {
@@ -833,7 +868,13 @@ export default function PromoteEventClient({
   };
 
   return (
-    <div className="container max-w-2xl mx-auto py-section-y px-section-x">
+    // max-w-[520px] matches DESIGN.md's `containers.detail` token (520px) —
+    // this is a single-focus confirmation flow like the event detail page,
+    // not a multi-field form (which would use the wider `container` class,
+    // as /publica and /edita do). Tailwind's config only customizes the
+    // generic `container` utility, not a named "detail" width, so the literal
+    // value is the correct concrete implementation of that design token today.
+    <div className="max-w-[520px] mx-auto py-section-y px-section-x">
       <Link
         href={`/e/${slug}`}
         className="inline-flex items-center gap-1 body-small text-foreground/70 hover:text-foreground mb-4"
@@ -867,7 +908,9 @@ export default function PromoteEventClient({
 
         <div className="card-bordered card-body flex items-center justify-between">
           <span className="body-normal text-foreground/70">{t("priceLabel")}</span>
-          <span className="heading-2 text-foreground-strong">{FLAT_FEE_EUR}€</span>
+          <span className="heading-2 text-foreground-strong">
+            {EVENT_PROMOTION_FLAT_FEE_EUR}€
+          </span>
         </div>
         <p className="body-small text-foreground/60 -mt-4">{t("priceNote")}</p>
 
@@ -896,12 +939,12 @@ export default function PromoteEventClient({
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Run test to verify it passes**
 
 Run: `yarn test test/promote-event-client.test.tsx`
 Expected: PASS (3 tests)
 
-- [ ] **Step 5: Implement the Server Component page**
+- [ ] **Step 6: Implement the Server Component page**
 
 Create `app/[locale]/e/[eventId]/promote/page.tsx`:
 
@@ -956,16 +999,16 @@ export default async function PromotePage({
 }
 ```
 
-- [ ] **Step 6: Run full test suite and typecheck**
+- [ ] **Step 7: Run full test suite and typecheck**
 
 Run: `yarn typecheck && yarn test test/promote-event-client.test.tsx test/promote-checkout-action.test.ts`
 Expected: PASS
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add app/\[locale\]/e/\[eventId\]/promote/page.tsx app/\[locale\]/e/\[eventId\]/promote/PromoteEventClient.tsx test/promote-event-client.test.tsx
-git commit -m "feat(promote): add /e/[eventId]/promote page"
+git add config/pricing.ts app/\[locale\]/e/\[eventId\]/promote/page.tsx app/\[locale\]/e/\[eventId\]/promote/PromoteEventClient.tsx test/promote-event-client.test.tsx
+git commit -m "feat(promote): add /e/[eventId]/promote page with centralized MVP pricing"
 ```
 
 ---
@@ -1015,8 +1058,11 @@ export default async function PromoteSuccessPage({
   const t = await getTranslations("App.EventPromote.successPage");
 
   return (
+    // max-w-3xl matches the existing /patrocina/success precedent exactly
+    // (app/[locale]/patrocina/success/page.tsx) — same return-page pattern,
+    // reused verbatim rather than picking a new width for no reason.
     <main className="min-h-screen bg-background py-section-y px-section-x">
-      <div className="max-w-2xl mx-auto text-center space-y-6">
+      <div className="max-w-3xl mx-auto text-center space-y-6">
         <div className="flex justify-center">
           <CheckCircleIcon className="h-16 w-16 text-success" />
         </div>
@@ -1066,8 +1112,10 @@ export default async function PromoteCancelPage({
   const t = await getTranslations("App.EventPromote.cancelPage");
 
   return (
+    // max-w-3xl matches /patrocina/cancelled exactly — same reasoning as the
+    // success page above.
     <main className="min-h-screen bg-background py-section-y px-section-x">
-      <div className="max-w-2xl mx-auto text-center space-y-6">
+      <div className="max-w-3xl mx-auto text-center space-y-6">
         <h1 className="heading-1">{t("title")}</h1>
         <p className="body-large text-foreground/80">{t("subtitle")}</p>
 
@@ -1448,14 +1496,51 @@ export default function PromoteUpsellModal({
 Run: `yarn test test/promote-upsell-modal.test.tsx`
 Expected: PASS (2 tests)
 
-- [ ] **Step 5: Splice the modal into `publica/page.tsx`**
+- [ ] **Step 5: Splice the modal into `publica/page.tsx`, lazy-loaded**
 
-In `app/[locale]/publica/page.tsx`, add the import next to the other colocated imports
-(near line 39, after `CompleteProfileGate`):
+The modal only ever renders after a successful publish — there's no reason to ship it in
+`/publica`'s initial bundle. This file already has the exact precedent for this: the
+preview modal's content is lazy-loaded via `next/dynamic` with `ssr: false` (lines 44-53).
+Follow the same pattern instead of a static import.
+
+In `app/[locale]/publica/page.tsx`, replace the existing `PreviewContent` dynamic-import
+block (lines 44-53):
 
 ```tsx
-import CompleteProfileGate from "./CompleteProfileGate";
-import PromoteUpsellModal from "./PromoteUpsellModal";
+// Lazy load preview content (only shown in modal when user clicks preview)
+// Client component, so we can use dynamic directly with ssr: false
+const PreviewContent = dynamic(
+  () => import("@components/ui/EventForm/preview/PreviewContent"),
+  {
+    ssr: false, // Preview is only shown in modal, not needed for initial render
+    loading: () => (
+      <div className="w-full h-64 bg-muted animate-pulse rounded" aria-label="Loading preview" />
+    ),
+  }
+);
+```
+
+with the same block plus a second `dynamic()` call for the new modal:
+
+```tsx
+// Lazy load preview content (only shown in modal when user clicks preview)
+// Client component, so we can use dynamic directly with ssr: false
+const PreviewContent = dynamic(
+  () => import("@components/ui/EventForm/preview/PreviewContent"),
+  {
+    ssr: false, // Preview is only shown in modal, not needed for initial render
+    loading: () => (
+      <div className="w-full h-64 bg-muted animate-pulse rounded" aria-label="Loading preview" />
+    ),
+  }
+);
+
+// Lazy load the post-publish upsell modal — same reasoning as PreviewContent
+// above: it only renders after a successful publish, so it shouldn't ship in
+// the initial /publica bundle.
+const PromoteUpsellModal = dynamic(() => import("./PromoteUpsellModal"), {
+  ssr: false,
+});
 ```
 
 Add a new state variable inside `PublishForm`, near the other `showPreview`/`showCompleteProfileGate`
@@ -1793,11 +1878,31 @@ during review is Task 7. Out-of-scope items (pricing lookup, duplicate-checkout 
 list sorting, non-owner promotion, webhook/Stripe SDK) are deliberately absent from every
 task.
 
-**Type consistency:** `PromotionCheckoutResult` (Task 1) is used identically in Task 3's
-action signature and Task 5's client component — checked. `EventPromoteActionProps` (Task
-1) matches `EventEditActionProps`'s shape exactly, used consistently in Task 7.
+**Type consistency:** `PromotionCheckoutResult` (Task 1, defined in `types/event.ts` next
+to its two direct precedents `EditEventResult`/`CreateEventActionResult` — not
+`types/props.ts`, which is props-only) is used identically in Task 3's action signature
+and Task 5's client component — checked. `EventPromoteActionProps` (Task 1) matches
+`EventEditActionProps`'s shape exactly, used consistently in Task 7.
 `PromoteUpsellModalProps` (Task 1) matches the props Task 8's component and test actually
 destructure.
 
 **No placeholders:** every step has complete, concrete code — no TBD/TODO markers, no
 "add appropriate error handling" prose without an implementation.
+
+**Post-plan audit (DRY/centralize/types/design/performance):** a second pass, prompted by
+direct user challenge, caught four issues fixed above: (1) `PromotionCheckoutResult` had
+been placed in `types/props.ts` instead of `types/event.ts`, inconsistent with its own
+named precedents — moved in Task 1. (2) The €5 MVP fee was a raw literal inline in JSX
+instead of living in `config/pricing.ts`, the file that already centralizes every other
+promotion/sponsor price in this repo specifically to prevent that — moved to
+`EVENT_PROMOTION_FLAT_FEE_EUR` in Task 5. (3) `DESIGN.md` (required reading before any UI
+code, per this repo's CLAUDE.md) was not actually read before the first draft of this
+plan; once read, the promote page's container width (`max-w-2xl`) didn't match either
+`DESIGN.md`'s `containers.detail` token (520px, the correct token for a single-focus
+confirmation page) or the actual `/patrocina/success`+`/patrocina/cancelled` precedent's
+`max-w-3xl` (which the success/cancel pages in Task 6 claimed to mirror but didn't) —
+both corrected to their proper values. (4) `PromoteUpsellModal` was a static import in
+`publica/page.tsx` despite that same file already lazy-loading `PreviewContent` via
+`next/dynamic` with `ssr: false` for the identical reason (only renders after a specific
+user action, not on initial page load) — changed to follow the existing pattern in
+Task 8.

--- a/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
+++ b/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
@@ -690,35 +690,53 @@ git commit -m "feat(promote): add i18n messages for event promotion"
 ## Task 5: Promote page (Server Component gate + client component)
 
 **Files:**
-- Modify: `config/pricing.ts` (add the MVP flat-fee constant)
+- Modify: `config/pricing.ts` (add the MVP pricing-options function)
 - Create: `app/[locale]/e/[eventId]/promote/page.tsx`
 - Create: `app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx`
 - Test: Create `test/promote-event-client.test.tsx`
 
 **Interfaces:**
 - Consumes: `fetchEventBySlug`, `getCurrentUser` (existing), `createPromotionCheckoutAction`
-  (Task 3), `PromoteEventClientProps` (Task 1), `EVENT_PROMOTION_FLAT_FEE_EUR`
+  (Task 3), `PromoteEventClientProps` (Task 1), `getEventPromotionOptions`
   (`config/pricing.ts`, this task).
 - Produces: the `/e/[eventId]/promote` route, rendered `PromoteEventClient` component
   used by Task 7's E2E flow.
 
-- [ ] **Step 1: Add the flat-fee constant to `config/pricing.ts`**
+- [ ] **Step 1: Add `getEventPromotionOptions` to `config/pricing.ts`**
 
 This repo already centralizes all promotion/sponsor pricing in `config/pricing.ts`
 (`BASE_PRICES_CENTS`, `DISPLAY_PRICES_EUR`) specifically so a price never lives loose in
-a component. Even as an MVP placeholder, the event-promotion fee belongs there, not
-inline in JSX. Add this at the end of `config/pricing.ts`, after `DISPLAY_PRICES_EUR`:
+a component. But Gerard's backend has no real pricing methodology for event promotion
+yet (duration tiers, geo-scope tiers — see the design doc's "Risks" section and the
+2026-08-03 Catalan message sent to him). Building a full `/api/promotions/event-config`
+route + external wrapper right now, for a value that's a single hardcoded number with
+zero real backend config behind it, would be inventing structure for a need that doesn't
+exist yet.
+
+The right-sized seam is a function that returns a list, not a network layer: today it
+returns exactly one option, so `PromoteEventClient` already renders "whatever the list
+contains" instead of a single hardcoded line. When Gerard defines real tiers, this
+function's *implementation* changes (likely a fetch from a new endpoint at that point) —
+but nothing that calls it has to change, since it already iterates a list. Add this at
+the end of `config/pricing.ts`, after `DISPLAY_PRICES_EUR`:
 
 ```ts
+export interface EventPromotionOption {
+  id: string;
+  priceEur: number;
+}
+
 /**
- * MVP flat fee for event promotion checkout (in EUR, not cents — this is a
- * display-only value passed straight to the confirm button, not used in any
- * server-side pricing calculation). The real backend pricing methodology is
- * still undecided (per-day vs. start-to-event-date) — see the design doc.
- * This constant is a placeholder until that's settled and the backend
- * exposes it via its own endpoint.
+ * MVP: exactly one flat-fee option for event promotion checkout. Structured
+ * as a list (not a single constant) so the promote page already renders
+ * "whatever this returns" rather than a hardcoded line — when Gerard defines
+ * real duration/geo-scope tiers (methodology still undecided — see the
+ * design doc and the message sent to him), this function's implementation
+ * changes, not its callers.
  */
-export const EVENT_PROMOTION_FLAT_FEE_EUR = 5;
+export function getEventPromotionOptions(): EventPromotionOption[] {
+  return [{ id: "standard", priceEur: 5 }];
+}
 ```
 
 - [ ] **Step 2: Write the failing test for `PromoteEventClient`**
@@ -803,6 +821,15 @@ describe("PromoteEventClient", () => {
     });
     expect(window.location.href).toBe("");
   });
+
+  it("renders the price from getEventPromotionOptions rather than a hardcoded value", () => {
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+
+    // 5 is today's only entry from getEventPromotionOptions() — asserting
+    // against the rendered text (not re-importing the config function) keeps
+    // this test honest about what the user actually sees.
+    expect(screen.getByText("5€")).toBeInTheDocument();
+  });
 });
 ```
 
@@ -823,7 +850,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Link } from "@i18n/routing";
 import { ArrowLeftIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Button from "@components/ui/common/button";
-import { EVENT_PROMOTION_FLAT_FEE_EUR } from "@config/pricing";
+import { getEventPromotionOptions } from "@config/pricing";
 import type { AppLocale } from "types/i18n";
 import type { PromoteEventClientProps } from "types/props";
 import { createPromotionCheckoutAction } from "./actions";
@@ -844,6 +871,11 @@ export default function PromoteEventClient({
   const locale = useLocale() as AppLocale;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // MVP: exactly one option today. Rendered from a list (not a single
+  // constant) so this component doesn't change shape when Gerard adds real
+  // duration/geo-scope tiers later — only getEventPromotionOptions' return
+  // value grows.
+  const [promotionOption] = getEventPromotionOptions();
 
   const handleConfirm = async () => {
     setError(null);
@@ -909,7 +941,7 @@ export default function PromoteEventClient({
         <div className="card-bordered card-body flex items-center justify-between">
           <span className="body-normal text-foreground/70">{t("priceLabel")}</span>
           <span className="heading-2 text-foreground-strong">
-            {EVENT_PROMOTION_FLAT_FEE_EUR}€
+            {promotionOption.priceEur}€
           </span>
         </div>
         <p className="body-small text-foreground/60 -mt-4">{t("priceNote")}</p>
@@ -942,7 +974,7 @@ export default function PromoteEventClient({
 - [ ] **Step 5: Run test to verify it passes**
 
 Run: `yarn test test/promote-event-client.test.tsx`
-Expected: PASS (3 tests)
+Expected: PASS (4 tests)
 
 - [ ] **Step 6: Implement the Server Component page**
 
@@ -1895,14 +1927,19 @@ been placed in `types/props.ts` instead of `types/event.ts`, inconsistent with i
 named precedents — moved in Task 1. (2) The €5 MVP fee was a raw literal inline in JSX
 instead of living in `config/pricing.ts`, the file that already centralizes every other
 promotion/sponsor price in this repo specifically to prevent that — moved to
-`EVENT_PROMOTION_FLAT_FEE_EUR` in Task 5. (3) `DESIGN.md` (required reading before any UI
-code, per this repo's CLAUDE.md) was not actually read before the first draft of this
-plan; once read, the promote page's container width (`max-w-2xl`) didn't match either
-`DESIGN.md`'s `containers.detail` token (520px, the correct token for a single-focus
-confirmation page) or the actual `/patrocina/success`+`/patrocina/cancelled` precedent's
-`max-w-3xl` (which the success/cancel pages in Task 6 claimed to mirror but didn't) —
-both corrected to their proper values. (4) `PromoteUpsellModal` was a static import in
-`publica/page.tsx` despite that same file already lazy-loading `PreviewContent` via
-`next/dynamic` with `ssr: false` for the identical reason (only renders after a specific
+`getEventPromotionOptions()` in Task 5 (a list-returning function rather than a bare
+constant, so the component already renders "whatever the list contains" instead of a
+hardcoded line — deliberately NOT a full `/api/promotions/event-config` route, since
+Gerard's backend has no real duration/geo-scope tiers yet and building that network layer
+now would be inventing structure for a need that doesn't exist; see the design doc's
+"Risks" section and the message sent to Gerard on 2026-08-03). (3) `DESIGN.md` (required
+reading before any UI code, per this repo's CLAUDE.md) was not actually read before the
+first draft of this plan; once read, the promote page's container width (`max-w-2xl`)
+didn't match either `DESIGN.md`'s `containers.detail` token (520px, the correct token for
+a single-focus confirmation page) or the actual `/patrocina/success`+`/patrocina/cancelled`
+precedent's `max-w-3xl` (which the success/cancel pages in Task 6 claimed to mirror but
+didn't) — both corrected to their proper values. (4) `PromoteUpsellModal` was a static
+import in `publica/page.tsx` despite that same file already lazy-loading `PreviewContent`
+via `next/dynamic` with `ssr: false` for the identical reason (only renders after a specific
 user action, not on initial page load) — changed to follow the existing pattern in
 Task 8.

--- a/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
+++ b/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
@@ -1943,3 +1943,41 @@ import in `publica/page.tsx` despite that same file already lazy-loading `Previe
 via `next/dynamic` with `ssr: false` for the identical reason (only renders after a specific
 user action, not on initial page load) — changed to follow the existing pattern in
 Task 8.
+
+## Post-review corrections (2026-08-04)
+
+An AI code review pass on the resulting PR (cubic, coderabbit, greptile) found several
+gaps between this plan's embedded code samples and what actually shipped. Recorded here
+rather than editing the historical code blocks above:
+
+1. **Analytics funnel was missing.** Task 5's `PromoteEventClient` code sample above
+   fires no `sendGoogleEvent` calls at all, contradicting this doc's own Self-Review
+   Notes ("analytics woven into Tasks 5 and 8") and the design doc's "Analytics (new)"
+   section, which specifies `promote_page_view`, `promote_checkout_click`,
+   `promote_checkout_redirect` (renamed from `promote_checkout_success` — no payment has
+   happened yet at redirect time), and `promote_checkout_error`. Fixed in the shipped
+   `PromoteEventClient.tsx`: all four now fire at the appropriate points in
+   `handleConfirm` and a mount-time `useEffect`.
+2. **Unguarded `getEventPromotionOptions()` destructure.** The `const [promotionOption] =
+   getEventPromotionOptions();` line above throws if that function ever returns an empty
+   array, and only ever reads index 0 regardless of how many options exist — worth
+   flagging since the whole reason for returning a list (not a constant) was to support
+   more than one tier later. The shipped component guards the empty case (renders a
+   disabled button + error state) rather than crashing; the "read only index 0" behavior
+   is accepted for now since real multi-tier UI is still backend-blocked (see the design
+   doc's "Risks" section) — the guard is the one change needed to make that acceptable.
+3. **`isSubmitting` reset only on the two explicit failure branches.** If
+   `createPromotionCheckoutAction` rejects outright (rather than returning `{ success:
+   false }`), the code sample above never resets `isSubmitting`, permanently disabling
+   the button. Shipped version wraps the body in `try/finally`.
+4. **Modal architecture superseded.** Task 8 below still describes splicing the modal
+   into `publica/page.tsx`. See the design doc's "Post-review architecture correction"
+   addendum for the full, current description — the modal now lives on the event detail
+   page, gated on ownership (a related review finding: the original `?promote=1` marker
+   had no ownership check, so any visitor could trigger the upsell by hand-editing the
+   URL).
+5. **Mobile visibility gap (Greptile).** `EventPromoteAction` (Task 7) is rendered only
+   in `EventSidebar`, which is desktop-only (`lg:block`). An owner on a phone or tablet
+   had no persistent way to reach `/promote` outside the one-time post-publish modal.
+   Fixed by also rendering `EventPromoteAction` in `EventDetailsSection` (the existing
+   mobile-visible counterpart to the sidebar).

--- a/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
+++ b/docs/superpowers/plans/2026-08-03-event-promotion-checkout.md
@@ -1,0 +1,1803 @@
+# Event Promotion Checkout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a post-publish "Wallapop-style" upsell modal, a dedicated `/e/[eventId]/promote`
+page, and a Server Action that hands off to Gerard's Spring Boot backend to create a
+Stripe Checkout session for event promotion.
+
+**Architecture:** Owner-only Server Component gate (copied from the existing `edita`
+page) renders a client component that calls a Server Action. The action re-verifies
+ownership server-side, POSTs to `${apiUrl}/events/{id}/promotions/checkout` with
+`skipBodySigning: true` HMAC auth (same pattern as every other event mutation in
+`lib/api/events.ts`), and returns a discriminated result. All payment logic — Stripe
+session, PENDING order, webhook, fulfillment — lives in the backend; this app only shows
+the upsell, collects confirmation, and redirects to the URL the backend returns.
+
+**Tech Stack:** Next.js App Router (Server Components + Server Actions), next-intl,
+Vitest, Playwright, Tailwind (semantic design classes only, per repo convention).
+
+Design doc: `docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md`
+
+## Global Constraints
+
+- Types live only in `types/` (ESLint-enforced) — no inline interfaces in components.
+- Use `Link`/`useRouter` from `@i18n/routing`, never `next/link` directly.
+- No `searchParams` reads in page components.
+- Never `next: { revalidate }` on external fetches — this feature makes no external
+  fetches directly (Server Action only), so this doesn't apply, but no new code should
+  violate it either.
+- All POST/PUT/DELETE `fetchWithHmac` calls MUST pass `skipBodySigning: true`.
+- Static price for MVP: €5 flat fee (hardcoded, explicitly marked as provisional).
+- No Stripe SDK, webhook, or secret key added to this repo for this feature — the
+  backend owns all of that.
+- No changes to `EventSummaryResponseDTO`/`EventDetailResponseDTO`, list rendering, or
+  sorting — "appears at top" is entirely backend-owned and out of scope here.
+- No "already promoted" duplicate-checkout guard — no lookup endpoint exists yet.
+- `yarn typecheck && yarn lint && yarn test` must pass before any task is considered done.
+- Analytics events use `sendGoogleEvent` (imperative), matching `app/[locale]/publica/page.tsx`'s
+  existing `publish_*` event pattern — not the declarative `data-analytics-*` attribute
+  pattern used inside `EventForm`.
+
+---
+
+## Task 1: Types for the promotion checkout feature
+
+**Files:**
+- Modify: `types/props.ts` (append new prop interfaces)
+- Test: none (pure type additions; verified via `yarn typecheck` in later tasks)
+
+**Interfaces:**
+- Produces: `PromotionCheckoutResult`, `PromoteEventClientProps`,
+  `PromoteUpsellModalProps`, `EventPromoteActionProps` — used by every later task.
+
+- [ ] **Step 1: Add the new prop/result types to `types/props.ts`**
+
+Find the block containing `EventEditActionProps` (around line 979) and add these new
+interfaces immediately after it:
+
+```ts
+export interface EventPromoteActionProps {
+  ownerId?: string;
+  slug: string;
+}
+
+// /e/[eventId]/promote client page
+export interface PromoteEventClientProps {
+  eventId: string;
+  slug: string;
+}
+
+// Discriminated result returned by createPromotionCheckoutAction — mirrors
+// EditEventResult's shape (no thrown errors reach the client).
+export type PromotionCheckoutResult =
+  | { success: true; url: string }
+  | { success: false; error: string };
+
+export interface PromoteUpsellModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  slug: string;
+}
+```
+
+- [ ] **Step 2: Verify the file still compiles**
+
+Run: `yarn typecheck`
+Expected: PASS (no errors related to `types/props.ts`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add types/props.ts
+git commit -m "feat(promote): add types for event promotion checkout"
+```
+
+---
+
+## Task 2: `createPromotionCheckout` in `lib/api/events.ts`
+
+**Files:**
+- Modify: `lib/api/events.ts` (add new exported function)
+- Test: Create `test/lib/api/events.createPromotionCheckout.test.ts`
+
+**Interfaces:**
+- Consumes: `requireMutationAuth()` (existing private helper in this file, returns
+  `{ apiUrl, authToken }`), `fetchWithHmac` (from `./fetch-wrapper`).
+- Produces: `createPromotionCheckout(id: string, successUrl: string, cancelUrl: string):
+  Promise<{ url: string }>` — the Server Action in Task 3 calls this directly.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/lib/api/events.createPromotionCheckout.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetValidAccessToken = vi.fn();
+const mockGetApiUrl = vi.fn();
+const mockIsApiUrlConfigured = vi.fn();
+const mockFetchWithHmac = vi.fn();
+
+vi.mock("@utils/auth-cookies", () => ({
+  getAccessTokenFromCookies: vi.fn(),
+  getValidAccessToken: () => mockGetValidAccessToken(),
+}));
+
+vi.mock("@utils/api-helpers", () => ({
+  getInternalApiUrl: vi.fn(),
+  buildEventsQuery: vi.fn(),
+  getVercelProtectionBypassHeaders: () => ({}),
+  getApiUrl: () => mockGetApiUrl(),
+  isApiUrlConfigured: () => mockIsApiUrlConfigured(),
+}));
+
+vi.mock("../fetch-wrapper", () => ({
+  fetchWithHmac: (url: string, options: RequestInit) =>
+    mockFetchWithHmac(url, options),
+}));
+
+import { createPromotionCheckout } from "../../../lib/api/events";
+
+describe("createPromotionCheckout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsApiUrlConfigured.mockReturnValue(true);
+    mockGetApiUrl.mockReturnValue("https://api.test");
+    mockGetValidAccessToken.mockResolvedValue("test-token");
+  });
+
+  it("POSTs to /events/{id}/promotions/checkout with skipBodySigning and returns the url", async () => {
+    mockFetchWithHmac.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/session123" }),
+    });
+
+    const result = await createPromotionCheckout(
+      "event-uuid-1",
+      "https://www.esdeveniments.cat/e/my-event/promote/success",
+      "https://www.esdeveniments.cat/e/my-event/promote/cancel",
+    );
+
+    expect(mockFetchWithHmac).toHaveBeenCalledWith(
+      "https://api.test/events/event-uuid-1/promotions/checkout",
+      expect.objectContaining({
+        method: "POST",
+        skipBodySigning: true,
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+    const [, callOptions] = mockFetchWithHmac.mock.calls[0];
+    expect(JSON.parse(callOptions.body as string)).toEqual({
+      successUrl: "https://www.esdeveniments.cat/e/my-event/promote/success",
+      cancelUrl: "https://www.esdeveniments.cat/e/my-event/promote/cancel",
+    });
+    expect(result).toEqual({ url: "https://checkout.stripe.com/session123" });
+  });
+
+  it("throws when the backend responds with a non-2xx status", async () => {
+    mockFetchWithHmac.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "Not found",
+    });
+
+    await expect(
+      createPromotionCheckout("event-uuid-1", "https://x/success", "https://x/cancel"),
+    ).rejects.toThrow(/404/);
+  });
+
+  it("throws when no valid access token is available", async () => {
+    mockGetValidAccessToken.mockResolvedValue(null);
+
+    await expect(
+      createPromotionCheckout("event-uuid-1", "https://x/success", "https://x/cancel"),
+    ).rejects.toThrow("Authentication required");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test test/lib/api/events.createPromotionCheckout.test.ts`
+Expected: FAIL with `createPromotionCheckout is not a function` (or import error)
+
+- [ ] **Step 3: Implement `createPromotionCheckout`**
+
+In `lib/api/events.ts`, add this function immediately after `deleteEventById` (which ends
+around line 358 — find the closing brace of `deleteEventById` and insert after it):
+
+```ts
+export async function createPromotionCheckout(
+  id: string,
+  successUrl: string,
+  cancelUrl: string,
+): Promise<{ url: string }> {
+  const { apiUrl, authToken } = await requireMutationAuth();
+
+  const response = await fetchWithHmac(
+    `${apiUrl}/events/${id}/promotions/checkout`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify({ successUrl, cancelUrl }),
+      skipBodySigning: true,
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("createPromotionCheckout: error response:", errorText);
+    throw new Error(
+      `HTTP error! status: ${response.status}, body: ${errorText}`,
+    );
+  }
+
+  const payload = await response.json();
+  if (!payload || typeof payload.url !== "string") {
+    throw new Error(
+      "createPromotionCheckout: backend response missing url field",
+    );
+  }
+
+  return { url: payload.url };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test test/lib/api/events.createPromotionCheckout.test.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/api/events.ts test/lib/api/events.createPromotionCheckout.test.ts
+git commit -m "feat(promote): add createPromotionCheckout backend call"
+```
+
+---
+
+## Task 3: Server Action `createPromotionCheckoutAction`
+
+**Files:**
+- Create: `app/[locale]/e/[eventId]/promote/actions.ts`
+- Test: Create `test/promote-checkout-action.test.ts`
+
+**Interfaces:**
+- Consumes: `createPromotionCheckout(id, successUrl, cancelUrl)` (Task 2),
+  `fetchEventBySlug(slug)` and `getCurrentUser()` (both already exist, same imports as
+  `edita/actions.ts`), `siteUrl` (`@config/index`), `withLocalePath` (`@utils/i18n-seo`).
+- Produces: `createPromotionCheckoutAction(eventId: string, slug: string, locale:
+  AppLocale): Promise<PromotionCheckoutResult>` — called by `PromoteEventClient` in
+  Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/promote-checkout-action.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EventDetailResponseDTO } from "types/api/event";
+
+const mockCreatePromotionCheckout = vi.fn();
+const mockFetchEventBySlug = vi.fn();
+const mockGetCurrentUser = vi.fn();
+
+vi.mock("@lib/api/events", () => ({
+  createPromotionCheckout: (id: string, successUrl: string, cancelUrl: string) =>
+    mockCreatePromotionCheckout(id, successUrl, cancelUrl),
+  fetchEventBySlug: (slug: string) => mockFetchEventBySlug(slug),
+}));
+
+vi.mock("@lib/auth/session", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+import { createPromotionCheckoutAction } from "../app/[locale]/e/[eventId]/promote/actions";
+
+const CREATOR_ID = "creator-uuid-1";
+
+function buildEvent(overrides: Partial<EventDetailResponseDTO> = {}): EventDetailResponseDTO {
+  return {
+    id: "event-uuid-1",
+    hash: "hash",
+    slug: "my-event",
+    title: "My Event",
+    type: "FREE",
+    url: "",
+    description: "desc",
+    imageUrl: "",
+    startDate: "2026-09-01",
+    startTime: null,
+    endDate: "2026-09-01",
+    endTime: null,
+    location: "Location",
+    visits: 0,
+    origin: "MANUAL",
+    owner: {
+      id: CREATOR_ID,
+      displayName: "Creator",
+      username: "creator",
+      avatarUrl: null,
+      organizerVerified: false,
+    },
+    city: { id: 1, name: "City", slug: "city", latitude: 0, longitude: 0, postalCode: "08001", rssFeed: null, enabled: true },
+    region: { id: 1, name: "Region", slug: "region" },
+    province: { id: 1, name: "Region", slug: "region" },
+    categories: [],
+    ...overrides,
+  };
+}
+
+describe("createPromotionCheckoutAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the checkout url when the caller owns the event", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+    mockCreatePromotionCheckout.mockResolvedValue({
+      url: "https://checkout.stripe.com/session123",
+    });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: true,
+      url: "https://checkout.stripe.com/session123",
+    });
+    expect(mockCreatePromotionCheckout).toHaveBeenCalledWith(
+      "event-uuid-1",
+      expect.stringContaining("/e/my-event/promote/success"),
+      expect.stringContaining("/e/my-event/promote/cancel"),
+    );
+  });
+
+  it("rejects when the provided eventId does not match the resolved event's id", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent({ id: "different-uuid" }));
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    });
+    expect(mockCreatePromotionCheckout).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the signed-in user does not own the event", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: "someone-else" });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    });
+  });
+
+  it("rejects when the event does not exist", async () => {
+    mockFetchEventBySlug.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({ success: false, error: "Event not found" });
+  });
+
+  it("converts a thrown backend error into a generic result instead of throwing", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+    mockCreatePromotionCheckout.mockRejectedValue(new Error("HTTP error! status: 404"));
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Something went wrong. Please try again.",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test test/promote-checkout-action.test.ts`
+Expected: FAIL (module not found: `app/[locale]/e/[eventId]/promote/actions`)
+
+- [ ] **Step 3: Implement the Server Action**
+
+Create `app/[locale]/e/[eventId]/promote/actions.ts`:
+
+```ts
+"use server";
+import { createPromotionCheckout, fetchEventBySlug } from "@lib/api/events";
+import { getCurrentUser } from "@lib/auth/session";
+import { siteUrl } from "@config/index";
+import { withLocalePath } from "@utils/i18n-seo";
+import type { AppLocale } from "types/i18n";
+import type { PromotionCheckoutResult } from "types/props";
+
+/**
+ * Resolves the event by slug and verifies the caller-provided eventId matches
+ * — same double-check as editEvent (app/[locale]/e/[eventId]/edita/actions.ts)
+ * to prevent a client passing a slug it owns alongside a different eventId.
+ */
+export async function createPromotionCheckoutAction(
+  eventId: string,
+  slug: string,
+  locale: AppLocale,
+): Promise<PromotionCheckoutResult> {
+  const [currentUser, event] = await Promise.all([
+    getCurrentUser(),
+    fetchEventBySlug(slug),
+  ]);
+
+  if (!event) {
+    return { success: false, error: "Event not found" };
+  }
+
+  if (event.id !== eventId) {
+    return {
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    };
+  }
+
+  const isCreator = Boolean(
+    currentUser?.id && event.owner?.id && currentUser.id === event.owner.id,
+  );
+  if (!isCreator) {
+    return {
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    };
+  }
+
+  const successUrl = `${siteUrl}${withLocalePath(`/e/${slug}/promote/success`, locale)}`;
+  const cancelUrl = `${siteUrl}${withLocalePath(`/e/${slug}/promote/cancel`, locale)}`;
+
+  try {
+    const { url } = await createPromotionCheckout(event.id, successUrl, cancelUrl);
+    return { success: true, url };
+  } catch (error) {
+    console.error("createPromotionCheckoutAction: checkout failed", error);
+    return {
+      success: false,
+      error: "Something went wrong. Please try again.",
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test test/promote-checkout-action.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/\[locale\]/e/\[eventId\]/promote/actions.ts test/promote-checkout-action.test.ts
+git commit -m "feat(promote): add createPromotionCheckoutAction server action"
+```
+
+---
+
+## Task 4: i18n messages for the promote page and upsell modal
+
+**Files:**
+- Modify: `messages/ca.json`, `messages/es.json`, `messages/en.json`
+
+**Interfaces:**
+- Produces: `App.EventPromote.*` namespace, `App.Publish.promoteUpsell.*` keys — consumed
+  by Task 5 (promote page) and Task 6 (modal).
+
+- [ ] **Step 1: Add `App.EventPromote` to `messages/ca.json`**
+
+Find the `"EventEdit"` block (line 204) and insert a new `"EventPromote"` block right
+after its closing `},` (before `"PublishPage"` at line 213):
+
+```json
+    "EventPromote": {
+      "title": "Promociona el teu esdeveniment",
+      "description": "Arriba a més gent promocionant el teu esdeveniment a Esdeveniments.cat.",
+      "heading": "Promociona el teu esdeveniment",
+      "subheading": "Destaca't per arribar a més gent i aparèixer als primers llocs.",
+      "benefit1": "Més visibilitat a l'agenda",
+      "benefit2": "Prioritat davant d'altres esdeveniments",
+      "benefit3": "Més persones interessades",
+      "priceLabel": "Preu",
+      "priceNote": "Tarifa plana, pagament únic.",
+      "confirmButton": "Confirma i paga",
+      "confirmButtonLoading": "Redirigint a pagament...",
+      "backToEvent": "Tornar a l'esdeveniment",
+      "errorGeneric": "Alguna cosa ha fallat. Torna-ho a intentar.",
+      "successPage": {
+        "title": "Gràcies!",
+        "subtitle": "El teu esdeveniment ja està promocionat.",
+        "backToEvent": "Veure el teu esdeveniment"
+      },
+      "cancelPage": {
+        "title": "Pagament cancel·lat",
+        "subtitle": "El teu esdeveniment continua sent gratuït.",
+        "backToEvent": "Tornar a l'esdeveniment"
+      }
+    },
+```
+
+- [ ] **Step 2: Add the matching `promoteUpsell` block inside `App.Publish` in `messages/ca.json`**
+
+Find `"sponsorLink": "Veure opcions de patrocini",` inside the `"Publish"` block (line
+315) and add a new `"promoteUpsell"` key right after it:
+
+```json
+      "promoteUpsell": {
+        "title": "Impulsa el teu esdeveniment!",
+        "description": "Promociona el teu esdeveniment ara per arribar a molta més gent i aparèixer als primers llocs de la plataforma.",
+        "promoteButton": "Promocionar esdeveniment",
+        "keepFreeButton": "Mantenir gratuït"
+      },
+```
+
+- [ ] **Step 3: Repeat Steps 1-2 for `messages/es.json`**
+
+`"EventPromote"` block (after the `"EventEdit"` block, same position, line 204 area):
+
+```json
+    "EventPromote": {
+      "title": "Promociona tu evento",
+      "description": "Llega a más gente promocionando tu evento en Esdeveniments.cat.",
+      "heading": "Promociona tu evento",
+      "subheading": "Destaca para llegar a más gente y aparecer en los primeros puestos.",
+      "benefit1": "Más visibilidad en la agenda",
+      "benefit2": "Prioridad frente a otros eventos",
+      "benefit3": "Más personas interesadas",
+      "priceLabel": "Precio",
+      "priceNote": "Tarifa plana, pago único.",
+      "confirmButton": "Confirmar y pagar",
+      "confirmButtonLoading": "Redirigiendo al pago...",
+      "backToEvent": "Volver al evento",
+      "errorGeneric": "Algo ha fallado. Inténtalo de nuevo.",
+      "successPage": {
+        "title": "¡Gracias!",
+        "subtitle": "Tu evento ya está promocionado.",
+        "backToEvent": "Ver tu evento"
+      },
+      "cancelPage": {
+        "title": "Pago cancelado",
+        "subtitle": "Tu evento sigue siendo gratuito.",
+        "backToEvent": "Volver al evento"
+      }
+    },
+```
+
+`"promoteUpsell"` inside `"Publish"` (after `"sponsorLink"`, line 315 area):
+
+```json
+      "promoteUpsell": {
+        "title": "¡Impulsa tu evento!",
+        "description": "Promociona tu evento ahora para llegar a mucha más gente y aparecer en los primeros puestos de la plataforma.",
+        "promoteButton": "Promocionar evento",
+        "keepFreeButton": "Mantener gratis"
+      },
+```
+
+- [ ] **Step 4: Repeat Steps 1-2 for `messages/en.json`**
+
+`"EventPromote"` block:
+
+```json
+    "EventPromote": {
+      "title": "Promote your event",
+      "description": "Reach more people by promoting your event on Esdeveniments.cat.",
+      "heading": "Promote your event",
+      "subheading": "Stand out to reach more people and appear at the top.",
+      "benefit1": "More visibility in the agenda",
+      "benefit2": "Priority over other events",
+      "benefit3": "More interested people",
+      "priceLabel": "Price",
+      "priceNote": "Flat fee, one-time payment.",
+      "confirmButton": "Confirm and pay",
+      "confirmButtonLoading": "Redirecting to payment...",
+      "backToEvent": "Back to event",
+      "errorGeneric": "Something went wrong. Please try again.",
+      "successPage": {
+        "title": "Thank you!",
+        "subtitle": "Your event is now promoted.",
+        "backToEvent": "View your event"
+      },
+      "cancelPage": {
+        "title": "Payment canceled",
+        "subtitle": "Your event remains free.",
+        "backToEvent": "Back to event"
+      }
+    },
+```
+
+`"promoteUpsell"` inside `"Publish"`:
+
+```json
+      "promoteUpsell": {
+        "title": "Boost your event!",
+        "description": "Promote your event now to reach way more people and appear at the top of the platform.",
+        "promoteButton": "Promote Event",
+        "keepFreeButton": "Keep it free"
+      },
+```
+
+- [ ] **Step 5: Validate JSON syntax and key parity across locales**
+
+Run: `yarn i18n:check`
+Expected: PASS (no missingKeys/invalidKeys reported for the new namespaces)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add messages/ca.json messages/es.json messages/en.json
+git commit -m "feat(promote): add i18n messages for event promotion"
+```
+
+---
+
+## Task 5: Promote page (Server Component gate + client component)
+
+**Files:**
+- Create: `app/[locale]/e/[eventId]/promote/page.tsx`
+- Create: `app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx`
+- Test: Create `test/promote-event-client.test.tsx`
+
+**Interfaces:**
+- Consumes: `fetchEventBySlug`, `getCurrentUser` (existing), `createPromotionCheckoutAction`
+  (Task 3), `PromoteEventClientProps` (Task 1).
+- Produces: the `/e/[eventId]/promote` route, rendered `PromoteEventClient` component
+  used by Task 7's E2E flow.
+
+- [ ] **Step 1: Write the failing test for `PromoteEventClient`**
+
+Create `test/promote-event-client.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockCreatePromotionCheckoutAction = vi.fn();
+const mockUseLocale = vi.fn(() => "ca");
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+  useLocale: () => mockUseLocale(),
+}));
+
+vi.mock("../app/[locale]/e/[eventId]/promote/actions", () => ({
+  createPromotionCheckoutAction: (eventId: string, slug: string, locale: string) =>
+    mockCreatePromotionCheckoutAction(eventId, slug, locale),
+}));
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // @ts-expect-error -- overriding a readonly for the test
+  delete window.location;
+  // @ts-expect-error -- test-only stub
+  window.location = { href: "" };
+});
+
+afterEach(() => {
+  window.location = originalLocation;
+});
+
+import PromoteEventClient from "../app/[locale]/e/[eventId]/promote/PromoteEventClient";
+
+describe("PromoteEventClient", () => {
+  it("redirects to the returned Stripe url on success", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: true,
+      url: "https://checkout.stripe.com/session123",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("https://checkout.stripe.com/session123");
+    });
+  });
+
+  it("shows a generic error and does not redirect when the action fails", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(window.location.href).toBe("");
+  });
+
+  it("rejects a non-https url instead of redirecting", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: true,
+      url: "/undefined",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(window.location.href).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test test/promote-event-client.test.tsx`
+Expected: FAIL (module not found: `PromoteEventClient`)
+
+- [ ] **Step 3: Implement `PromoteEventClient`**
+
+Create `app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { Link } from "@i18n/routing";
+import { ArrowLeftIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import Button from "@components/ui/common/button";
+import type { AppLocale } from "types/i18n";
+import type { PromoteEventClientProps } from "types/props";
+import { createPromotionCheckoutAction } from "./actions";
+
+// MVP flat fee — static per design doc; a real pricing config is a follow-up
+// once the backend's pricing methodology is decided.
+const FLAT_FEE_EUR = 5;
+
+function isValidCheckoutUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export default function PromoteEventClient({
+  eventId,
+  slug,
+}: PromoteEventClientProps) {
+  const t = useTranslations("App.EventPromote");
+  const locale = useLocale() as AppLocale;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setError(null);
+    setIsSubmitting(true);
+
+    const result = await createPromotionCheckoutAction(eventId, slug, locale);
+
+    if (!result.success) {
+      setError(t("errorGeneric"));
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (!isValidCheckoutUrl(result.url)) {
+      console.error("PromoteEventClient: invalid checkout url", result.url);
+      setError(t("errorGeneric"));
+      setIsSubmitting(false);
+      return;
+    }
+
+    window.location.href = result.url;
+  };
+
+  return (
+    <div className="container max-w-2xl mx-auto py-section-y px-section-x">
+      <Link
+        href={`/e/${slug}`}
+        className="inline-flex items-center gap-1 body-small text-foreground/70 hover:text-foreground mb-4"
+      >
+        <ArrowLeftIcon className="w-4 h-4" />
+        {t("backToEvent")}
+      </Link>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2 text-center">
+          <h1 className="heading-1 text-foreground-strong">{t("heading")}</h1>
+          <p className="body-large text-foreground/80">{t("subheading")}</p>
+        </div>
+
+        <div className="card-bordered card-body space-y-3">
+          <ul className="flex flex-col gap-2 body-normal text-foreground/80">
+            <li className="flex items-center gap-2">
+              <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" />
+              {t("benefit1")}
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" />
+              {t("benefit2")}
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircleIcon className="w-5 h-5 text-primary flex-shrink-0" />
+              {t("benefit3")}
+            </li>
+          </ul>
+        </div>
+
+        <div className="card-bordered card-body flex items-center justify-between">
+          <span className="body-normal text-foreground/70">{t("priceLabel")}</span>
+          <span className="heading-2 text-foreground-strong">{FLAT_FEE_EUR}€</span>
+        </div>
+        <p className="body-small text-foreground/60 -mt-4">{t("priceNote")}</p>
+
+        {error && (
+          <div
+            className="w-full px-4 py-3 bg-error/10 border border-error rounded-lg"
+            role="alert"
+          >
+            <p className="text-sm font-medium text-error">{error}</p>
+          </div>
+        )}
+
+        <Button
+          type="button"
+          variant="primary"
+          className="w-full min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={isSubmitting}
+          data-testid="promote-confirm-button"
+          onClick={handleConfirm}
+        >
+          {isSubmitting ? t("confirmButtonLoading") : t("confirmButton")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test test/promote-event-client.test.tsx`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Implement the Server Component page**
+
+Create `app/[locale]/e/[eventId]/promote/page.tsx`:
+
+```tsx
+import { notFound } from "next/navigation";
+import { locale as rootLocale } from "next/root-params";
+import { getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
+import { siteUrl } from "@config/index";
+import { withLocalePath } from "@utils/i18n-seo";
+import type { AppLocale } from "types/i18n";
+import { fetchEventBySlug } from "lib/api/events";
+import { getCurrentUser } from "@lib/auth/session";
+import PromoteEventClient from "./PromoteEventClient";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}): Promise<Metadata> {
+  const { eventId } = await params;
+  const locale = (await rootLocale()) as AppLocale;
+  const t = await getTranslations({ locale, namespace: "App.EventPromote" });
+  const canonical = `${siteUrl}${withLocalePath(`/e/${eventId}/promote`, locale)}`;
+  return {
+    title: t("title"),
+    description: t("description"),
+    robots: "noindex, nofollow",
+    alternates: { canonical },
+  };
+}
+
+export default async function PromotePage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const slug = (await params).eventId;
+  const [event, currentUser] = await Promise.all([
+    fetchEventBySlug(slug),
+    getCurrentUser(),
+  ]);
+
+  // Only the event creator may promote it. Treat missing/unknown ownership as
+  // 404 to avoid leaking the existence of the promote page — same convention
+  // as the edita page's ownership gate.
+  const currentUserId = currentUser?.id;
+  const isCreator = Boolean(currentUserId) && currentUserId === event?.owner?.id;
+  if (!event || !isCreator) return notFound();
+
+  return <PromoteEventClient eventId={event.id} slug={event.slug} />;
+}
+```
+
+- [ ] **Step 6: Run full test suite and typecheck**
+
+Run: `yarn typecheck && yarn test test/promote-event-client.test.tsx test/promote-checkout-action.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/\[locale\]/e/\[eventId\]/promote/page.tsx app/\[locale\]/e/\[eventId\]/promote/PromoteEventClient.tsx test/promote-event-client.test.tsx
+git commit -m "feat(promote): add /e/[eventId]/promote page"
+```
+
+---
+
+## Task 6: Success and cancel return pages
+
+**Files:**
+- Create: `app/[locale]/e/[eventId]/promote/success/page.tsx`
+- Create: `app/[locale]/e/[eventId]/promote/cancel/page.tsx`
+- Test: none (static pages; covered by the typecheck/lint gate and manual verification
+  in Task 9)
+
+**Interfaces:**
+- Consumes: `App.EventPromote.successPage.*` / `App.EventPromote.cancelPage.*` (Task 4).
+- Produces: the two return routes that `successUrl`/`cancelUrl` (Task 3) point to.
+
+- [ ] **Step 1: Implement the success page**
+
+Create `app/[locale]/e/[eventId]/promote/success/page.tsx`:
+
+```tsx
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { locale as rootLocale } from "next/root-params";
+import type { AppLocale } from "types/i18n";
+import { Link } from "@i18n/routing";
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = (await rootLocale()) as AppLocale;
+  const t = await getTranslations({ locale, namespace: "App.EventPromote.successPage" });
+  return {
+    title: t("title"),
+    description: t("subtitle"),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function PromoteSuccessPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId: slug } = await params;
+  const locale = (await rootLocale()) as AppLocale;
+  setRequestLocale(locale);
+  const t = await getTranslations("App.EventPromote.successPage");
+
+  return (
+    <main className="min-h-screen bg-background py-section-y px-section-x">
+      <div className="max-w-2xl mx-auto text-center space-y-6">
+        <div className="flex justify-center">
+          <CheckCircleIcon className="h-16 w-16 text-success" />
+        </div>
+        <h1 className="heading-1">{t("title")}</h1>
+        <p className="body-large text-foreground/80">{t("subtitle")}</p>
+
+        <div className="flex justify-center">
+          <Link href={`/e/${slug}`} className="btn-primary">
+            {t("backToEvent")}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Implement the cancel page**
+
+Create `app/[locale]/e/[eventId]/promote/cancel/page.tsx`:
+
+```tsx
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { locale as rootLocale } from "next/root-params";
+import type { AppLocale } from "types/i18n";
+import { Link } from "@i18n/routing";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = (await rootLocale()) as AppLocale;
+  const t = await getTranslations({ locale, namespace: "App.EventPromote.cancelPage" });
+  return {
+    title: t("title"),
+    description: t("subtitle"),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function PromoteCancelPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId: slug } = await params;
+  const locale = (await rootLocale()) as AppLocale;
+  setRequestLocale(locale);
+  const t = await getTranslations("App.EventPromote.cancelPage");
+
+  return (
+    <main className="min-h-screen bg-background py-section-y px-section-x">
+      <div className="max-w-2xl mx-auto text-center space-y-6">
+        <h1 className="heading-1">{t("title")}</h1>
+        <p className="body-large text-foreground/80">{t("subtitle")}</p>
+
+        <div className="flex justify-center">
+          <Link href={`/e/${slug}`} className="btn-outline">
+            {t("backToEvent")}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/\[locale\]/e/\[eventId\]/promote/success/page.tsx app/\[locale\]/e/\[eventId\]/promote/cancel/page.tsx
+git commit -m "feat(promote): add promotion success and cancel return pages"
+```
+
+---
+
+## Task 7: Owner-only "Promote" entry point on the event detail page
+
+**Files:**
+- Create: `app/[locale]/e/[eventId]/components/EventPromoteAction.tsx`
+- Modify: `app/[locale]/e/[eventId]/components/EventSidebar.tsx:136`
+- Test: Create `test/event-promote-action.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAuth()` (existing), `EventPromoteActionProps` (Task 1).
+- Produces: `EventPromoteAction` component, rendered inside `EventSidebar`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/event-promote-action.test.tsx` (mirrors `test/event-edit-action.test.tsx`
+exactly):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { AuthUser } from "types/auth";
+
+const OWNER_ID = "e10c6a5f-306c-487f-9e71-876f67c7bbb2";
+const OTHER_USER_ID = "different-user-uuid";
+
+let authUser: AuthUser | null = null;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@i18n/routing", () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@heroicons/react/24/outline", () => ({
+  MegaphoneIcon: () => <svg data-testid="megaphone-icon" />,
+}));
+
+vi.mock("@components/hooks/useAuth", () => ({
+  useAuth: () => ({ user: authUser }),
+}));
+
+import EventPromoteAction from "@app/[locale]/e/[eventId]/components/EventPromoteAction";
+
+describe("EventPromoteAction", () => {
+  beforeEach(() => {
+    authUser = null;
+  });
+
+  it("shows the promote link when the signed-in user owns the event", () => {
+    authUser = { id: OWNER_ID, email: "a@b.com", name: "A", username: "a" };
+    render(<EventPromoteAction ownerId={OWNER_ID} slug="my-event" />);
+
+    const link = screen.getByTestId("event-promote-link");
+    expect(link.getAttribute("href")).toBe("/e/my-event/promote");
+  });
+
+  it("renders nothing when the signed-in user is not the owner", () => {
+    authUser = { id: OTHER_USER_ID, email: "b@c.com", name: "B", username: "b" };
+    render(<EventPromoteAction ownerId={OWNER_ID} slug="my-event" />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+
+  it("renders nothing when logged out", () => {
+    authUser = null;
+    render(<EventPromoteAction ownerId={OWNER_ID} slug="my-event" />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+
+  it("renders nothing when the event has no owner (e.g. scraped/RSS events)", () => {
+    authUser = { id: OWNER_ID, email: "a@b.com", name: "A", username: "a" };
+    render(<EventPromoteAction ownerId={undefined} slug="my-event" />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test test/event-promote-action.test.tsx`
+Expected: FAIL (module not found: `EventPromoteAction`)
+
+- [ ] **Step 3: Implement `EventPromoteAction`**
+
+Create `app/[locale]/e/[eventId]/components/EventPromoteAction.tsx`:
+
+```tsx
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link } from "@i18n/routing";
+import { MegaphoneIcon } from "@heroicons/react/24/outline";
+import { useAuth } from "@components/hooks/useAuth";
+import type { EventPromoteActionProps } from "types/props";
+
+/**
+ * Owner-only promote link for the event detail sidebar. Client-side check
+ * (not a server-side getCurrentUser() call) so a page view doesn't pay for
+ * a backend enrichment round-trip just to decide whether to show this link —
+ * mirrors EventEditAction exactly.
+ */
+export default function EventPromoteAction({
+  ownerId,
+  slug,
+}: EventPromoteActionProps) {
+  const { user } = useAuth();
+  const t = useTranslations("Components.EventPage");
+
+  if (!ownerId || user?.id !== ownerId) return null;
+
+  return (
+    <Link
+      href={`/e/${slug}/promote`}
+      className="inline-flex items-center gap-2 btn-outline btn-sm"
+      data-testid="event-promote-link"
+    >
+      <MegaphoneIcon className="w-4 h-4" aria-hidden="true" />
+      {t("promoteEvent")}
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4: Add the `promoteEvent` translation key**
+
+Add `"promoteEvent"` next to `"editEvent"` in `Components.EventPage` in all three
+`messages/*.json` files:
+
+`messages/ca.json` (next to line 916): `"promoteEvent": "Promocionar",`
+`messages/es.json` (next to line 908): `"promoteEvent": "Promocionar",`
+`messages/en.json` (next to line 908): `"promoteEvent": "Promote",`
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn test test/event-promote-action.test.tsx`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Render `EventPromoteAction` in `EventSidebar`**
+
+In `app/[locale]/e/[eventId]/components/EventSidebar.tsx`, add the import next to the
+existing `EventEditAction` import (line 16):
+
+```tsx
+import EventEditAction from "./EventEditAction";
+import EventPromoteAction from "./EventPromoteAction";
+```
+
+Then render it right after `EventEditAction` at line 136:
+
+```tsx
+            {/* Owner-only edit action */}
+            <EventEditAction ownerId={event.owner?.id} slug={event.slug ?? ""} />
+            <EventPromoteAction ownerId={event.owner?.id} slug={event.slug ?? ""} />
+```
+
+- [ ] **Step 7: Run i18n check, typecheck, lint**
+
+Run: `yarn i18n:check && yarn typecheck && yarn lint`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/\[locale\]/e/\[eventId\]/components/EventPromoteAction.tsx app/\[locale\]/e/\[eventId\]/components/EventSidebar.tsx test/event-promote-action.test.tsx messages/ca.json messages/es.json messages/en.json
+git commit -m "feat(promote): add owner-only Promote entry point on event detail page"
+```
+
+---
+
+## Task 8: Post-publish upsell modal
+
+**Files:**
+- Create: `app/[locale]/publica/PromoteUpsellModal.tsx`
+- Modify: `app/[locale]/publica/page.tsx` (splice into `onSubmit`'s success path)
+- Test: Create `test/promote-upsell-modal.test.tsx`
+
+**Interfaces:**
+- Consumes: `Modal` (`components/ui/common/modal`), `PromoteUpsellModalProps` (Task 1),
+  `sendGoogleEvent` (`@utils/analytics`).
+- Produces: modal shown right after `createEventAction` succeeds in `publica/page.tsx`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/promote-upsell-modal.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const mockPush = vi.fn();
+vi.mock("@i18n/routing", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Minimal Modal stub mirroring the real component's close/actionButton contract:
+// calls setOpen(false) after onActionButtonClick resolves, unless it returns false.
+vi.mock("@components/ui/common/modal", () => ({
+  __esModule: true,
+  default: ({
+    open,
+    setOpen,
+    title,
+    children,
+    actionButton,
+    onActionButtonClick,
+  }: {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    title: string;
+    children: ReactNode;
+    actionButton?: ReactNode;
+    onActionButtonClick?: () => boolean | void | Promise<boolean | void>;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        {children}
+        {actionButton && (
+          <button
+            data-testid="modal-action-button"
+            onClick={async () => {
+              const result = await onActionButtonClick?.();
+              if (result !== false) setOpen(false);
+            }}
+          >
+            {actionButton}
+          </button>
+        )}
+      </div>
+    );
+  },
+}));
+
+import PromoteUpsellModal from "../app/[locale]/publica/PromoteUpsellModal";
+
+describe("PromoteUpsellModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates to the promote page and keeps working even if Modal also calls setOpen", () => {
+    const setOpen = vi.fn();
+    render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("modal-action-button"));
+
+    expect(mockPush).toHaveBeenCalledWith("/e/my-event/promote");
+  });
+
+  it("navigates to the event detail page and closes the modal on 'keep it free'", () => {
+    const setOpen = vi.fn();
+    render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("promote-modal-keep-free"));
+
+    expect(setOpen).toHaveBeenCalledWith(false);
+    expect(mockPush).toHaveBeenCalledWith("/e/my-event");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test test/promote-upsell-modal.test.tsx`
+Expected: FAIL (module not found: `PromoteUpsellModal`)
+
+- [ ] **Step 3: Implement `PromoteUpsellModal`**
+
+Create `app/[locale]/publica/PromoteUpsellModal.tsx`:
+
+```tsx
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useRouter } from "@i18n/routing";
+import Modal from "@components/ui/common/modal";
+import Button from "@components/ui/common/button";
+import { sendGoogleEvent } from "@utils/analytics";
+import type { PromoteUpsellModalProps } from "types/props";
+
+export default function PromoteUpsellModal({
+  open,
+  setOpen,
+  slug,
+}: PromoteUpsellModalProps) {
+  const t = useTranslations("App.Publish.promoteUpsell");
+  const router = useRouter();
+
+  const handlePromote = () => {
+    sendGoogleEvent("promote_modal_cta_click", {
+      event_slug: slug,
+      source: "publica",
+    });
+    router.push(`/e/${slug}/promote`);
+    // Explicitly returning false stops Modal's own setOpen(false) from racing
+    // this navigation — see the design doc's "Modal" section for why this
+    // matters (Modal calls setOpen(false) automatically unless told not to).
+    return false;
+  };
+
+  const handleKeepFree = () => {
+    sendGoogleEvent("promote_modal_dismiss", {
+      event_slug: slug,
+      source: "publica",
+    });
+    setOpen(false);
+    router.push(`/e/${slug}`);
+  };
+
+  return (
+    <Modal
+      open={open}
+      setOpen={setOpen}
+      title={t("title")}
+      actionButton={t("promoteButton")}
+      onActionButtonClick={handlePromote}
+      testId="promote-upsell-modal"
+    >
+      <div className="flex flex-col gap-4 py-4">
+        <p className="body-normal text-foreground/80">{t("description")}</p>
+        <Button
+          type="button"
+          variant="neutral"
+          className="btn-outline w-full"
+          data-testid="promote-modal-keep-free"
+          onClick={handleKeepFree}
+        >
+          {t("keepFreeButton")}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn test test/promote-upsell-modal.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Splice the modal into `publica/page.tsx`**
+
+In `app/[locale]/publica/page.tsx`, add the import next to the other colocated imports
+(near line 39, after `CompleteProfileGate`):
+
+```tsx
+import CompleteProfileGate from "./CompleteProfileGate";
+import PromoteUpsellModal from "./PromoteUpsellModal";
+```
+
+Add a new state variable inside `PublishForm`, near the other `showPreview`/`showCompleteProfileGate`
+state (around line 135, after `showCompleteProfileGate`):
+
+```tsx
+  const [showCompleteProfileGate, setShowCompleteProfileGate] = useState(false);
+  const [publishedSlug, setPublishedSlug] = useState<string | null>(null);
+```
+
+Replace the success-path tail of `onSubmit` (currently lines 606-625):
+
+```tsx
+        const { slug } = event;
+        if (typeof document !== "undefined") {
+          document.body.dataset.lastE2eSlug = slug;
+        }
+        if (typeof window !== "undefined") {
+          window.__LAST_E2E_PUBLISH_SLUG__ = slug;
+        }
+
+        sendGoogleEvent("publish_success", {
+          ...buildPublishContext({
+            form,
+            imageFile,
+            uploadedImageUrl: resolvedImageUrl,
+          }),
+          source: "publica",
+          has_slug: Boolean(slug),
+        });
+
+        submittedRef.current = true;
+        router.push(`/e/${slug}`);
+```
+
+with:
+
+```tsx
+        const { slug } = event;
+        if (typeof document !== "undefined") {
+          document.body.dataset.lastE2eSlug = slug;
+        }
+        if (typeof window !== "undefined") {
+          window.__LAST_E2E_PUBLISH_SLUG__ = slug;
+        }
+
+        sendGoogleEvent("publish_success", {
+          ...buildPublishContext({
+            form,
+            imageFile,
+            uploadedImageUrl: resolvedImageUrl,
+          }),
+          source: "publica",
+          has_slug: Boolean(slug),
+        });
+
+        submittedRef.current = true;
+        sendGoogleEvent("promote_modal_shown", {
+          event_slug: slug,
+          source: "publica",
+        });
+        setPublishedSlug(slug);
+```
+
+Add the modal render right before the closing `</>` of the returned JSX (after the
+`EventForm` block, near line 815, still inside the same top-level fragment as the
+existing preview `Modal`):
+
+```tsx
+      {publishedSlug && (
+        <PromoteUpsellModal
+          open={Boolean(publishedSlug)}
+          setOpen={(open) => {
+            if (!open) setPublishedSlug(null);
+          }}
+          slug={publishedSlug}
+        />
+      )}
+```
+
+- [ ] **Step 6: Run typecheck and the full unit suite**
+
+Run: `yarn typecheck && yarn test`
+Expected: PASS (all suites, including the new ones)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/\[locale\]/publica/PromoteUpsellModal.tsx app/\[locale\]/publica/page.tsx test/promote-upsell-modal.test.tsx
+git commit -m "feat(promote): show post-publish promotion upsell modal"
+```
+
+---
+
+## Task 9: Update the E2E publish-integration spec for the new modal
+
+**Files:**
+- Modify: `e2e/publish-integration.spec.ts:288-294`
+
+**Interfaces:**
+- Consumes: `promote-upsell-modal` testId (`testId="promote-upsell-modal"` from Task 8,
+  which `Modal` forwards as `data-testid`), `promote-modal-keep-free` testId.
+
+- [ ] **Step 1: Replace the racing assertion**
+
+In `e2e/publish-integration.spec.ts`, find this block (lines 288-294):
+
+```ts
+    // Start waiting before the click so the redirect cannot race the assertion.
+    await Promise.all([
+      page.waitForURL((url) => !url.pathname.includes("/publica"), {
+        timeout: 60_000,
+      }),
+      publishButton.click(),
+    ]);
+```
+
+Replace it with:
+
+```ts
+    // Publishing now shows the post-publish promotion upsell modal instead of
+    // an immediate redirect. Wait for the modal, then dismiss via "keep it
+    // free" (the existing test's intent: verify the plain publish → detail
+    // page path still works).
+    await publishButton.click();
+    const upsellModal = page.getByTestId("promote-upsell-modal");
+    await expect(upsellModal).toBeVisible({ timeout: 30_000 });
+
+    await Promise.all([
+      page.waitForURL((url) => !url.pathname.includes("/publica"), {
+        timeout: 60_000,
+      }),
+      page.getByTestId("promote-modal-keep-free").click(),
+    ]);
+```
+
+- [ ] **Step 2: Add a second test for the "Promote Event" path**
+
+After the closing `});` of the existing `test("login → publish event → verify detail page
+shows creator", ...)` test (just before the final `});` that closes `test.describe`), add:
+
+```ts
+  test("login → publish event → promote upsell links to the promote page", async ({
+    page,
+  }) => {
+    await loginViaUI(page, email!, password!);
+    await expect(page.getByTestId("user-avatar-button")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.goto("/en/publica", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+
+    const form = page.getByTestId("event-form");
+    await expect(form).toBeVisible({ timeout: 30_000 });
+    await expect(form).toHaveAttribute("data-hydrated", "true", {
+      timeout: 30_000,
+    });
+
+    const promoteTestTitle = `${TEST_EVENT_TITLE} Promote`;
+    await page.locator("#title").fill(promoteTestTitle);
+    await page.locator("#description").fill(
+      `Automated E2E test event for promote flow, created at ${new Date().toISOString()}. Safe to delete.`
+    );
+    await page.locator("#url").fill("https://example.com/e2e-test-promote");
+    await page.getByTestId("next-button").click();
+
+    const townSelect = page.getByTestId("town-select");
+    await expect(townSelect).toBeVisible({ timeout: 15_000 });
+    await townSelect.click();
+    await page.keyboard.type("Barcelona");
+    const townOption = page
+      .locator('[role="listbox"]:visible')
+      .getByRole("option")
+      .first();
+    await expect(townOption).toBeVisible({ timeout: 15_000 });
+    await townOption.click();
+    await page.locator("#location").fill("Test Venue - E2E Promote");
+
+    const categoriesSelect = page.locator("#categories").locator("..");
+    await categoriesSelect.click();
+    const categoryOption = page
+      .locator('[role="listbox"]:visible')
+      .getByRole("option")
+      .first();
+    await expect(categoryOption).toBeVisible({ timeout: 15_000 });
+    await categoryOption.click();
+    await page.getByTestId("next-button").click();
+
+    const imageUrlTab = page.getByRole("button", { name: /url|enllaç/i });
+    if (await imageUrlTab.isVisible()) {
+      await imageUrlTab.click();
+    }
+    const imageUrlInput = page.locator('input[placeholder*="http"]').first();
+    if (await imageUrlInput.isVisible()) {
+      await imageUrlInput.fill("https://picsum.photos/800/600");
+    }
+
+    const futureDateIso = await page.evaluate(() => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 2);
+      return [
+        futureDate.getFullYear(),
+        String(futureDate.getMonth() + 1).padStart(2, "0"),
+        String(futureDate.getDate()).padStart(2, "0"),
+      ].join("-");
+    });
+    const datePickerPlaceholder = page.getByRole("button", {
+      name: /select date and time|seleccionar data i hora/i,
+    });
+    const startDateButton = page.getByRole("button", { name: /^(Start|Inici):/ });
+    await expect(datePickerPlaceholder.or(startDateButton)).toBeVisible({
+      timeout: 15_000,
+    });
+    if (await datePickerPlaceholder.isVisible().catch(() => false)) {
+      await datePickerPlaceholder.focus();
+    }
+    await expect(startDateButton).toBeVisible({ timeout: 15_000 });
+    await startDateButton.click();
+    const futureDateButton = page.locator(`[data-day="${futureDateIso}"]`);
+    await expect(futureDateButton).toBeVisible({ timeout: 15_000 });
+    await futureDateButton.click();
+
+    const publishButton = page.getByTestId("publish-button");
+    await expect(publishButton).toBeVisible({ timeout: 10_000 });
+    await expect(publishButton).toHaveAttribute("data-publish-ready", "true", {
+      timeout: 10_000,
+    });
+    await publishButton.click();
+
+    const upsellModal = page.getByTestId("promote-upsell-modal");
+    await expect(upsellModal).toBeVisible({ timeout: 30_000 });
+
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.includes("/promote"), {
+        timeout: 30_000,
+      }),
+      page.getByTestId("promote-upsell-modal-action-button").click(),
+    ]);
+
+    expect(page.url()).toContain("/promote");
+
+    // Cleanup: this test creates its own event, separate from the suite-level
+    // afterAll cleanup which only tracks TEST_EVENT_TITLE (not this variant).
+    const currentUrl = page.url();
+    const slugMatch = currentUrl.match(/\/e\/([^/]+)\/promote/);
+    if (slugMatch) {
+      const promoteEventId = await findCreatedEventId(page, promoteTestTitle);
+      if (promoteEventId) await cleanupEvent(page, promoteEventId);
+    }
+  });
+```
+
+Note: `promote-upsell-modal-action-button` is the `data-testid` the shared `Modal`
+component derives from `testId` — confirmed in `components/ui/common/modal/index.tsx`:
+`data-testid={testId ? \`${testId}-action-button\` : undefined}` on its action button.
+
+- [ ] **Step 3: Verify the spec file still typechecks**
+
+Run: `yarn typecheck`
+Expected: PASS
+
+Note: this spec only runs against real staging credentials
+(`E2E_STAGING_EMAIL`/`E2E_STAGING_PASSWORD`), so it cannot be executed locally without
+them — typecheck is the practical verification step here, plus manual review against
+Task 8's testIds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/publish-integration.spec.ts
+git commit -m "test(e2e): update publish-integration spec for promotion upsell modal"
+```
+
+---
+
+## Task 10: Full verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run: `yarn test`
+Expected: PASS — all suites green, including every new test file from Tasks 2, 3, 5, 7, 8
+
+- [ ] **Step 2: Typecheck**
+
+Run: `yarn typecheck`
+Expected: PASS with zero errors
+
+- [ ] **Step 3: Lint**
+
+Run: `yarn lint`
+Expected: PASS with zero errors (pre-existing warnings acceptable per repo convention)
+
+- [ ] **Step 4: i18n key parity check**
+
+Run: `yarn i18n:check`
+Expected: PASS — no missingKeys/invalidKeys across `ca`/`es`/`en` for any new namespace
+
+- [ ] **Step 5: Manual browser verification**
+
+Start the dev server (`yarn dev`), then manually:
+1. Log in, publish a test event, confirm the upsell modal appears with the correct copy.
+2. Click "Keep it free" — confirm it closes the modal and lands on `/e/[slug]`.
+3. Publish another event, click "Promote Event" — confirm it lands on
+   `/e/[slug]/promote` with benefits, the €5 price, and a working "Confirm and Pay"
+   button (this will hit the real backend endpoint, which does not exist yet, so expect
+   and verify the generic error message renders cleanly rather than a broken page).
+4. Visit an existing event you own — confirm the new "Promote" button appears in the
+   sidebar next to "Edit", and that it's absent for events you don't own or when logged
+   out.
+5. Navigate directly to `/e/[slug]/promote/success` and `/e/[slug]/promote/cancel` —
+   confirm both render cleanly with a working "back to event" link.
+
+- [ ] **Step 6: Final commit (if manual verification surfaced fixes)**
+
+```bash
+git add -A
+git commit -m "fix(promote): address issues found in manual verification"
+```
+
+(Skip this commit if no fixes were needed.)
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** All five in-scope items from the design doc are covered — modal
+(Task 8), promote page (Task 5), Server Action integration (Tasks 2-3), success/cancel
+pages (Task 6), analytics (woven into Tasks 5 and 8). The event-detail entry point added
+during review is Task 7. Out-of-scope items (pricing lookup, duplicate-checkout guard,
+list sorting, non-owner promotion, webhook/Stripe SDK) are deliberately absent from every
+task.
+
+**Type consistency:** `PromotionCheckoutResult` (Task 1) is used identically in Task 3's
+action signature and Task 5's client component — checked. `EventPromoteActionProps` (Task
+1) matches `EventEditActionProps`'s shape exactly, used consistently in Task 7.
+`PromoteUpsellModalProps` (Task 1) matches the props Task 8's component and test actually
+destructure.
+
+**No placeholders:** every step has complete, concrete code — no TBD/TODO markers, no
+"add appropriate error handling" prose without an implementation.

--- a/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
+++ b/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
@@ -1,0 +1,704 @@
+# Promoted Events Carousel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a "Promoted events" carousel on the homepage and on every event listing
+page, sourced from a new isolated, feature-flagged, fail-soft data fetch, reusing the
+existing `EventsAroundServer` carousel engine end to end.
+
+**Architecture:** One new isolated fetch function (`getActivePromotedEvents`) gated behind
+`PROMOTED_EVENTS_ENABLED` (default off, since the real backend endpoint doesn't exist yet).
+One new server component (`PromotedEventsSection`) that calls it and renders nothing on
+empty. One new optional prop (`isPromoted`) threaded through the existing
+`EventsAroundServer` → `CardHorizontalServer` chain for a "Promoted" disclosure badge. Two
+insertion points: `serverEventsCategorized/index.tsx` (homepage) and `PlacePageShell.tsx`
+(every listing page).
+
+**Tech Stack:** Next.js App Router (Server Components), TypeScript, Vitest, next-intl,
+Tailwind (DESIGN.md tokens only).
+
+## Global Constraints
+
+- Reuse `badge-primary` (DESIGN.md token) for the "Promoted" badge — do not invent a new
+  color. Precedent: `components/ui/restaurantPromotion/PromotedRestaurantCard.tsx:36`.
+- `PromotionScope`'s place-type variants are `"town" | "region"` (this codebase's own
+  `PlaceType` vocabulary, not "comarca").
+- `getActivePromotedEvents` must not make a network call when
+  `process.env.PROMOTED_EVENTS_ENABLED !== "true"` — return `[]` immediately.
+- No `captureException`/Sentry wiring for this fetch's failures — `console.warn` only.
+- No changes to the phase-1 checkout flow, pricing config, or `/e/[eventId]/promote` page.
+- `yarn typecheck && yarn lint` must pass before every commit.
+- Spec: `docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md`.
+
+---
+
+### Task 1: `getActivePromotedEvents` data-fetch function
+
+**Files:**
+- Create: `lib/api/promotedEvents.ts`
+- Test: `test/lib/api/promotedEvents.test.ts`
+
+**Interfaces:**
+- Produces: `export type PromotionScope = { type: "homepage" } | { type: "town" | "region"; slug: string }`
+- Produces: `export async function getActivePromotedEvents(scope: PromotionScope): Promise<EventSummaryResponseDTO[]>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// test/lib/api/promotedEvents.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fetchWithHmacMock = vi.fn();
+vi.mock("@lib/api/fetch-wrapper", () => ({
+  fetchWithHmac: (...args: unknown[]) => fetchWithHmacMock(...args),
+}));
+
+import { getActivePromotedEvents } from "@lib/api/promotedEvents";
+
+const originalEnv = process.env.PROMOTED_EVENTS_ENABLED;
+
+describe("getActivePromotedEvents", () => {
+  beforeEach(() => {
+    fetchWithHmacMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.PROMOTED_EVENTS_ENABLED = originalEnv;
+  });
+
+  it("returns [] with no network call when the feature flag is off", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "false";
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toEqual([]);
+    expect(fetchWithHmacMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] with no network call when the flag is unset", async () => {
+    delete process.env.PROMOTED_EVENTS_ENABLED;
+    const result = await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+    expect(result).toEqual([]);
+    expect(fetchWithHmacMock).not.toHaveBeenCalled();
+  });
+
+  it("builds the right query string for a homepage scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [] }),
+    });
+    await getActivePromotedEvents({ type: "homepage" });
+    const [url] = fetchWithHmacMock.mock.calls[0];
+    expect(url).toContain("scope=homepage");
+    expect(url).not.toContain("slug=");
+  });
+
+  it("builds the right query string for a town scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [] }),
+    });
+    await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+    const [url] = fetchWithHmacMock.mock.calls[0];
+    expect(url).toContain("scope=town");
+    expect(url).toContain("slug=cardedeu");
+  });
+
+  it("returns [] (not a throw) on a non-2xx response", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "not found",
+    });
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] (not a throw) when fetchWithHmac rejects", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockRejectedValue(new Error("network down"));
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toEqual([]);
+  });
+
+  it("caps results at MAX_PROMOTED_EVENTS", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const content = Array.from({ length: 20 }, (_, i) => ({
+      id: `event-${i}`,
+      hash: `hash-${i}`,
+      slug: `event-${i}`,
+      title: `Event ${i}`,
+      type: "FREE",
+      url: "https://example.com",
+      description: "",
+      imageUrl: "https://example.com/img.jpg",
+      startDate: "2099-01-01",
+      startTime: null,
+      endDate: "2099-01-01",
+      endTime: null,
+      location: "Barcelona",
+      visits: 0,
+      origin: "MANUAL",
+      categories: [],
+    }));
+    fetchWithHmacMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content }),
+    });
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toHaveLength(8);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn vitest run test/lib/api/promotedEvents.test.ts`
+Expected: FAIL — `Cannot find module '@lib/api/promotedEvents'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// lib/api/promotedEvents.ts
+import type { z } from "zod";
+import { fetchWithHmac } from "./fetch-wrapper";
+import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
+import {
+  EventSummaryResponseDTOSchema,
+  enhanceEventImage,
+} from "@lib/validation/event";
+import type { EventSummaryResponseDTO } from "types/api/event";
+import type { PromotionScope } from "types/event";
+
+const MAX_PROMOTED_EVENTS = 8;
+
+function buildScopeQuery(scope: PromotionScope): string {
+  const params = new URLSearchParams({ scope: scope.type });
+  if (scope.type !== "homepage") {
+    params.set("slug", scope.slug);
+  }
+  return params.toString();
+}
+
+/**
+ * Provisional, isolated contract: the backend endpoint this calls does not exist yet
+ * (Gerard's promotion-checkout endpoint shipped in phase 1; the "list active promoted
+ * events" read side is still undecided). A field-name or shape mismatch once it ships
+ * is a one-file fix, confined to this function.
+ */
+export async function getActivePromotedEvents(
+  scope: PromotionScope,
+): Promise<EventSummaryResponseDTO[]> {
+  if (process.env.PROMOTED_EVENTS_ENABLED !== "true") {
+    return [];
+  }
+
+  if (!isApiUrlConfigured()) {
+    return [];
+  }
+
+  try {
+    const apiUrl = getApiUrl();
+    const finalUrl = `${apiUrl}/events/promotions/active?${buildScopeQuery(scope)}`;
+
+    // NEVER add `next: { revalidate, tags }` here — external wrappers must not opt
+    // into the Next fetch cache (high-cardinality per-scope URLs caused a 146k-entry
+    // cache explosion, see docs/incidents/2026-01-20-fetch-cache-explosion.md).
+    const response = await fetchWithHmac(finalUrl, {
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `getActivePromotedEvents: HTTP ${response.status} for ${finalUrl}`,
+      );
+      return [];
+    }
+
+    const data = await response.json();
+    const content = Array.isArray(data?.content) ? data.content : [];
+
+    // Validate each item individually rather than the array atomically — one
+    // malformed item (wherever it falls in the response) should be dropped,
+    // not discard every valid promotion alongside it.
+    const events: EventSummaryResponseDTO[] = [];
+    let invalidCount = 0;
+    let firstError: z.ZodError | undefined;
+    for (const item of content) {
+      const parsed = EventSummaryResponseDTOSchema.safeParse(item);
+      if (parsed.success) {
+        events.push(parsed.data as EventSummaryResponseDTO);
+      } else {
+        invalidCount++;
+        firstError ??= parsed.error;
+      }
+    }
+    if (invalidCount > 0) {
+      console.warn(
+        `getActivePromotedEvents: dropped ${invalidCount} invalid content item(s)`,
+        firstError,
+      );
+    }
+
+    return events.map(enhanceEventImage).slice(0, MAX_PROMOTED_EVENTS);
+  } catch (error) {
+    console.warn("getActivePromotedEvents: fetch failed", error);
+    return [];
+  }
+}
+```
+
+Check `lib/api/events.ts` for the exact exported name of the API-url helper (`getApiUrl`)
+before importing it — if it's not exported, export it or inline the same `apiUrl`
+resolution `fetchEventsInternal` uses.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn vitest run test/lib/api/promotedEvents.test.ts`
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/api/promotedEvents.ts test/lib/api/promotedEvents.test.ts
+git commit -m "feat(promoted-events): add isolated, flag-gated active-promotions fetch"
+```
+
+---
+
+### Task 2: Thread `isPromoted` through `EventsAroundServer` → `CardHorizontalServer`
+
+**Files:**
+- Modify: `types/common.ts` (`EventsAroundServerProps`, `CardHorizontalServerProps`)
+- Modify: `components/ui/eventsAround/EventsAroundServer.tsx`
+- Modify: `components/ui/cardHorizontal/CardHorizontalServer.tsx`
+- Modify: `messages/ca.json`, `messages/es.json`, `messages/en.json`
+
+**Interfaces:**
+- Consumes: nothing new from Task 1.
+- Produces: `EventsAroundServer` accepts `isPromoted?: boolean`; `CardHorizontalServer`
+  accepts `isPromoted?: boolean` and renders a `badge-primary` pill when true.
+
+- [ ] **Step 1: Add the i18n key** (do this first so the component step below compiles
+  against real translations)
+
+Add to `messages/ca.json`, inside the existing `"Components"` object, as a sibling of
+`"PromotedRestaurantCard"` (around line 857):
+
+```json
+"PromotedEvents": {
+  "title": "Esdeveniments destacats",
+  "badge": "Patrocinat"
+},
+```
+
+Add to `messages/es.json` (same location, same nesting):
+
+```json
+"PromotedEvents": {
+  "title": "Eventos destacados",
+  "badge": "Patrocinado"
+},
+```
+
+Add to `messages/en.json` (same location, same nesting):
+
+```json
+"PromotedEvents": {
+  "title": "Featured events",
+  "badge": "Promoted"
+},
+```
+
+- [ ] **Step 2: Add `isPromoted` to the prop types**
+
+In `types/common.ts`, find `EventsAroundServerProps` (currently `layout?`, `loading?`,
+`usePriority?`, `showJsonLd?`, `jsonLdId?`, `analyticsCategory?`) and add:
+
+```ts
+export interface EventsAroundServerProps extends EventsAroundProps {
+  layout?: EventsAroundLayout;
+  loading?: boolean;
+  usePriority?: boolean;
+  showJsonLd?: boolean;
+  jsonLdId?: string;
+  analyticsCategory?: string;
+  isPromoted?: boolean;
+}
+```
+
+Find `CardHorizontalServerProps` in the same file and add the same field:
+
+```ts
+isPromoted?: boolean;
+```
+
+- [ ] **Step 3: Thread the prop through `EventsAroundServer`**
+
+In `components/ui/eventsAround/EventsAroundServer.tsx`, add `isPromoted = false` to the
+destructured props (function signature currently `{ events, layout = "compact", loading =
+false, usePriority = false, showJsonLd = false, jsonLdId, title }`), and pass it to
+`CardHorizontalServer` in the horizontal-layout branch:
+
+```tsx
+<CardHorizontalServer
+  event={event}
+  isPriority={usePriority && index <= 2}
+  isPromoted={isPromoted}
+/>
+```
+
+- [ ] **Step 4: Render the badge in `CardHorizontalServer`**
+
+In `components/ui/cardHorizontal/CardHorizontalServer.tsx`, add `isPromoted = false` to the
+destructured props, get a second translation namespace, and render the badge next to
+`CategoryBadge`:
+
+```tsx
+const CardHorizontalServer = async ({
+  event,
+  isPriority = false,
+  initialIsFavorite,
+  isPromoted = false,
+}: CardHorizontalServerProps) => {
+  const locale = await getLocaleSafely();
+  const tCard = await getTranslations({ locale, namespace: "Components.CardContent" });
+  const tTime = await getTranslations({ locale, namespace: "Utils.EventTime" });
+  const tCategories = await getTranslations({ locale, namespace: "Config.Categories" });
+  const tPromoted = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  // ...(unchanged prepareCardContentData call)...
+```
+
+And in the JSX, immediately above or beside `<CategoryBadge label={categoryLabel} />`:
+
+```tsx
+{isPromoted && (
+  <span className="badge-primary mb-1 w-fit">{tPromoted("badge")}</span>
+)}
+<CategoryBadge label={categoryLabel} />
+```
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors. This step has no new automated test of its own (rendering
+`CardHorizontalServer`, an async server component, isn't unit-tested anywhere in this
+codebase today — see spec's Testing section) — verify visually in Task 5's manual check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add types/common.ts components/ui/eventsAround/EventsAroundServer.tsx \
+  components/ui/cardHorizontal/CardHorizontalServer.tsx \
+  messages/ca.json messages/es.json messages/en.json
+git commit -m "feat(promoted-events): thread isPromoted badge through card carousel chain"
+```
+
+---
+
+### Task 3: `PromotedEventsSection` component
+
+**Files:**
+- Create: `components/ui/promotedEvents/PromotedEventsSection.tsx`
+
+**Interfaces:**
+- Consumes: `getActivePromotedEvents(scope)` from Task 1; `EventsAroundServer` with
+  `isPromoted` from Task 2; i18n key `Components.PromotedEvents.title` from Task 2.
+- Produces: `export default async function PromotedEventsSection({ scope }: { scope: PromotionScope }): Promise<JSX.Element | null>`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/ui/promotedEvents/PromotedEventsSection.tsx
+import { getTranslations } from "next-intl/server";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import { getActivePromotedEvents } from "@lib/api/promotedEvents";
+import type { PromotionScope } from "@lib/api/promotedEvents";
+import { getLocaleSafely } from "@utils/i18n-seo";
+
+function scopeKey(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}`;
+}
+
+function scopePlaceSlug(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : scope.slug;
+}
+
+export default async function PromotedEventsSection({
+  scope,
+}: {
+  scope: PromotionScope;
+}) {
+  const promotedEvents = await getActivePromotedEvents(scope);
+  if (promotedEvents.length === 0) {
+    return null;
+  }
+
+  const locale = await getLocaleSafely();
+  const t = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  const key = scopeKey(scope);
+
+  return (
+    <div className="container content-auto-section">
+      <section className="py-section-y border-b">
+        <h2 className="heading-2 text-foreground">{t("title")}</h2>
+        <div
+          data-analytics-container="true"
+          data-analytics-context="promoted_carousel"
+          data-analytics-place-slug={scopePlaceSlug(scope)}
+        >
+          <EventsAroundServer
+            events={promotedEvents}
+            layout="horizontal"
+            usePriority={false}
+            isPromoted
+            showJsonLd
+            title={t("title")}
+            jsonLdId={`promoted-events-${key}`}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+Match `SectionHeading`'s exact heading markup instead of the raw `<h2>` above if
+`components/ui/serverEventsCategorized/SectionHeading.tsx` is exported for reuse outside
+that folder — check its import path before wiring Task 4; if it's private to that folder,
+the inline `<h2 className="heading-2 text-foreground">` above (copied verbatim from the
+"Popular Now" heading style) is the correct fallback and needs no further change.
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/ui/promotedEvents/PromotedEventsSection.tsx
+git commit -m "feat(promoted-events): add PromotedEventsSection component"
+```
+
+---
+
+### Task 4: Homepage insertion
+
+**Files:**
+- Modify: `components/ui/serverEventsCategorized/index.tsx`
+
+**Interfaces:**
+- Consumes: `PromotedEventsSection` from Task 3.
+
+- [ ] **Step 1: Insert the section before "Popular Now"**
+
+In the returned JSX (around line 509-511, immediately before the `{/* Popular Now Section
+*/}` comment), add:
+
+```tsx
+return (
+  <>
+    <PromotedEventsSection scope={{ type: "homepage" }} />
+
+    {/* Popular Now Section — derived from existing data, zero extra API calls */}
+    {popularEvents.length > 0 && (
+      // ...unchanged...
+```
+
+Add the import at the top of the file:
+
+```tsx
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
+```
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 3: Manual verification**
+
+Since `PROMOTED_EVENTS_ENABLED` is unset by default, `PromotedEventsSection` returns `null`
+here — running the dev server and loading `/` should look **identical to before this
+task**. That's the correct, expected result; it does not prove the carousel renders
+correctly. Separately, verify the populated path locally:
+
+```bash
+PROMOTED_EVENTS_ENABLED=true yarn dev
+```
+
+With the flag on, `getActivePromotedEvents` will still hit the real (nonexistent) backend
+endpoint and fail soft to `[]` unless a local mock is added — to see the populated carousel
+render, temporarily stub `getActivePromotedEvents` to return a hardcoded
+`EventSummaryResponseDTO[]` fixture, load `/`, confirm the carousel + badge render, then
+revert the stub before committing. Record in the PR description which of the two states
+(empty-hidden vs. populated-with-stub) was actually checked in the browser.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ui/serverEventsCategorized/index.tsx
+git commit -m "feat(promoted-events): render promoted carousel on homepage"
+```
+
+---
+
+### Task 5: Listing-page insertion
+
+**Files:**
+- Modify: `components/partials/PlacePageShell.tsx`
+
+**Interfaces:**
+- Consumes: `PromotedEventsSection` from Task 3; `PlaceTypeAndLabel` from `types/common.ts`
+  (already available in this file's props, per phase-2 spec's "Placement" section).
+
+- [ ] **Step 1: Locate the render point and confirm the `placeTypeLabel` prop's shape**
+
+Read `components/partials/PlacePageShell.tsx` around line 354 (where `HybridEventsList` is
+rendered) and confirm which prop already carries the resolved `PlaceTypeAndLabel` (it's
+computed in `PlacePageGate`/`app/[locale]/[place]/page.tsx` via
+`getPlaceTypeAndLabelCached(place)` and passed down — find its prop name in
+`PlacePageShellProps`, `types/props.ts`, before writing the insertion).
+
+- [ ] **Step 2: Insert the section above `HybridEventsList`**
+
+```tsx
+{placeTypeLabel.type && (
+  <PromotedEventsSection
+    scope={{ type: placeTypeLabel.type, slug: place }}
+  />
+)}
+
+<HybridEventsList
+  // ...unchanged props...
+/>
+```
+
+`placeTypeLabel.type` is `"town" | "region" | ""` at the type level; the `{placeTypeLabel.type
+&& (...)}` guard is the defensive, spec-mandated check for the `""` member even though it's
+unreachable in practice (verified: `getPlaceTypeAndLabel`,
+`utils/location-helpers.ts:209-292`, has no code path returning `""`).
+
+Add the import at the top of the file:
+
+```tsx
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
+```
+
+- [ ] **Step 3: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 4: Manual verification**
+
+Same caveat as Task 4 Step 3 — with the flag off (default), a town page (e.g. `/cardedeu`)
+and a region page (e.g. `/maresme`) should render identically to before this task. Verify
+that first, then repeat the temporary-stub check from Task 4 on one town page and one
+region page to confirm the scope-slug plumbing is correct for both `PlaceType` values, then
+revert the stub.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/partials/PlacePageShell.tsx
+git commit -m "feat(promoted-events): render promoted carousel on listing pages"
+```
+
+---
+
+### Task 6: `.env.example` entry
+
+**Files:**
+- Modify: `.env.example` (or the repo's equivalent env-documentation file — confirm exact
+  filename first; some Next.js repos use `.env.local.example`)
+
+- [ ] **Step 1: Add the flag with an explanatory comment**
+
+```bash
+# Promoted events carousel — gates lib/api/promotedEvents.ts's active-promotions fetch.
+# Keep false/unset until the backend's GET /events/promotions/active endpoint exists.
+PROMOTED_EVENTS_ENABLED=false
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "docs(promoted-events): document PROMOTED_EVENTS_ENABLED in env example"
+```
+
+---
+
+### Task 7: E2E regression spec
+
+**Files:**
+- Create: `e2e/promoted-events-carousel.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new — this is a black-box regression check against the running app
+  with the feature flag in its default (off) state.
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+// e2e/promoted-events-carousel.spec.ts
+import { test, expect } from "@playwright/test";
+
+test.describe("promoted events carousel (flag off, default state)", () => {
+  test("homepage renders normally with no promoted-events section", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+
+  test("a town listing page renders normally with no promoted-events section", async ({
+    page,
+  }) => {
+    await page.goto("/cardedeu");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run: `yarn playwright test e2e/promoted-events-carousel.spec.ts`
+Expected: PASS (2 tests) — confirms this phase ships with zero visible/behavioral change
+while `PROMOTED_EVENTS_ENABLED` is off, matching the spec's documented default state.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/promoted-events-carousel.spec.ts
+git commit -m "test(e2e): add promoted-events-carousel regression spec (flag-off state)"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: data contract (Task 1), pill/badge threading (Task 2), component (Task 3),
+  homepage placement (Task 4), listing-page placement (Task 5), env docs (Task 6), E2E
+  (Task 7). Unit tests for `getActivePromotedEvents` are in Task 1. i18n keys land in Task
+  2, before any component references them, so no task ever compiles against a missing key.
+- No RSC render tests for `PromotedEventsSection`/`CardHorizontalServer`, matching the
+  spec's explicit call — verified via typecheck + manual/stub verification instead.
+- Task 3's `SectionHeading` note is a genuine open point for the implementer to resolve in
+  five seconds (check one import), not a placeholder — the fallback behavior if it's
+  private is fully specified inline.
+- Task 5's Step 1 asks the implementer to find one prop name in a file this plan doesn't
+  fully reproduce — flagged rather than guessed, since guessing a wrong prop name here
+  would be a shipped bug, and the plan gives the exact function/line to find it from.

--- a/docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md
+++ b/docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md
@@ -1,0 +1,303 @@
+# Event Promotion Checkout (Wallapop-style upsell)
+
+Date: 2026-08-03
+Status: Approved for implementation planning
+
+## Problem
+
+Right after a user publishes an event, there's no offer to boost its reach. We want a
+post-publish upsell modal (Wallapop-style) leading to a dedicated promotion page, where
+confirming payment hands off to Gerard's Spring Boot backend, which owns the Stripe
+session, the pending order, and the webhook that activates the promotion. This app's job
+is: show the upsell, collect the "yes", get a Stripe URL from the backend, and redirect.
+
+## Source of truth for the backend contract
+
+Gerard (backend, Spring Boot) described the flow directly (verbatim, translated):
+
+> Owner-only for now (not decided if others can promote later). Button on the event page
+> → Next.js page → user confirms a price (pricing methodology not decided yet — could be
+> per-day, or start-date-to-event-date, TBD) → frontend POSTs to something like
+> `api/events/{eventId}/promotions/checkout` → backend validates user + event, computes
+> price, creates a PENDING order record, creates a Stripe Checkout Session, returns the
+> URL → frontend redirects to Stripe → user pays → Stripe redirects to **our** page
+> *and* separately fires a webhook to Spring Boot → webhook flips the order to
+> successful and the event to paid → frontend, seeing "paid", would show it promoted —
+> or, "we'd build an endpoint to give me the promoted ones" (not decided: a reordered
+> list vs. a dedicated endpoint) → a scheduled job later reverts to free at expiry.
+
+This confirms the endpoint shape (`POST /events/{eventId}/promotions/checkout` →
+`{ url }`) but confirms nothing else is finalized: pricing methodology, whether
+non-owners can promote, and how "promoted" surfaces to the frontend are all explicitly
+undecided on the backend side. No OpenAPI spec, staging URL, or Postman collection
+exists yet (confirmed with the user). This design treats the endpoint contract as
+provisional and isolates it behind a single function so a field-name or shape mismatch,
+once the real endpoint ships, is a one-file fix.
+
+## Scope
+
+**In scope**
+1. Post-publish upsell modal in `app/[locale]/publica/page.tsx`.
+2. `/e/[eventId]/promote` page: benefits, static flat fee (€5, MVP placeholder), "Confirm
+   and Pay".
+3. Server Action that POSTs to the backend checkout endpoint and returns the Stripe URL
+   for the client to redirect to.
+4. `/e/[eventId]/promote/success` and `/e/[eventId]/promote/cancel`: static, no
+   verification (Stripe's own docs: fulfillment must come from the webhook, not the
+   redirect — and that webhook is Gerard's, not ours).
+5. Analytics for the funnel.
+
+**Explicitly out of scope**
+- Pricing lookup/config — hardcoded constant, marked as MVP-provisional. Gerard: "no sé,
+  ja ho pensarem" (pricing methodology not decided).
+- Duplicate-checkout / already-promoted guard — no lookup endpoint exists for this yet
+  (the closest analog, `/api/promotions/active`, is an explicit `TODO` placeholder for
+  an unrelated restaurant-promotion feature and must not be reused here).
+- "Appears at top of list" sorting or a "Promoted" badge — no field for this exists on
+  `EventSummaryResponseDTO`/`EventDetailResponseDTO`, and Gerard hasn't decided whether
+  it's a reordered list or a separate endpoint. Zero changes to list rendering or DTOs.
+- Non-owner promotion.
+- Any webhook, Stripe SDK usage, or Stripe secret key in this repo. Two other Stripe
+  integrations already exist here (`/api/sponsors/*` for place banner ads, and a stubbed
+  `/api/promotions/*` + `/api/leads/restaurant` for restaurant-promotion leads) — both do
+  Stripe entirely inside Next.js with their own DB/webhook. This feature does not touch
+  either; it is a third, backend-owned pattern and must not be confused with those two.
+
+## Files
+
+**New**
+- `app/[locale]/e/[eventId]/promote/page.tsx` — Server Component. Fetches event +
+  current user in parallel (`fetchEventBySlug`, `getCurrentUser`), `notFound()` if
+  `currentUser?.id !== event?.owner?.id` — exact pattern copied from
+  `app/[locale]/e/[eventId]/edita/page.tsx`. Passes both `event.id` and `event.slug` to
+  the client component (the Server Action needs both — see "Checkout flow" below).
+- `app/[locale]/e/[eventId]/promote/PromoteEventClient.tsx` — client component: benefits
+  list (pinned top), static price, "Confirm and Pay" button, loading/error state.
+- `app/[locale]/e/[eventId]/promote/actions.ts` — `"use server"`,
+  `createPromotionCheckoutAction(eventId: string, slug: string): Promise<PromotionCheckoutResult>`
+  — see "Checkout flow" for the full contract.
+- `app/[locale]/e/[eventId]/promote/success/page.tsx` — static thank-you page.
+- `app/[locale]/e/[eventId]/promote/cancel/page.tsx` — static cancel page.
+- `app/[locale]/publica/PromoteUpsellModal.tsx` — the modal, colocated like
+  `PublishAuthGate.tsx` / `CompleteProfileGate.tsx` in the same route folder.
+- `app/[locale]/e/[eventId]/components/EventPromoteAction.tsx` — owner-only "Promote"
+  entry point on the event detail page itself, mirroring `EventEditAction.tsx` exactly
+  (client-side `useAuth()` check, `ownerId`/`slug` props, no extra round-trip). Gerard's
+  own description of the flow starts with "hi hagi un botó de promocionar esdeveniment...
+  a la pàgina d'esdeveniment" — the modal is the *post-publish* upsell path, this is the
+  *always-available* path for an owner revisiting their own event later. Missing this
+  was a scope gap caught in review.
+- `app/[locale]/e/[eventId]/page.tsx` — render `EventPromoteAction` next to
+  `EventEditAction` (wherever that already renders — same sidebar/mobile-detail slot).
+
+**Modified**
+- `lib/api/events.ts` — new `createPromotionCheckout(id: string, successUrl: string,
+  cancelUrl: string): Promise<{ url: string }>`, same shape as
+  `updateEventById`/`deleteEventById`: `requireMutationAuth()` for the Bearer token,
+  `fetchWithHmac` with `skipBodySigning: true`, POST to
+  `${apiUrl}/events/${id}/promotions/checkout` with `{ successUrl, cancelUrl }` as the
+  JSON body (see "Return pages" for why the frontend, not the backend, builds these).
+  Throws on failure — the Server Action wrapping it is what converts that into a
+  discriminated result (matching how `createEventAction` wraps `createEvent`'s throw).
+- `types/api/event.ts` — extend `E2EEventExtras` with an optional `owner?:
+  EventDetailResponseDTO["owner"]`. Needed so `createE2EEvent` can stamp an owner
+  matching the E2E-authenticated user (see "Testing").
+- `app/[locale]/publica/page.tsx` — in `buildE2EExtras()`, populate the new `owner` field
+  from the authenticated user already available via `useAuth()` in this file. Around line
+  625, replace the unconditional `router.push('/e/${slug}')` after a successful publish
+  with: show `PromoteUpsellModal`, navigate on either button (see "Modal" below for the
+  exact close/navigate sequencing).
+- `lib/api/events.ts` (`createE2EEvent`) — set `owner: extras?.owner` on the constructed
+  E2E event object.
+- `messages/ca.json`, `es.json`, `en.json` — new `App.EventPromote` namespace (mirroring
+  `App.EventEdit` — verified this naming convention against `messages/ca.json:204-219`),
+  plus a few new keys under `App.Publish` for the modal copy.
+
+**Not touched**
+- `proxy.ts`, `utils/api-gate.ts` — the checkout call goes through a Server Action, which
+  bypasses the `/api/*` HMAC gateway entirely (same as `createEventAction`). No
+  allowlist/middleware change needed. (Verified: the one place in this codebase where a
+  browser-initiated mutation to `/api/events/*` exists — `DELETE /api/events/[slug]` —
+  needed an explicit regex carve-out in `gateApiRequest`. The Server Action route avoids
+  that class of change entirely.)
+- No new `app/api/*` route. No Stripe SDK/webhook/secret in this repo for this feature.
+
+## Modal (Wallapop-style)
+
+Reuses the shared `Modal` component (`components/ui/common/modal`) unchanged, but its
+close/navigate sequencing must be exact:
+
+- **"Promote Event"** is the modal's `actionButton`. Its `onActionButtonClick` handler
+  calls `router.push('/e/${slug}/promote')` and then **explicitly returns `false`**.
+  This matters: `Modal` (`components/ui/common/modal/index.tsx:92-102`) calls
+  `setOpen(false)` automatically after `onActionButtonClick` resolves, *unless* the
+  handler returns `false`. Without the explicit `return false`, the sequence would be:
+  push to `/promote` → Modal's own `setOpen(false)` still fires on the (now unmounting,
+  or about-to-unmount) component → in practice this is a redundant state update racing
+  the navigation, not a correctness bug per se, but it's exactly the escape hatch Modal
+  documents for "don't auto-close, I'm handling it" — using it here removes the race
+  entirely rather than relying on unmount timing to save us.
+- **"Keep it free"** is a plain button inside the modal body (not wired through
+  `actionButton`) → calls `setOpen(false)` then `router.push('/e/${slug}')` directly
+  (today's existing post-publish behavior, unchanged).
+- Backdrop/back-arrow dismiss falls back to the same "keep it free" path (`setOpen`'s
+  default `onClose` already routes there) — no separate analytics event for that edge,
+  matching how the existing preview modal in the same file already behaves.
+
+Copy (from the brief): "Boost your event! Promote your event now to reach way more
+people and appear at the top of the platform." Exact translated strings live in
+`messages/*.json` under `App.Publish.promoteUpsell.*`.
+
+## Checkout flow
+
+**Server Action signature and ownership check.** Copied verbatim from the pattern in
+`app/[locale]/e/[eventId]/edita/actions.ts` (`editEvent(eventId, slug, data)`), which
+exists precisely to prevent a client from passing an `eventId` it doesn't actually own
+alongside a `slug` it does:
+
+```ts
+type PromotionCheckoutResult =
+  | { success: true; url: string }
+  | { success: false; error: string };
+
+async function createPromotionCheckoutAction(
+  eventId: string,
+  slug: string,
+): Promise<PromotionCheckoutResult>
+```
+
+Inside the action: resolve `event` via `fetchEventBySlug(slug)`, resolve `currentUser`
+via `getCurrentUser()`, reject (`{ success: false, error: ... }`) unless `event.id ===
+eventId` **and** `currentUser?.id === event.owner?.id` — both checks, exactly as
+`editEvent` does at lines 24-47. `PromoteEventClient` therefore needs both `event.id` and
+`event.slug` as props from the Server Component (`page.tsx` already has both from the
+same `fetchEventBySlug` call the ownership gate already uses).
+
+**The action returns a result, it does not throw.** `createPromotionCheckout` (the
+`lib/api/events.ts` function) throws on non-2xx and on `requireMutationAuth()` failure —
+same as `updateEventById`/`deleteEventById`. But unlike those two (which are called from
+contexts that already handle thrown errors upstream), this Server Action is the last
+stop before the client needs to render an error state, so it must catch and convert,
+exactly like `createEventAction` does for `createEvent`'s 401/403 throws. This is not
+optional: since Gerard's endpoint doesn't exist yet, a 404 (or any non-2xx) *is* the
+realistic near-term demo path, and an uncaught throw from a Server Action reaches the
+client as an opaque, Next.js-redacted rejection in production — not the "generic inline
+error" this design promises.
+
+**Building the request:** the action builds `successUrl`/`cancelUrl` itself (see "Return
+pages" below for why) using `siteUrl` (`@config/index`) + `withLocalePath` + the known
+`slug`, then calls `createPromotionCheckout(event.id, successUrl, cancelUrl)` → `POST
+${apiUrl}/events/${id}/promotions/checkout` with `Authorization: Bearer <token>` and
+`{ successUrl, cancelUrl }` as the JSON body → `{ url }`.
+
+**Client-side redirect, with validation.** `PromoteEventClient` calls the action, and on
+`{ success: true, url }` **validates `url` before redirecting** — it must parse as an
+absolute `https://` URL (matching the precedent in `uploadEventImage`,
+`lib/api/events.ts:489-498`, which validates its own returned URL rather than trusting it
+blindly). This guards two real failure modes at once: a provisional/renamed backend field
+silently producing `window.location.href = "/undefined"`, and an unvalidated redirect
+target becoming an open-redirect surface. If validation fails, treat it the same as a
+`{ success: false }` result — generic inline error, no partial redirect attempt.
+
+No assumption is made about Gerard's error response shape/codes (none confirmed) — any
+non-2xx surfaces as the same one generic inline error on the promote page ("Something
+went wrong, try again"), no special-casing by status code.
+
+## Return pages
+
+`/e/[eventId]/promote/success` and `/e/[eventId]/promote/cancel`, static, mirroring the
+existing `/patrocina/success` + `/patrocina/cancelled` precedent (feature-scoped, not
+global). Per Stripe's own docs (confirmed via web search of stripe.com/docs): "customers
+aren't guaranteed to visit the success page" — fulfillment must come from the webhook,
+never the redirect. Since that webhook lives in Gerard's Spring Boot backend, these pages
+do zero verification; they are purely "thank you" / "canceled, event stays free" copy
+with a link back to the event.
+
+**`success_url` / `cancel_url` are built by this app, not the backend, and sent in the
+checkout POST body.** This reverses the original assumption in this design's first draft.
+Reasoning: `/e/[eventId]/promote/success` uses `[eventId]` as a **slug** (confirmed —
+this route param is a slug throughout the app, resolved via `fetchEventBySlug`; see the
+canonical-slug `redirect()` logic in `app/[locale]/e/[eventId]/page.tsx`), plus a locale
+prefix. The backend only ever receives the UUID (`event.id`) in the checkout request path
+— it has no way to construct a slug-based, locale-prefixed URL like
+`/es/e/estiu-al-carrer-2026/promote/success` from that UUID alone. So the frontend
+computes both absolute URLs (via `siteUrl` + `withLocalePath` + the known `slug`) and
+passes them to the backend as part of the checkout request; the backend's Stripe session
+creation uses whatever it's given rather than constructing its own.
+
+## Analytics (new)
+
+Matching the existing `publish_*` naming already in `app/[locale]/publica/page.tsx`,
+sent via `sendGoogleEvent` (imperative calls, matching the majority pattern in that file
+— not the declarative `data-analytics-*` attribute pattern used inside `EventForm`):
+
+- `promote_modal_shown` — `{ event_slug, source: "publica" }`
+- `promote_modal_cta_click` — `{ event_slug, source: "publica" }`
+- `promote_modal_dismiss` — `{ event_slug, source: "publica" }`
+- `promote_page_view` — `{ event_slug, source: "promote" }`
+- `promote_checkout_click` — `{ event_slug, source: "promote" }`
+- `promote_checkout_redirect` — `{ event_slug, source: "promote" }` (fired right before
+  the `window.location.href` redirect to Stripe; named `_redirect` rather than
+  `_success` since no payment has happened yet at this point — actual payment success is
+  only known to the backend via its webhook)
+- `promote_checkout_error` — `{ event_slug, source: "promote", reason }`
+
+## Testing
+
+- Unit (Vitest): `createPromotionCheckout` and `createPromotionCheckoutAction` — env-guard
+  + HMAC call shape, ownership-mismatch rejection, and the throw-to-result conversion.
+  (Correction from an earlier draft of this doc: `updateEventById`/`deleteEventById`
+  don't have dedicated unit tests today — they're exercised indirectly via mocks in
+  `test/server-actions.test.ts` and `test/api-events-slug-cache.test.ts`. The new
+  functions should get real direct unit tests, not just mocked call-sites, since this is
+  a money-adjacent path.) Modal button branching (Promote vs. Keep it free navigate to
+  the right paths, and the `actionButton` handler's `return false` is asserted so the
+  race described above can't regress silently).
+- E2E (Playwright): **this requires two changes to E2E infra, not just a new
+  assertion.**
+  1. `createE2EEvent` (`lib/api/events.ts`) never sets `owner`, so the new promote page's
+     ownership gate would `notFound()` for every E2E-created event regardless of who's
+     logged in. Fix: extend `E2EEventExtras` with `owner`, populate it in
+     `buildE2EExtras()` (`publica/page.tsx`) from the already-authenticated E2E test
+     user, and pass it through in `createE2EEvent`.
+  2. `e2e/publish-integration.spec.ts`'s existing assertion
+     (`page.waitForURL((url) => !url.pathname.includes("/publica"), ...)` right after
+     clicking publish) currently races the new modal: the URL no longer changes on
+     publish success, the modal appears instead. This existing test **must be updated**,
+     not just extended — insert an explicit wait for the modal, then a "Keep it free"
+     click, before the existing URL assertion can proceed. Add a second, separate test
+     (or a branch in the same one) that instead clicks "Promote Event" and asserts landing
+     on `/e/[slug]/promote`.
+
+## Risks / open questions carried forward (not blocking this implementation)
+
+- Real endpoint contract may differ once Gerard ships it (field names, auth, error
+  shape, and whether it even accepts `successUrl`/`cancelUrl` in the body as this design
+  assumes). Mitigated by isolating the call in one function
+  (`createPromotionCheckout`) and by the client-side URL validation described above.
+- Pricing is a hardcoded placeholder; will need a real config once Gerard's pricing
+  methodology is decided.
+- "Appears at top of list" has no frontend implementation — purely a backend ranking/
+  endpoint decision still pending on Gerard's side.
+- The existing preview-modal path in `publica/page.tsx` (`showPreview` →
+  `onActionButtonClick` → `await onSubmit()`) already relies on the publish button's
+  existing `isLoading`/spinner state (via `isPending` from `useTransition`) to cover the
+  time between form submission and the new upsell modal appearing — this is pre-existing
+  behavior this design relies on rather than changes, and is called out here so it isn't
+  mistaken for an oversight if the gap is ever felt during a demo.
+
+## Review history
+
+This design went through one adversarial staff-engineer review pass (2026-08-03) before
+implementation. Five blocking issues were found and fixed in this document: (1) the
+modal's `actionButton` auto-close racing the "Promote Event" navigation — fixed by an
+explicit `return false`; (2) the Server Action signature couldn't support an ownership
+check with only `eventId` — fixed by adding `slug` and copying `editEvent`'s
+double-check; (3) the action was designed to let `createPromotionCheckout` throw through
+to the client — fixed with a discriminated result type; (4) `success_url`/`cancel_url`
+can't be built from a UUID alone since the return routes use slugs — fixed by having the
+frontend build and pass both URLs to the backend; (5) the existing E2E publish test and
+`createE2EEvent`'s missing `owner` field would break/block the new promote-page
+assertions — fixed by extending E2E test infra and explicitly updating (not just
+extending) the existing test. All five are reflected in the sections above, not just
+listed here.

--- a/docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md
+++ b/docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md
@@ -99,16 +99,10 @@ once the real endpoint ships, is a one-file fix.
   JSON body (see "Return pages" for why the frontend, not the backend, builds these).
   Throws on failure — the Server Action wrapping it is what converts that into a
   discriminated result (matching how `createEventAction` wraps `createEvent`'s throw).
-- `types/api/event.ts` — extend `E2EEventExtras` with an optional `owner?:
-  EventDetailResponseDTO["owner"]`. Needed so `createE2EEvent` can stamp an owner
-  matching the E2E-authenticated user (see "Testing").
-- `app/[locale]/publica/page.tsx` — in `buildE2EExtras()`, populate the new `owner` field
-  from the authenticated user already available via `useAuth()` in this file. Around line
-  625, replace the unconditional `router.push('/e/${slug}')` after a successful publish
-  with: show `PromoteUpsellModal`, navigate on either button (see "Modal" below for the
-  exact close/navigate sequencing).
-- `lib/api/events.ts` (`createE2EEvent`) — set `owner: extras?.owner` on the constructed
-  E2E event object.
+- `app/[locale]/publica/page.tsx` — around line 625, replace the unconditional
+  `router.push('/e/${slug}')` after a successful publish with: show
+  `PromoteUpsellModal`, navigate on either button (see "Modal" below for the exact
+  close/navigate sequencing).
 - `messages/ca.json`, `es.json`, `en.json` — new `App.EventPromote` namespace (mirroring
   `App.EventEdit` — verified this naming convention against `messages/ca.json:204-219`),
   plus a few new keys under `App.Publish` for the modal copy.
@@ -253,21 +247,23 @@ sent via `sendGoogleEvent` (imperative calls, matching the majority pattern in t
   a money-adjacent path.) Modal button branching (Promote vs. Keep it free navigate to
   the right paths, and the `actionButton` handler's `return false` is asserted so the
   race described above can't regress silently).
-- E2E (Playwright): **this requires two changes to E2E infra, not just a new
-  assertion.**
-  1. `createE2EEvent` (`lib/api/events.ts`) never sets `owner`, so the new promote page's
-     ownership gate would `notFound()` for every E2E-created event regardless of who's
-     logged in. Fix: extend `E2EEventExtras` with `owner`, populate it in
-     `buildE2EExtras()` (`publica/page.tsx`) from the already-authenticated E2E test
-     user, and pass it through in `createE2EEvent`.
-  2. `e2e/publish-integration.spec.ts`'s existing assertion
-     (`page.waitForURL((url) => !url.pathname.includes("/publica"), ...)` right after
-     clicking publish) currently races the new modal: the URL no longer changes on
-     publish success, the modal appears instead. This existing test **must be updated**,
-     not just extended — insert an explicit wait for the modal, then a "Keep it free"
-     click, before the existing URL assertion can proceed. Add a second, separate test
-     (or a branch in the same one) that instead clicks "Promote Event" and asserts landing
-     on `/e/[slug]/promote`.
+- E2E (Playwright): `e2e/publish-integration.spec.ts` is the one real-backend,
+  real-login E2E that publishes an event and immediately asserts on the post-publish
+  redirect — it runs against staging (gated on `E2E_STAGING_EMAIL`/`E2E_STAGING_PASSWORD`,
+  see `.github/workflows/e2e-integration.yml`), not the mocked-auth or
+  `E2E_TEST_MODE`-short-circuited specs (`publish-wizard.spec.ts`,
+  `publish-no-autosubmit.spec.ts`, `publica_to_event.flow.spec.ts` — none of those
+  submit-and-land-on-`/e/[slug]`, so they're unaffected). Its existing assertion
+  (`page.waitForURL((url) => !url.pathname.includes("/publica"), ...)` right after
+  clicking publish) races the new modal: the URL no longer changes immediately on
+  publish success, the modal appears instead. This existing test **must be updated**,
+  not just extended — insert an explicit wait for the modal, then a "Keep it free"
+  click, before the existing URL assertion can proceed. Add a second, separate test (or
+  a branch in the same one) that instead clicks "Promote Event" and asserts landing on
+  `/e/[slug]/promote`. Since this spec logs in against the real staging backend and
+  publishes a real event, `event.owner` is populated by the backend itself — no
+  synthetic E2E owner-stamping is needed for the new promote page's ownership gate to
+  pass here.
 
 ## Risks / open questions carried forward (not blocking this implementation)
 
@@ -289,15 +285,24 @@ sent via `sendGoogleEvent` (imperative calls, matching the majority pattern in t
 ## Review history
 
 This design went through one adversarial staff-engineer review pass (2026-08-03) before
-implementation. Five blocking issues were found and fixed in this document: (1) the
-modal's `actionButton` auto-close racing the "Promote Event" navigation — fixed by an
-explicit `return false`; (2) the Server Action signature couldn't support an ownership
-check with only `eventId` — fixed by adding `slug` and copying `editEvent`'s
+implementation. Five blocking issues were found; four are fixed in this document as
+written: (1) the modal's `actionButton` auto-close racing the "Promote Event" navigation
+— fixed by an explicit `return false`; (2) the Server Action signature couldn't support
+an ownership check with only `eventId` — fixed by adding `slug` and copying `editEvent`'s
 double-check; (3) the action was designed to let `createPromotionCheckout` throw through
 to the client — fixed with a discriminated result type; (4) `success_url`/`cancel_url`
 can't be built from a UUID alone since the return routes use slugs — fixed by having the
-frontend build and pass both URLs to the backend; (5) the existing E2E publish test and
-`createE2EEvent`'s missing `owner` field would break/block the new promote-page
-assertions — fixed by extending E2E test infra and explicitly updating (not just
-extending) the existing test. All five are reflected in the sections above, not just
-listed here.
+frontend build and pass both URLs to the backend.
+
+The fifth (E2E test breakage) needed a follow-up correction after the review: the
+reviewer's proposed fix — extending `E2EEventExtras`/`createE2EEvent` with a synthetic
+`owner` field — turned out to be solving a problem that doesn't exist for the one test
+that's actually affected. `e2e/publish-integration.spec.ts` (the only spec that publishes
+and asserts on the post-publish redirect) authenticates against the real staging backend
+and publishes a real event, so `event.owner` is already populated server-side; the
+mocked-auth/`E2E_TEST_MODE` specs that *would* need a synthetic owner
+(`publish-wizard.spec.ts`, `publish-no-autosubmit.spec.ts`,
+`publica_to_event.flow.spec.ts`) never submit-and-land-on-`/e/[slug]`, so they're
+unaffected by the modal either. Verified directly against all four spec files before
+finalizing — see "Testing" above for the corrected, narrower fix (update the one race
+condition in `publish-integration.spec.ts`, no E2E infra changes).

--- a/docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md
+++ b/docs/superpowers/specs/2026-08-03-event-promotion-checkout-design.md
@@ -36,6 +36,12 @@ once the real endpoint ships, is a one-file fix.
 
 ## Scope
 
+> **Superseded — see "Post-review architecture correction" at the end of this doc.**
+> Item 1 below (modal living in `app/[locale]/publica/page.tsx`) describes the
+> *original* plan. During PR review the modal was moved to the event's own detail page
+> instead, with `/publica` only redirecting there via a `?promote=1` marker. The rest of
+> this section (2-5) is unaffected.
+
 **In scope**
 1. Post-publish upsell modal in `app/[locale]/publica/page.tsx`.
 2. `/e/[eventId]/promote` page: benefits, static flat fee (€5, MVP placeholder), "Confirm
@@ -117,6 +123,15 @@ once the real endpoint ships, is a one-file fix.
 - No new `app/api/*` route. No Stripe SDK/webhook/secret in this repo for this feature.
 
 ## Modal (Wallapop-style)
+
+> **Superseded — see "Post-review architecture correction" at the end of this doc.** This
+> section describes the modal living in `publica/page.tsx` with `router.push` for both
+> buttons. The shipped version moves the modal to the event's own detail page
+> (`EventClient.tsx` + `components/PromoteUpsellModal.tsx`); `publica/page.tsx` only
+> redirects there with a `?promote=1` marker. "Keep it free" no longer navigates (the
+> user is already on the event page) — it only closes the modal and strips the marker.
+> The `return false` / close-sequencing mechanics described below are otherwise accurate
+> and still apply to the shipped component.
 
 Reuses the shared `Modal` component (`components/ui/common/modal`) unchanged, but its
 close/navigate sequencing must be exact:
@@ -306,3 +321,36 @@ mocked-auth/`E2E_TEST_MODE` specs that *would* need a synthetic owner
 unaffected by the modal either. Verified directly against all four spec files before
 finalizing — see "Testing" above for the corrected, narrower fix (update the one race
 condition in `publish-integration.spec.ts`, no E2E infra changes).
+
+## Post-review architecture correction (2026-08-04)
+
+An AI code review pass on the resulting PR (cubic) caught that this design doc and its
+implementation plan still described the modal living inside `publica/page.tsx`, but the
+shipped code doesn't work that way — a second, user-requested correction moved the modal
+after the design doc above was already written. Recording what actually shipped, since a
+future reader following the sections above verbatim would build a conflicting flow:
+
+**What actually ships:**
+- `publica/page.tsx`'s `onSubmit` success path redirects to `` /e/${slug}?promote=1 ``
+  (a query marker, not modal state) instead of rendering the modal itself.
+- The modal (`app/[locale]/e/[eventId]/components/PromoteUpsellModal.tsx`) is rendered
+  by `EventClient.tsx` — the event's own detail page — gated on `?promote=1` **and** on
+  the signed-in user matching `event.ownerId` (a second review finding: without the
+  ownership check, any visitor could trigger the upsell by hand-editing the URL, and its
+  CTA would lead them to the owner-only `/promote` page, which 404s for them).
+- "Keep it free" no longer calls `router.push` at all — the user is already on the
+  event's detail page, so it only closes the modal and strips the `promote` query param
+  (preserving any other existing params, e.g. `edit_suggested`) via `router.replace`.
+- "Promote Event" also strips the `promote` marker (via `router.replace`) *before*
+  pushing to `/promote`, so a later browser-back to the event doesn't re-show the modal.
+- This reuses the exact one-time-query-marker convention already established by
+  `newEvent`/`edit_suggested` in `EventClient.tsx` — not a new mechanism.
+
+**Why the change:** the user's own framing of the request ("when the user creates a new
+event, when it lands in the event detail page that has created, appears a new modal")
+was the actual product intent all along; the original plan's `publica`-hosted modal
+blocked navigation on the publish form itself, which didn't match that.
+
+This correction lives only in this addendum — the "Scope" and "Modal" sections above are
+left as historical record of the original plan (each now carries an inline pointer here)
+rather than being silently rewritten.

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -1,0 +1,358 @@
+# Promoted Events Carousel (phase 2 of event promotion)
+
+Date: 2026-08-03
+Status: Approved for implementation planning
+Branch: `feat/promoted-events-carousel` (based on `feat/event-promotion-checkout`)
+
+## Problem
+
+Phase 1 (`feat/event-promotion-checkout`, already shipped on this branch's base) added the
+upsell modal, the `/e/[eventId]/promote` page, and the Server Action that hands off to
+Gerard's backend for Stripe checkout. It explicitly left "how promoted surfaces to the
+frontend" undecided — no field on `EventSummaryResponseDTO`, no lookup endpoint, zero
+changes to list rendering. That's this phase: once an event is promoted, show it in a
+carousel — on the homepage, and on every event listing page — similar to how e.g. Vilaweb's
+"Agenda del Maresme" surfaces a region's events today.
+
+## Source of truth / what's confirmed vs. still open
+
+- No backend endpoint exists yet for "give me the active promoted events for X". The
+  closest existing thing, `app/api/promotions/active/route.ts`, is a placeholder that
+  returns `null` with a `TODO: replace with real database lookup` comment — and it's for
+  the unrelated restaurant-promotion feature, not events.
+- `EventSummaryResponseDTO` (`types/api/event.ts`) has no promotion/featured field. The only
+  existing "special card in a list" mechanism is `AdEvent`/`isAd` — Google AdSense banners
+  injected at deterministic positions (`insertAds` in `lib/api/events.ts`) — a different
+  domain (third-party ad revenue, not paid event boosts) and not reused here.
+- The existing restaurant-promotion product (`config/pricing.ts`, `types/sponsor.ts`) already
+  has a real geo-scope model: `town` / `region` / `country` tiers × duration. Event
+  promotion (phase 1) does not — `getEventPromotionOptions()` returns a single flat €5
+  fee, no scope choice at all.
+- Decision (confirmed with user): scope is **auto-derived** from the event's own location
+  for this MVP, not a purchasable choice. No changes to the phase-1 checkout flow. The
+  *purchased promotion record* (backend-owned) should still carry a scope field
+  (`town`/`region`/`everywhere` + slug) from day one so that turning scope into a paid
+  tier later is a pricing/config change, not a rearchitecture — but since that record and
+  its creation live entirely in Gerard's backend (per phase 1's "all payment logic lives
+  in the backend" boundary), this repo has nothing to build for that part. This phase only
+  *reads*.
+- **Terminology note**: this repo's own `PlaceType` (`types/common.ts`) is
+  `"region" | "town" | ""` — "comarca" (the Catalan administrative unit, e.g. Maresme) is
+  what this codebase already calls a **region**. `PromotionScope` below uses `region`, not
+  "comarca", to match the existing type rather than introduce a second word for the same
+  thing.
+- **Explicit divergence from the literal ask, called out so it isn't mistaken for the real
+  thing later**: the original request enumerated three purchasable surface tiers ("if only
+  appears in Cardedeu town, or homepage, or all pages"). What ships here, `PromotionScope`,
+  is a **query-side surface descriptor** ("which page is asking"), not the **purchased
+  tier** ("what the buyer paid for") — those happen to share vocabulary (town/homepage/
+  everywhere) but are different types. No purchase path for "all pages" reach exists yet;
+  every promoted event is only fetchable via its own town/region/homepage scope in this
+  phase, regardless of what a future buyer might want to pay extra for.
+- An old, unrelated remote branch (`origin/cursor/implement-featured-events-section-for-
+  user-promotion-7ea0`) already has commits mentioning a "featured events" section and
+  Stripe promotions. Checked and rejected as a base: it diverged from `main` in August
+  2025, touches 989 files, deletes ~144k lines relative to current `main` — an abandoned,
+  unrelated rewrite, not a usable starting point.
+
+## Scope
+
+**In scope**
+1. A new, isolated data-fetch function for "active promoted events for a given surface"
+   (homepage, or a specific town/region), built against a provisional contract — same
+   approach phase 1 took with the checkout endpoint before it existed.
+2. A reusable `PromotedEventsSection` server component, rendered on the homepage and on
+   every event listing page, hidden entirely when there's nothing to show for that scope.
+3. A small "Promoted" disclosure pill on cards inside this carousel only.
+4. i18n strings for the new section heading + pill label.
+
+**Explicitly out of scope**
+- Any change to the phase-1 checkout flow, pricing config, or `/e/[eventId]/promote` page.
+  Scope selection/pricing tiers are a future, backend-driven change.
+- The real backend endpoint itself (owned by Gerard's Spring Boot backend, not this repo).
+- A "Promoted" filter/toggle in the existing filter system.
+- Sorting/reordering organic listing results — this is an additional carousel, not a
+  reordering of the existing grid.
+
+## Data contract (provisional, isolated)
+
+New file `lib/api/promotedEvents.ts` (kept separate from `lib/api/events.ts`, which is
+already 800+ lines and has an unrelated set of responsibilities):
+
+```ts
+export type PromotionScope =
+  | { type: "homepage" }
+  | { type: "town" | "region"; slug: string };
+
+export async function getActivePromotedEvents(
+  scope: PromotionScope,
+): Promise<EventSummaryResponseDTO[]>
+```
+
+- Calls a placeholder endpoint, e.g. `GET ${apiUrl}/events/promotions/active?scope=<type>&slug=<slug>`
+  (query shape marked provisional/isolated in a comment, exactly like `createPromotionCheckout`
+  was marked in phase 1 — a field-name or shape mismatch once Gerard's real endpoint ships
+  is a one-file fix).
+- **Feature-flag short-circuit (performance + noise control).** The endpoint this calls
+  does not exist yet — every call is a guaranteed miss until Gerard ships it. Rather than
+  make that network round trip on every homepage/listing-page render forever, gate the
+  entire function on `process.env.PROMOTED_EVENTS_ENABLED === "true"` (default off/unset):
+  when off, return `[]` immediately with **no fetch call at all** — not "call and fail
+  fast," genuinely skip the network hop. This is not a permanent compatibility shim; it's a
+  dark-launch gate for a dependency that doesn't exist yet, flipped on once the real
+  endpoint is confirmed. Without it, every page on the site pays a doomed round trip on
+  every cache miss, indefinitely, with no ship date attached.
+- **Failures are quiet, not `captureException`-worthy.** Unlike `fetchEventsInternal`
+  (which reports failures via Sentry because a broken `/events` fetch is a real incident),
+  a non-2xx from this placeholder endpoint during the pre-launch gap is the *expected*
+  outcome, not an exception. Log via `console.warn` (or nothing) and return `[]`; do not
+  wire this into Sentry until the flag is flipped on and the endpoint is real — otherwise
+  every deploy alerts on a "failure" that's actually just "not built yet."
+- **Request mechanics copy `fetchEventsInternal` exactly** (`lib/api/events.ts:128-139`), not
+  `createPromotionCheckout`'s mutation path — this is a public GET, not an authenticated
+  mutation, so there's no `requireMutationAuth()`/`skipBodySigning`:
+  ```ts
+  const response = await fetchWithHmac(finalUrl, {
+    next: { revalidate: 300, tags: ["promoted-events"] },
+    headers: { Accept: "application/json" },
+  });
+  ```
+  `revalidate: 300` (5 min) is shorter than `fetchEvents`'s `600` since a promotion activating
+  should surface reasonably quickly; adjust once real traffic patterns exist. Same
+  `tags: ["promoted-events"]` convention as `fetchEvents`'s `tags: ["events"]`, for future
+  on-demand revalidation.
+- **cacheComponents (PPR) compatibility.** `next.config` has `cacheComponents: true`, and
+  `app/[locale]/[place]/page.tsx` already wraps its dynamic event fetch in a `Suspense`
+  boundary so the static shell can flush first (see the comment at `page.tsx:80`). The new
+  promoted-events fetch reuses that same existing Suspense boundary — it does not add a new
+  one, and it does not fetch anything outside it. This keeps the static-shell/dynamic-content
+  split intact; it does not introduce a second, uncached, un-suspended request per page load
+  the way a naive addition would.
+- Fails soft: any non-2xx response or network error is caught and returns `[]`. No thrown
+  error reaches a render path — this mirrors the Places "Where to eat" section's own
+  documented behavior ("Fails soft (200 + empty result) on any upstream error; the section
+  hides").
+- **Cap at the fetch layer, not the render layer**: `getActivePromotedEvents` slices its
+  result to `.slice(0, 8)` before returning (constant, e.g. `MAX_PROMOTED_EVENTS = 8`,
+  colocated in the same file). `EventsAroundServer` itself never caps `events.length` (only
+  its JSON-LD schema slices to 10), so an unbounded promoted list would otherwise be a
+  layout/payload problem, not just a hypothetical one.
+
+## Component
+
+New `components/ui/promotedEvents/PromotedEventsSection.tsx` — server component:
+
+```ts
+async function PromotedEventsSection({ scope }: { scope: PromotionScope })
+```
+
+- Calls `getActivePromotedEvents(scope)`. If empty, returns `null` (no wrapper markup at
+  all — matches `EventsAroundServer`'s own empty-hides-itself behavior, so nesting two
+  "hide if empty" checks is harmless, not redundant guard-of-a-guard).
+- Otherwise renders a heading (new `Components.PromotedEvents` i18n namespace — no
+  "see more" link, since there's no dedicated "all promoted events" page, and no
+  `DateFilterBadges`, since this isn't a date-filterable section), copying the exact JSX
+  shape of the existing "Popular Now Section" in
+  `components/ui/serverEventsCategorized/index.tsx:511-529` (`<div className="container
+  content-auto-section"><section className="py-section-y border-b"><SectionHeading .../>
+  <EventsAroundServer .../></section></div>`) — the closest existing sibling to what this
+  component needs, right down to `showJsonLd`:
+  ```tsx
+  <EventsAroundServer
+    events={promotedEvents}
+    layout="horizontal"
+    isPromoted
+    showJsonLd
+    title={t("title")}
+    jsonLdId={`promoted-events-${scopeKey}`}
+  />
+  ```
+  where `scopeKey = scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}``
+  — this also becomes `HorizontalScroll`'s `hintStorageKey` (via `jsonLdId` passthrough in
+  `EventsAroundServer`), so it must be unique per page or the first-scroll-nudge sessionStorage
+  flag would incorrectly carry over between e.g. Cardedeu's and Mataró's promoted carousels.
+  `showJsonLd` is included (reversing an earlier draft of this doc that considered omitting
+  it to avoid "duplicate `ItemList` schema" risk): the same page already renders multiple
+  overlapping `ItemList` blocks today (Popular Now + one per `FeaturedPlaceSection`), so this
+  isn't a new risk this design introduces — it's the codebase's already-accepted norm, and
+  the JSON-LD data source (`EventsAroundServer`) is the one being reused here anyway.
+- Reuses `EventsAroundServer` entirely for rendering: dedup, horizontal `HorizontalScroll`,
+  `CardHorizontalServer`, JSON-LD `ItemList` schema — all for free. No new carousel
+  primitive, no new card component.
+- `initialIsFavorite` is not passed (same as `FeaturedPlaceSection`'s existing call path
+  today — verified, not a regression this design introduces). Promoted cards render hearts
+  identically to comarca-carousel cards.
+
+**Threading the "Promoted" pill.** `EventsAroundServer` gets one new optional prop,
+`isPromoted?: boolean`, applied uniformly to every card it renders in a given call (not a
+per-event flag — if you're inside `PromotedEventsSection`'s carousel, every card in it is
+promoted, so there is nothing to distinguish per-item). Passed through to
+`CardHorizontalServer`, which gets the same optional prop and renders a small pill next to
+the existing `CategoryBadge`. **Styling: `badge-primary`**, an existing DESIGN.md token
+(`badge-primary: { background: colors.primary, color: colors.on-primary, rounded: full,
+... }`) — not invented for this feature. It's already the exact class used for this exact
+purpose elsewhere: `components/ui/restaurantPromotion/PromotedRestaurantCard.tsx:36` renders
+`<span className="badge-primary">{t("badge")}</span>` as that feature's own "this is a paid
+promotion" disclosure badge. Copying it here keeps one visual language for "promoted/paid"
+across both promotion features instead of inventing a second one. No changes to
+`EventSummaryResponseDTO`, no `ListEvent`-style union — this stays a rendering-only flag,
+avoiding the schema bloat the `isAd`/`AdEvent` mechanism has for an unrelated reason (that
+one needs a union because ad placeholders are spliced into an otherwise-organic array; here
+the whole array passed to `EventsAroundServer` is already 100% promoted events).
+
+## Placement
+
+- **Homepage**: NOT `app/[locale]/page.tsx` directly — that file only fetches data and
+  delegates all layout to `<ServerEventsCategorized>`. The actual insertion point is
+  inside `components/ui/serverEventsCategorized/index.tsx`, in the JSX block that today
+  renders "Popular Now" then "Featured Places" (`index.tsx:509-539`). Insert
+  `<PromotedEventsSection scope={{ type: "homepage" }} />` **before** the "Popular Now"
+  block — paid placements lead organic-popularity content, which itself already leads the
+  per-region "Featured Places" carousels.
+- **Every listing page**: `app/[locale]/[place]/page.tsx` (`PlacePageGate`) delegates its
+  layout to `PlacePageShell` (`components/partials/PlacePageShell.tsx`), which is what
+  actually renders `HybridEventsList` (`PlacePageShell.tsx:354`) — that's the insertion
+  point, prepended above `HybridEventsList`, not `page.tsx` itself. Scope is built from
+  `getPlaceTypeAndLabelCached(place)` (`@utils/helpers`, already called in
+  `generateMetadata` and reused for the page body). Its declared return type,
+  `PlaceTypeAndLabel.type`, is `"town" | "region" | ""` — but **verified against the actual
+  implementation** (`getPlaceTypeAndLabel`, `utils/location-helpers.ts:209-292`): every
+  branch returns `"town"` or `"region"` (empty place → `"region"`/"Catalunya";
+  `fetchPlaceBySlug` hit → `"town"`/`"region"` from the DTO's type; every fallback down to
+  the final catch-all → `"town"`) — there is no code path that returns `""`. The `""` member
+  of `PlaceType` is not reachable from this function; it exists for some other consumer of
+  the shared type, not this one. `PromotionScope`'s mapping is therefore total in practice,
+  but the insertion code still guards it defensively rather than casting past the type
+  checker: `if (!placeTypeLabel.type) return null;` before building `scope` — cheap,
+  correct, and honest that the branch is believed unreachable rather than pretending the
+  type union doesn't include it. The `[byDate]` and `[byDate]/[category]` child routes reuse
+  the same `PlacePageShell`, so no separate wiring is needed for those.
+- Both cases: the section renders nothing when `getActivePromotedEvents` returns `[]` —
+  no "no promoted events" empty state, no layout shift beyond a normal conditional render.
+
+## Performance
+
+- **No LCP competition.** The homepage's actual LCP element is a raw `<img
+  fetchPriority="high">` hero background (`serverEventsCategorized/index.tsx:205-212`),
+  entirely separate from event-card images. Every existing card carousel on this page,
+  including "Popular Now" and every `FeaturedPlaceSection`, is already explicitly
+  `usePriority={false}` (`index.tsx:351`, comment: "Homepage images are below the fold -
+  don't use priority loading"). `PromotedEventsSection` matches that convention —
+  `usePriority={false}` — regardless of where in the stack it sits; it does not introduce
+  a second priority image competing with the hero.
+- **Zero new client bundle.** `PromotedEventsSection`, `getActivePromotedEvents`, and every
+  component it reuses (`EventsAroundServer`, `HorizontalScroll`, `CardHorizontalServer`)
+  are server components or already-shipped client code — no new client-side JS ships for
+  the base carousel. The "Promoted" pill is a static server-rendered `<span>`, same cost
+  class as the existing `CategoryBadge`.
+- **Render-cost deferral for free.** The homepage insertion point reuses the
+  `content-auto-section` wrapper class already used by sibling sections (`content-
+  visibility: auto`), so this section gets the same off-screen render-cost deferral without
+  any new CSS.
+- **The real cost is the extra network call**, addressed above by the feature-flag
+  short-circuit: while `PROMOTED_EVENTS_ENABLED` is unset/false (its state through this
+  entire phase, until Gerard ships the real endpoint), `getActivePromotedEvents` returns
+  `[]` with zero network I/O — so shipping this phase today has **no** performance cost on
+  any page. The cost only appears once the flag is flipped on, at which point the existing
+  `next: { revalidate: 300 }` caching bounds it to one upstream call per scope per 5-minute
+  window, not per request.
+
+## SEO
+
+- **No new URLs, no sitemap change.** This adds cards linking to already-indexed
+  `/e/[slug]` pages — nothing new to crawl or list in `utils/sitemap.ts`.
+- **Duplicate internal links are not a duplicate-content issue.** The same event may now
+  be linked from both its organic listing position and the promoted carousel on one page.
+  Multiple internal links to the same URL on a page is normal and not penalized — this is
+  purely a UX/redundancy question, not an SEO one.
+- **`rel="sponsored"` does not apply here.** That attribute exists for paid *outbound*
+  links to third parties (Google's link-scheme guidance on advertising). These are internal
+  `/e/[slug]` navigations to the site's own content, not paid backlinks — calling this out
+  so it isn't reflexively added by a future contributor who sees "paid promotion" and
+  reaches for `rel="sponsored"` out of habit.
+- **JSON-LD**: see "Component" above — `showJsonLd` stays on, matching sibling sections.
+
+## Analytics
+
+- **Click tracking needs zero new props or component changes.** `CardHorizontalServer`
+  already wraps its link in `data-analytics-event-name="select_event"` with
+  `data-analytics-event-id`/`data-analytics-event-slug` (`CardLayout.tsx:40`, consumed by
+  the delegated click listener in `app/GoogleScriptsHeavy.tsx`). That listener already
+  merges in ambient context from the nearest ancestor `[data-analytics-container="true"]`
+  element — exactly the pattern `components/ui/hybridEventsList/index.tsx:59-61` uses today
+  (`data-analytics-container="true" data-analytics-context="events_list" data-analytics-
+  place-slug={place}`). `PromotedEventsSection` wraps its `EventsAroundServer` call in the
+  same kind of container:
+  ```tsx
+  <div data-analytics-container="true" data-analytics-context="promoted_carousel"
+       data-analytics-place-slug={scope.type === "homepage" ? "homepage" : scope.slug}>
+    <EventsAroundServer ... />
+  </div>
+  ```
+  Every click on a promoted card automatically fires `select_event` with `context:
+  "promoted_carousel"` and the right `place_slug` — no changes to `CardLayout`,
+  `CardHorizontalServer`, or the GA listener's attribute whitelist.
+- **Impression/view tracking is explicitly out of scope for this phase.** The one existing
+  impression-tracking hook, `useListingAnalytics` (`components/hooks/useListingAnalytics.ts`),
+  is hardcoded to the organic grid's DOM shape (`container.querySelector("section")`) and a
+  fixed `context: "listing"` — it doesn't fit a horizontal carousel's DOM, and adapting it
+  is new, non-trivial client code for a nice-to-have metric. Flagging this as a deliberate
+  non-goal, not a silent gap: "carousel was shown" impressions aren't tracked, only clicks.
+
+## Testing
+
+- **Unit (Vitest), new `test/lib/api/promotedEvents.test.ts`** — matching this codebase's
+  existing convention of testing pure/isolated functions rather than rendering async server
+  components in Vitest (see `test/events-around-server.test.tsx`, which tests the exported
+  `dedupeEvents` helper, not a rendered tree):
+  - `getActivePromotedEvents` returns `[]`, with no fetch call at all, when
+    `PROMOTED_EVENTS_ENABLED` is unset/false.
+  - Returns `[]` (not a throw) on non-2xx and on network error, once the flag is on.
+  - Builds the right query string per scope variant (`homepage` vs `town`/`region` + slug).
+  - Caps results at `MAX_PROMOTED_EVENTS` even if the (mocked) backend returns more.
+  - Does not call `captureException`/Sentry on a routine non-2xx (only `console.warn`, or
+    silent).
+- **Unit: any extracted pure helper** (e.g. a `scopeKey(scope)` function, if pulled out
+  rather than inlined) gets the same direct-function-call test treatment.
+- **No RSC render tests for `PromotedEventsSection` itself** — consistent with how
+  `FeaturedPlaceSection`/`EventsAroundServer` aren't render-tested today either; behavior
+  is covered via `getActivePromotedEvents`'s unit tests (does it return data) plus manual/
+  `agent-browser` verification during implementation (does it render correctly).
+- **E2E: honest scoping.** `getActivePromotedEvents` is a **server-side** fetch to the
+  external backend (same shape as `fetchEventsInternal`) — Playwright's `page.route()` only
+  intercepts *browser*-initiated requests. Existing e2e mocks (`e2e/filters-client-fetch.spec.ts`,
+  `e2e/load_more_with_filters.spec.ts`) all mock `/api/events`, a client-visible route; there
+  is no existing pattern in this repo for mocking a direct SSR-to-backend call, and building
+  one is out of scope here. Consequently, a "carousel populated with real promoted events"
+  E2E test isn't feasible until real staging backend data exists (same constraint phase 1
+  hit with the checkout endpoint). Scope for this phase: one regression assertion, in a new
+  `e2e/promoted-events-carousel.spec.ts`, that the homepage and one listing page still render
+  their existing content correctly with the feature flag off (today's actual production
+  state) — i.e., this change doesn't break anything, not that the new carousel works
+  end-to-end. Full E2E coverage of the populated carousel is a follow-up once
+  `PROMOTED_EVENTS_ENABLED` is flipped on against real backend data.
+
+## i18n
+
+New keys (added to `messages/ca.json`, `es.json`, `en.json`, mirroring the `App.EventPromote`
+namespace precedent from phase 1):
+- `Components.PromotedEvents.title` — carousel heading (e.g. "Esdeveniments destacats").
+- `Components.PromotedEvents.badge` — the disclosure pill label (e.g. "Patrocinat").
+
+## Risks / open questions carried forward (not blocking this implementation)
+
+- Real endpoint contract (query param names, response shape, whether `slug` needs to be a
+  town or also accept region/province) is unknown until Gerard defines it — isolated to
+  `getActivePromotedEvents`, one-file fix if it differs.
+- Auto-derived scope means a promoted event's audience is capped by its own town/region
+  for this MVP — the "everywhere"/"all pages" tier described in the original ask has no
+  purchase path yet (see the divergence note above); known, explicitly deferred, not an
+  oversight.
+- `PROMOTED_EVENTS_ENABLED` is documented in `.env.example`; the remaining deployment action
+  is configuring it in prod env config, deliberately deferred until Gerard's endpoint exists.
+  Checked `utils/env.ts`:
+  there's no central zod-validated env schema to register with (it's a handful of direct
+  `process.env.X` reads, e.g. `E2E_TEST_MODE`) — a plain `process.env.PROMOTED_EVENTS_ENABLED
+  === "true"` read is consistent with that convention, and it's server-only (no
+  `NEXT_PUBLIC_` prefix), which is correct since it's never read client-side.
+- No impression/view analytics (see "Analytics" above) — click-only for this phase.

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -108,19 +108,19 @@ export async function getActivePromotedEvents(
   outcome, not an exception. Log via `console.warn` (or nothing) and return `[]`; do not
   wire this into Sentry until the flag is flipped on and the endpoint is real — otherwise
   every deploy alerts on a "failure" that's actually just "not built yet."
-- **Request mechanics copy `fetchEventsInternal` exactly** (`lib/api/events.ts:128-139`), not
+- **Request mechanics copy `fetchEventsInternal`'s call shape** (`lib/api/events.ts:128-139`), not
   `createPromotionCheckout`'s mutation path — this is a public GET, not an authenticated
-  mutation, so there's no `requireMutationAuth()`/`skipBodySigning`:
+  mutation, so there's no `requireMutationAuth()`/`skipBodySigning`. Unlike `fetchEventsInternal`,
+  it does **not** opt into the Next fetch cache:
   ```ts
   const response = await fetchWithHmac(finalUrl, {
-    next: { revalidate: 300, tags: ["promoted-events"] },
     headers: { Accept: "application/json" },
   });
   ```
-  `revalidate: 300` (5 min) is shorter than `fetchEvents`'s `600` since a promotion activating
-  should surface reasonably quickly; adjust once real traffic patterns exist. Same
-  `tags: ["promoted-events"]` convention as `fetchEvents`'s `tags: ["events"]`, for future
-  on-demand revalidation.
+  No `next: { revalidate, tags }` here — external wrappers with high-cardinality per-scope URLs
+  caused a 146k-entry cache explosion previously (see
+  `docs/incidents/2026-01-20-fetch-cache-explosion.md`); this endpoint's per-place `scope`
+  parameter has the same shape, so it stays uncached at this layer.
 - **cacheComponents (PPR) compatibility.** `next.config` has `cacheComponents: true`, and
   `app/[locale]/[place]/page.tsx` already wraps its dynamic event fetch in a `Suspense`
   boundary so the static shell can flush first (see the comment at `page.tsx:80`). The new
@@ -167,7 +167,7 @@ async function PromotedEventsSection({ scope }: { scope: PromotionScope })
     jsonLdId={`promoted-events-${scopeKey}`}
   />
   ```
-  where `scopeKey = scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}``
+  where ``scopeKey = scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}` ``
   — this also becomes `HorizontalScroll`'s `hintStorageKey` (via `jsonLdId` passthrough in
   `EventsAroundServer`), so it must be unique per page or the first-scroll-nudge sessionStorage
   flag would incorrectly carry over between e.g. Cardedeu's and Mataró's promoted carousels.

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,4 +1,117 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
+
+const APP_REDIRECT_TIMEOUT = 30_000;
+const SESSION_READY_TIMEOUT = 30_000;
+
+function isAppUrl(url: URL): boolean {
+  return url.pathname === "/en" || url.pathname === "/en/";
+}
+
+async function pageDiagnostics(page: Page): Promise<string> {
+  const diagnostics = await page
+    .evaluate(() => ({
+      url: window.location.href,
+      readyState: document.readyState,
+    }))
+    .catch(() => ({ url: page.url(), readyState: "unavailable" }));
+
+  return `url=${diagnostics.url}, readyState=${diagnostics.readyState}`;
+}
+
+async function assertAuthenticatedSession(page: Page): Promise<void> {
+  let lastSessionCheck = "not checked";
+  try {
+    await expect
+      .poll(
+        async () => {
+          const state = await page.evaluate(async () => {
+            try {
+              const response = await fetch("/api/auth/me", {
+                credentials: "include",
+                cache: "no-store",
+              });
+              const body = await response.text();
+              if (!response.ok) {
+                return { authenticated: false, detail: `status=${response.status}` };
+              }
+              try {
+                const data = JSON.parse(body) as { user?: unknown };
+                return {
+                  authenticated: Boolean(data.user),
+                  detail: data.user ? "user present" : "response has no user",
+                };
+              } catch {
+                return { authenticated: false, detail: "invalid JSON response" };
+              }
+            } catch (error) {
+              return {
+                authenticated: false,
+                detail: `request failed: ${error instanceof Error ? error.message : String(error)}`,
+              };
+            }
+          });
+          lastSessionCheck = state.detail;
+          return state.authenticated;
+        },
+        {
+          timeout: SESSION_READY_TIMEOUT,
+          intervals: [250, 500, 1_000, 2_000],
+        },
+      )
+      .toBe(true);
+  } catch (error) {
+    throw new Error(
+      `OIDC callback reached the app, but /api/auth/me did not confirm an authenticated session (${lastSessionCheck}; ${await pageDiagnostics(page)}).`,
+      { cause: error },
+    );
+  }
+}
+
+async function throwLoginError(page: Page, cause: unknown): Promise<never> {
+  const invalidCredentials = page
+    .getByText(/incorrect account or password|invalid.?credentials/i)
+    .first();
+  if (await invalidCredentials.isVisible().catch(() => false)) {
+    throw new Error(
+      "Logto rejected E2E_STAGING_EMAIL/E2E_STAGING_PASSWORD (\"Incorrect account or " +
+        "password\"). This is a staging test-user credentials problem, not an app bug — " +
+        "verify the account exists and its email is verified in the preproduction Logto " +
+        "tenant, and that the `staging` GitHub environment secret matches its password " +
+        "(see scripts/e2e-staging-setup.sh).",
+      { cause },
+    );
+  }
+
+  throw new Error(
+    `Logto login did not reach a usable application session (${await pageDiagnostics(page)}).`,
+    { cause },
+  );
+}
+
+// This helper intentionally waits for the OIDC navigation to commit, not for
+// the destination's complete `load` event. The authenticated application state
+// is established by /api/auth/me below, which is the contract the app itself
+// uses instead of an incidental page-load milestone.
+async function waitForAppRedirect(page: Page): Promise<void> {
+  try {
+    await Promise.all([
+      page.waitForURL(isAppUrl, {
+        timeout: APP_REDIRECT_TIMEOUT,
+        waitUntil: "commit",
+      }),
+      page
+        .getByRole("button", { name: /sign in|log in|continue|submit|entra/i })
+        .first()
+        .click({ noWaitAfter: true }),
+    ]);
+  } catch (error) {
+    // `waitForURL` also checks the current URL. If the app committed but the
+    // waiter was interrupted by a later lifecycle problem, continue to the
+    // authoritative session check rather than failing on page `load`.
+    if (isAppUrl(new URL(page.url()))) return;
+    await throwLoginError(page, error);
+  }
+}
 
 /**
  * Log in through Logto's hosted sign-in page (reached via the OIDC redirect
@@ -26,38 +139,6 @@ export async function loginViaUI(page: Page, email: string, password: string) {
   const password_ = page.locator('input[type="password"]').first();
   await password_.waitFor({ timeout: 15_000 });
   await password_.fill(password);
-  await page
-    .getByRole("button", { name: /sign in|log in|continue|submit|entra/i })
-    .first()
-    .click();
-
-  // Wait until Logto redirects back to the app (off the auth domain / OIDC).
-  try {
-    await page.waitForURL(
-      (url) =>
-        !/\/oidc\//.test(url.pathname) &&
-        !url.host.startsWith("auth-") &&
-        !url.pathname.includes("/iniciar-sessio"),
-      { timeout: 30_000 },
-    );
-  } catch (timeoutError) {
-    // A stuck-on-Logto timeout is ambiguous by itself — surface the actual
-    // reason (usually a stale/unverified test-user password) instead of a
-    // bare "Timeout 30000ms exceeded" that sends the next person spelunking
-    // through API response logs.
-    const invalidCredentials = page
-      .getByText(/incorrect account or password|invalid.?credentials/i)
-      .first();
-    if (await invalidCredentials.isVisible().catch(() => false)) {
-      throw new Error(
-        "Logto rejected E2E_STAGING_EMAIL/E2E_STAGING_PASSWORD (\"Incorrect account or " +
-          "password\"). This is a staging test-user credentials problem, not an app bug — " +
-          "verify the account exists and its email is verified in the preproduction Logto " +
-          "tenant, and that the `staging` GitHub environment secret matches its password " +
-          "(see scripts/e2e-staging-setup.sh).",
-        { cause: timeoutError },
-      );
-    }
-    throw timeoutError;
-  }
+  await waitForAppRedirect(page);
+  await assertAuthenticatedSession(page);
 }

--- a/e2e/promoted-events-carousel.spec.ts
+++ b/e2e/promoted-events-carousel.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+// PROMOTED_EVENTS_ENABLED is unset/false in every real deploy today (the
+// backend endpoint this feature calls doesn't exist yet — see
+// lib/api/promotedEvents.ts and docs/superpowers/specs/2026-08-03-promoted-
+// events-carousel-design.md). This spec is a regression check for that
+// default state: the new code path must not change existing page behavior
+// while the flag is off. Full E2E coverage of the populated carousel is a
+// follow-up once the flag is flipped on against real backend data.
+test.describe("promoted events carousel (flag off, default state)", () => {
+  test("homepage renders normally with no promoted-events section", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // Homepage intentionally renders two <h1>s (an sr-only one for SEO/crawler
+    // resilience plus the visible hero title) — see app/[locale]/page.tsx.
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+
+  test("a town listing page renders normally with no promoted-events section", async ({
+    page,
+  }) => {
+    await page.goto("/cardedeu");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect, type Page } from "@playwright/test";
+import type {
+  EventSummaryResponseDTO,
+  PagedResponseDTO,
+} from "types/api/event";
 import { loginViaUI } from "./helpers/login";
 
 /**
@@ -27,8 +31,9 @@ const hasCredentials = Boolean(email && password);
 const UNIQUE_SUFFIX = `e2e-${Date.now()}`;
 const TEST_EVENT_TITLE = `Test Event ${UNIQUE_SUFFIX}`;
 
-// Store created event slug for cleanup
+// Store created event identity for cleanup
 let createdEventSlug: string | null = null;
+let createdEventId: string | null = null;
 
 /** Delete event via API (direct fetch with cookies from browser context) */
 async function cleanupEvent(page: Page, uuid: string) {
@@ -45,24 +50,81 @@ async function cleanupEvent(page: Page, uuid: string) {
   }
 }
 
+async function findCreatedEventId(
+  page: Page,
+  title: string,
+): Promise<string | null> {
+  try {
+    const query = new URLSearchParams({
+      page: "0",
+      size: "50",
+      term: title,
+      _e2e_cleanup: String(Date.now()),
+    });
+    const response = await page.request.get(`/api/events?${query.toString()}`);
+    if (!response.ok()) return null;
+    const data = (await response.json()) as PagedResponseDTO<EventSummaryResponseDTO>;
+    return data.content.find((event) => event.title === title)?.id ?? null;
+  } catch (error) {
+    console.warn(`Failed to find event for cleanup (${title}):`, error);
+    return null;
+  }
+}
+
+async function listingContainsEvent(
+  page: Page,
+  eventSlug: string,
+  title: string,
+  attempt: number,
+): Promise<boolean> {
+  const query = new URLSearchParams({
+    page: "0",
+    size: "50",
+    place: "barcelona",
+    term: title,
+    // The events proxy is intentionally cached for normal users. A unique
+    // query key per poll prevents a failed first read from pinning the test to
+    // a stale CDN response while the backend finishes indexing the event.
+    _e2e: `${Date.now()}-${attempt}`,
+  });
+  const response = await page.request.get(`/api/events?${query.toString()}`);
+  if (!response.ok()) return false;
+
+  const data = (await response.json()) as PagedResponseDTO<EventSummaryResponseDTO>;
+  return data.content.some((event) => event.slug === eventSlug);
+}
+
 test.describe("Publish integration (staging)", () => {
   // Skip entire suite if no staging credentials
   test.skip(!hasCredentials, "Skipped: E2E_STAGING_EMAIL/E2E_STAGING_PASSWORD not set");
   test.setTimeout(180_000); // 3 minutes — real backend is slow
 
   test.afterAll(async ({ browser }) => {
-    // Best-effort cleanup via API if we captured the slug
-    if (createdEventSlug) {
-      const context = await browser.newContext();
-      const page = await context.newPage();
-      try {
-        await loginViaUI(page, email!, password!);
-        await cleanupEvent(page, createdEventSlug);
-      } catch (error) {
-        console.warn("Cleanup failed:", error);
-      } finally {
-        await context.close();
+    if (!hasCredentials) return;
+
+    // Always attempt cleanup after login. If redirect parsing failed after a
+    // successful publish, recover the unique event ID through the API first.
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await loginViaUI(page, email!, password!);      let fallbackEventId: string | null = null;
+      if (!createdEventId) {
+        await expect
+          .poll(
+            async () => {
+              fallbackEventId = await findCreatedEventId(page, TEST_EVENT_TITLE);
+              return fallbackEventId;
+            },
+            { timeout: 30_000, intervals: [500, 1_000, 2_000, 5_000] },
+          )
+          .not.toBeNull();
       }
+      const eventId = createdEventId ?? fallbackEventId;
+      if (eventId) await cleanupEvent(page, eventId);
+    } catch (error) {
+      console.warn("Cleanup failed:", error);
+    } finally {
+      await context.close();
     }
   });
 
@@ -137,9 +199,14 @@ test.describe("Publish integration (staging)", () => {
     // Click the select to open dropdown, type to search, pick first result
     await townSelect.click();
     await page.keyboard.type("Barcelona");
-    await page.waitForTimeout(1_000); // Wait for async search
-    // Select the first option from the dropdown
-    await page.keyboard.press("Enter");
+    // Wait for the async result the user can actually select; do not sleep for
+    // an assumed network duration.
+    const townOption = page
+      .locator('[role="listbox"]:visible')
+      .getByRole("option")
+      .first();
+    await expect(townOption).toBeVisible({ timeout: 15_000 });
+    await townOption.click();
 
     // Fill location name
     await page.locator("#location").fill("Test Venue - E2E");
@@ -147,11 +214,12 @@ test.describe("Publish integration (staging)", () => {
     // Select first available category
     const categoriesSelect = page.locator("#categories").locator("..");
     await categoriesSelect.click();
-    await page.waitForTimeout(500);
-    await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("Enter");
-    // Close the dropdown
-    await page.keyboard.press("Escape");
+    const categoryOption = page
+      .locator('[role="listbox"]:visible')
+      .getByRole("option")
+      .first();
+    await expect(categoryOption).toBeVisible({ timeout: 15_000 });
+    await categoryOption.click();
 
     // Advance to step 2
     await page.getByTestId("next-button").click();
@@ -184,14 +252,23 @@ test.describe("Publish integration (staging)", () => {
         String(futureDate.getDate()).padStart(2, "0"),
       ].join("-");
     });
-    const datePickerTrigger = page.getByRole("button", {
+    // The DatePicker is lazy-loaded. Its placeholder intentionally replaces
+    // itself on focus, so pointer/keyboard activation can race the React
+    // remount (detached element / html intercepts pointer events). Focus is
+    // the wrapper's explicit lazy-load contract; wait for the real Start
+    // button after that replacement before interacting with the calendar.
+    const datePickerPlaceholder = page.getByRole("button", {
       name: /select date and time|seleccionar data i hora/i,
     });
-    await expect(datePickerTrigger).toBeVisible({ timeout: 15_000 });
-    await datePickerTrigger.click();
     const startDateButton = page.getByRole("button", {
-      name: /^(Start|Inici) \*:/,
+      name: /^(Start|Inici):/,
     });
+    await expect(datePickerPlaceholder.or(startDateButton)).toBeVisible({
+      timeout: 15_000,
+    });
+    if (await datePickerPlaceholder.isVisible().catch(() => false)) {
+      await datePickerPlaceholder.focus();
+    }
     await expect(startDateButton).toBeVisible({ timeout: 15_000 });
     await startDateButton.click();
     const futureDateButton = page.locator(`[data-day="${futureDateIso}"]`);
@@ -202,17 +279,23 @@ test.describe("Publish integration (staging)", () => {
     const publishButton = page.getByTestId("publish-button");
     await expect(publishButton).toBeVisible({ timeout: 10_000 });
 
-    // Wait for canPublishRef to arm (250ms guard in EventForm)
-    await page.waitForTimeout(500);
-
-    await publishButton.click();
+    // The button's visibility/enabled state is the public readiness contract;
+    // let Playwright's web-first assertion wait for it instead of sleeping for
+    // the implementation's internal publish-arm timer.
+    await expect(publishButton).toHaveAttribute("data-publish-ready", "true", {
+      timeout: 10_000,
+    });
+    // Start waiting before the click so the redirect cannot race the assertion.
+    await Promise.all([
+      page.waitForURL((url) => !url.pathname.includes("/publica"), {
+        timeout: 60_000,
+      }),
+      publishButton.click(),
+    ]);
 
     // ── Step 6: Wait for success ──
-    // After publish, the page should redirect to the event detail or show success
-    // Wait for navigation away from /publica
-    await page.waitForURL((url) => !url.pathname.includes("/publica"), {
-      timeout: 60_000,
-    });
+    // The URL assertion above proves the publish action completed and redirected
+    // away from the form.
 
     const currentUrl = page.url();
     console.log(`Event created, redirected to: ${currentUrl}`);
@@ -234,6 +317,14 @@ test.describe("Publish integration (staging)", () => {
       waitUntil: "domcontentloaded",
       timeout: 60_000,
     });
+
+    const createdEvent = await page.evaluate(async (slug: string) => {
+      const res = await fetch(`/api/events/${slug}?_e2e=${Date.now()}`);
+      if (!res.ok) return null;
+      return res.json();
+    }, createdEventSlug);
+    createdEventId = createdEvent?.id ?? null;
+    expect(createdEventId, "expected the created event to have an id").toBeTruthy();
 
     // Title (data we entered) is the H1. This also proves it's not the
     // not-found page, which would render a different heading.
@@ -263,12 +354,28 @@ test.describe("Publish integration (staging)", () => {
     // from the created event's own `owner` field (OwnerSummaryDTO, the same
     // data the page renders from) rather than the auth session — see the
     // note above Step 0's login check for why those two can diverge.
-    const eventOwner = await page.evaluate(async (slug: string) => {
-      const res = await fetch(`/api/events/${slug}`);
-      if (!res.ok) return null;
-      const data = await res.json();
-      return data?.owner ?? null;
-    }, createdEventSlug);
+    const readEventOwner = async () =>
+      page.evaluate(async (slug: string | null) => {
+        if (!slug) return null;
+        const res = await fetch(`/api/events/${slug}?_e2e=${Date.now()}`);
+        if (!res.ok) return null;
+        const data = await res.json();
+        return data?.owner ?? null;
+      }, createdEventSlug);
+
+    // Owner enrichment can lag behind the initial event write. Poll the same
+    // detail API contract the page consumes instead of assuming one response
+    // immediately contains the attribution data.
+    await expect
+      .poll(
+        async () => {
+          const owner = await readEventOwner();
+          return Boolean(owner?.username || owner?.displayName);
+        },
+        { timeout: 30_000, intervals: [250, 500, 1_000, 2_000] },
+      )
+      .toBe(true);
+    const eventOwner = await readEventOwner();
     const expectedCreatorName: string =
       eventOwner?.displayName || eventOwner?.username || "";
     const expectedCreatorSlug: string = eventOwner?.username || "";
@@ -281,33 +388,41 @@ test.describe("Publish integration (staging)", () => {
       "expected the created event's owner to have a username (used for the /perfil/<username> link)"
     ).not.toBe("");
 
-    // Rendered twice, same as the location block above — once inline for
-    // mobile, once in the desktop sidebar — so filter to the visible
-    // instance instead of assuming DOM order.
-    const creatorBlock = page
-      .locator('[data-testid="event-created-by"]:visible')
+    // The page renders this semantic block twice for responsive layouts. Test
+    // the attribution contract in the DOM and scope the link to the matching
+    // block; CSS visibility is a layout concern and is not part of this API
+    // integration test.
+    const creatorBlock =    page
+      .getByTestId("event-created-by")
+      .filter({ hasText: expectedCreatorName })
       .first();
-    await expect(creatorBlock).toBeVisible({ timeout: 10_000 });
+    await expect(creatorBlock).toBeAttached({ timeout: 10_000 });
     await expect(creatorBlock).toContainText(expectedCreatorName);
-    const creatorLinkHref = await page
-      .locator('[data-testid="event-created-by-link"]:visible')
-      .first()
-      .getAttribute("href");
-    expect(creatorLinkHref).toContain(
-      `/perfil/${encodeURIComponent(expectedCreatorSlug)}`
-    );
+    await expect(
+      creatorBlock.getByTestId("event-created-by-link").first()
+    ).toHaveAttribute("href", new RegExp(`/perfil/${expectedCreatorSlug}`));
 
-    // ── Step 8: Verify the event appears on a listing page ──
-    await page.goto("/en/barcelona", {
-      waitUntil: "domcontentloaded",
-      timeout: 60_000,
-    });
-    // Soft: listing may be cached or paginate the fresh event off page 1.
+    // ── Step 8: Verify eventual listing inclusion through the API ──
+    // The rendered place page and /api/events are cached independently, and a
+    // newly published event can take time to reach the backend's search/index
+    // path. Poll a fresh cache key until the server contract observes it. This
+    // keeps the check meaningful without asserting against one stale HTML page
+    // or hiding the failure with expect.soft().
+    let listingAttempt = 0;
     await expect
-      .soft(
-        page.getByText(TEST_EVENT_TITLE).first(),
-        "freshly published event should appear in the Barcelona listing"
+      .poll(
+        async () =>
+          listingContainsEvent(
+            page,
+            createdEventSlug!,
+            TEST_EVENT_TITLE,
+            listingAttempt++,
+          ),
+        {
+          timeout: 60_000,
+          intervals: [500, 1_000, 2_000, 5_000],
+        },
       )
-      .toBeVisible({ timeout: 15_000 });
+      .toBe(true);
   });
 });

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -497,8 +497,14 @@ test.describe("Publish integration (staging)", () => {
       // This test creates its own event, separate from the suite-level
       // afterAll cleanup (which only tracks TEST_EVENT_TITLE). The DELETE
       // route resolves by slug internally, so no extra id lookup is needed.
-      if (createdPromoteSlug) {
-        await cleanupEvent(page, createdPromoteSlug);
+      // Falls back to a title lookup (reusing the same helper afterAll uses
+      // for its own recovery) on the rare chance the redirect itself never
+      // matched /e/{slug} — otherwise a failed run leaks an event on staging
+      // that nothing ever cleans up.
+      const cleanupTarget =
+        createdPromoteSlug ?? (await findCreatedEventId(page, promoteTestTitle));
+      if (cleanupTarget) {
+        await cleanupEvent(page, cleanupTarget);
       }
     }
   });

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -471,25 +471,35 @@ test.describe("Publish integration (staging)", () => {
       publishButton.click(),
     ]);
 
-    const upsellModal = page.getByTestId("promote-upsell-modal");
-    await expect(upsellModal).toBeVisible({ timeout: 15_000 });
+    // Capture the slug as soon as it's known (right after the redirect off
+    // /publica), then run every subsequent assertion inside try/finally.
+    // Cleanup only runs at the very end of the happy path otherwise — if the
+    // modal never becomes visible or the /promote navigation times out, the
+    // event this test created would never be deleted, and the suite-level
+    // afterAll can't recover it (it only matches TEST_EVENT_TITLE, not this
+    // test's distinct promoteTestTitle).
+    const createdSlugMatch = page.url().match(/\/e\/([^/?#]+)/);
+    const createdPromoteSlug = createdSlugMatch ? createdSlugMatch[1] : null;
 
-    await Promise.all([
-      page.waitForURL((url) => url.pathname.includes("/promote"), {
-        timeout: 30_000,
-      }),
-      page.getByTestId("promote-upsell-modal-action-button").click(),
-    ]);
+    try {
+      const upsellModal = page.getByTestId("promote-upsell-modal");
+      await expect(upsellModal).toBeVisible({ timeout: 15_000 });
 
-    expect(page.url()).toContain("/promote");
+      await Promise.all([
+        page.waitForURL((url) => url.pathname.includes("/promote"), {
+          timeout: 30_000,
+        }),
+        page.getByTestId("promote-upsell-modal-action-button").click(),
+      ]);
 
-    // Cleanup: this test creates its own event, separate from the suite-level
-    // afterAll cleanup (which only tracks TEST_EVENT_TITLE). The DELETE route
-    // resolves by slug internally — same simple pattern already used for
-    // createdEventSlug in afterAll above — so no extra id lookup is needed.
-    const slugMatch = page.url().match(/\/e\/([^/]+)\/promote/);
-    if (slugMatch) {
-      await cleanupEvent(page, slugMatch[1]);
+      expect(page.url()).toContain("/promote");
+    } finally {
+      // This test creates its own event, separate from the suite-level
+      // afterAll cleanup (which only tracks TEST_EVENT_TITLE). The DELETE
+      // route resolves by slug internally, so no extra id lookup is needed.
+      if (createdPromoteSlug) {
+        await cleanupEvent(page, createdPromoteSlug);
+      }
     }
   });
 });

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -94,6 +94,109 @@ async function listingContainsEvent(
   return data.content.some((event) => event.slug === eventSlug);
 }
 
+/**
+ * Fills and advances the publish wizard through all three steps (basics,
+ * location, image/dates), leaving the caller on step 3 ready to interact
+ * with the publish button. Shared by every test in this file that needs to
+ * get an event through the form — each test still owns its own submit and
+ * post-submit assertions, since those differ (keep it free vs. promote).
+ */
+async function fillPublishForm(
+  page: Page,
+  data: { title: string; description: string; url: string; location: string },
+): Promise<void> {
+  await page.goto("/en/publica", {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+
+  const form = page.getByTestId("event-form");
+  await expect(form).toBeVisible({ timeout: 30_000 });
+  await expect(form).toHaveAttribute("data-hydrated", "true", {
+    timeout: 30_000,
+  });
+
+  // ── Step 0 (basics) ──
+  await page.locator("#title").fill(data.title);
+  await page.locator("#description").fill(data.description);
+  await page.locator("#url").fill(data.url);
+  await page.getByTestId("next-button").click();
+
+  // ── Step 1 (location) ──
+  const townSelect = page.getByTestId("town-select");
+  await expect(townSelect).toBeVisible({ timeout: 15_000 });
+  await townSelect.click();
+  await page.keyboard.type("Barcelona");
+  // Wait for the async result the user can actually select; do not sleep for
+  // an assumed network duration.
+  const townOption = page
+    .locator('[role="listbox"]:visible')
+    .getByRole("option")
+    .first();
+  await expect(townOption).toBeVisible({ timeout: 15_000 });
+  await townOption.click();
+
+  await page.locator("#location").fill(data.location);
+
+  const categoriesSelect = page.locator("#categories").locator("..");
+  await categoriesSelect.click();
+  const categoryOption = page
+    .locator('[role="listbox"]:visible')
+    .getByRole("option")
+    .first();
+  await expect(categoryOption).toBeVisible({ timeout: 15_000 });
+  await categoryOption.click();
+  await page.getByTestId("next-button").click();
+
+  // ── Step 2 (image & dates) ──
+  const imageUrlTab = page.getByRole("button", { name: /url|enllaç/i });
+  if (await imageUrlTab.isVisible()) {
+    await imageUrlTab.click();
+  }
+  const imageUrlInput = page.locator('input[placeholder*="http"]').first();
+  if (await imageUrlInput.isVisible()) {
+    await imageUrlInput.fill("https://picsum.photos/800/600");
+  }
+
+  // The date picker renders buttons rather than #event-date-* inputs. Its
+  // defaults are today at 09:00, which can already be past when CI runs in
+  // the afternoon; active listing endpoints correctly omit such events.
+  // Move the start to a deterministic future date so the published event is
+  // eligible for the active Barcelona listing. The picker keeps the default
+  // one-hour duration when the start day changes.
+  const futureDateIso = await page.evaluate(() => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 2);
+    return [
+      futureDate.getFullYear(),
+      String(futureDate.getMonth() + 1).padStart(2, "0"),
+      String(futureDate.getDate()).padStart(2, "0"),
+    ].join("-");
+  });
+  // The DatePicker is lazy-loaded. Its placeholder intentionally replaces
+  // itself on focus, so pointer/keyboard activation can race the React
+  // remount (detached element / html intercepts pointer events). Focus is
+  // the wrapper's explicit lazy-load contract; wait for the real Start
+  // button after that replacement before interacting with the calendar.
+  const datePickerPlaceholder = page.getByRole("button", {
+    name: /select date and time|seleccionar data i hora/i,
+  });
+  const startDateButton = page.getByRole("button", {
+    name: /^(Start|Inici):/,
+  });
+  await expect(datePickerPlaceholder.or(startDateButton)).toBeVisible({
+    timeout: 15_000,
+  });
+  if (await datePickerPlaceholder.isVisible().catch(() => false)) {
+    await datePickerPlaceholder.focus();
+  }
+  await expect(startDateButton).toBeVisible({ timeout: 15_000 });
+  await startDateButton.click();
+  const futureDateButton = page.locator(`[data-day="${futureDateIso}"]`);
+  await expect(futureDateButton).toBeVisible({ timeout: 15_000 });
+  await futureDateButton.click();
+}
+
 test.describe("Publish integration (staging)", () => {
   // Skip entire suite if no staging credentials
   test.skip(!hasCredentials, "Skipped: E2E_STAGING_EMAIL/E2E_STAGING_PASSWORD not set");
@@ -169,111 +272,13 @@ test.describe("Publish integration (staging)", () => {
       "expected /api/auth/me to return a logged-in user with a username"
     ).toBeTruthy();
 
-    // ── Step 1: Navigate to publish page ──
-    await page.goto("/en/publica", {
-      waitUntil: "domcontentloaded",
-      timeout: 60_000,
+    // ── Steps 1-4: Fill and advance the publish form ──
+    await fillPublishForm(page, {
+      title: TEST_EVENT_TITLE,
+      description: `Automated E2E test event created at ${new Date().toISOString()}. Safe to delete.`,
+      url: "https://example.com/e2e-test",
+      location: "Test Venue - E2E",
     });
-
-    const form = page.getByTestId("event-form");
-    await expect(form).toBeVisible({ timeout: 30_000 });
-    await expect(form).toHaveAttribute("data-hydrated", "true", {
-      timeout: 30_000,
-    });
-
-    // ── Step 2: Fill form — Step 0 (basics) ──
-    await page.locator("#title").fill(TEST_EVENT_TITLE);
-    await page.locator("#description").fill(
-      `Automated E2E test event created at ${new Date().toISOString()}. Safe to delete.`
-    );
-    await page.locator("#url").fill("https://example.com/e2e-test");
-
-    // Advance to step 1
-    await page.getByTestId("next-button").click();
-
-    // ── Step 3: Fill form — Step 1 (location) ──
-    // Wait for cities to load, then select first available town
-    const townSelect = page.getByTestId("town-select");
-    await expect(townSelect).toBeVisible({ timeout: 15_000 });
-
-    // Click the select to open dropdown, type to search, pick first result
-    await townSelect.click();
-    await page.keyboard.type("Barcelona");
-    // Wait for the async result the user can actually select; do not sleep for
-    // an assumed network duration.
-    const townOption = page
-      .locator('[role="listbox"]:visible')
-      .getByRole("option")
-      .first();
-    await expect(townOption).toBeVisible({ timeout: 15_000 });
-    await townOption.click();
-
-    // Fill location name
-    await page.locator("#location").fill("Test Venue - E2E");
-
-    // Select first available category
-    const categoriesSelect = page.locator("#categories").locator("..");
-    await categoriesSelect.click();
-    const categoryOption = page
-      .locator('[role="listbox"]:visible')
-      .getByRole("option")
-      .first();
-    await expect(categoryOption).toBeVisible({ timeout: 15_000 });
-    await categoryOption.click();
-
-    // Advance to step 2
-    await page.getByTestId("next-button").click();
-
-    // ── Step 4: Fill form — Step 2 (image & dates) ──
-    // Use URL mode for image (simpler for E2E)
-    const imageUrlTab = page.getByRole("button", { name: /url|enllaç/i });
-    if (await imageUrlTab.isVisible()) {
-      await imageUrlTab.click();
-    }
-
-    // Fill image URL (use a known stable placeholder)
-    const imageUrlInput = page.locator('input[placeholder*="http"]').first();
-    if (await imageUrlInput.isVisible()) {
-      await imageUrlInput.fill("https://picsum.photos/800/600");
-    }
-
-    // The date picker renders buttons rather than #event-date-* inputs. Its
-    // defaults are today at 09:00, which can already be past when CI runs in
-    // the afternoon; active listing endpoints correctly omit such events.
-    // Move the start to a deterministic future date so the published event is
-    // eligible for the active Barcelona listing. The picker keeps the default
-    // one-hour duration when the start day changes.
-    const futureDateIso = await page.evaluate(() => {
-      const futureDate = new Date();
-      futureDate.setDate(futureDate.getDate() + 2);
-      return [
-        futureDate.getFullYear(),
-        String(futureDate.getMonth() + 1).padStart(2, "0"),
-        String(futureDate.getDate()).padStart(2, "0"),
-      ].join("-");
-    });
-    // The DatePicker is lazy-loaded. Its placeholder intentionally replaces
-    // itself on focus, so pointer/keyboard activation can race the React
-    // remount (detached element / html intercepts pointer events). Focus is
-    // the wrapper's explicit lazy-load contract; wait for the real Start
-    // button after that replacement before interacting with the calendar.
-    const datePickerPlaceholder = page.getByRole("button", {
-      name: /select date and time|seleccionar data i hora/i,
-    });
-    const startDateButton = page.getByRole("button", {
-      name: /^(Start|Inici):/,
-    });
-    await expect(datePickerPlaceholder.or(startDateButton)).toBeVisible({
-      timeout: 15_000,
-    });
-    if (await datePickerPlaceholder.isVisible().catch(() => false)) {
-      await datePickerPlaceholder.focus();
-    }
-    await expect(startDateButton).toBeVisible({ timeout: 15_000 });
-    await startDateButton.click();
-    const futureDateButton = page.locator(`[data-day="${futureDateIso}"]`);
-    await expect(futureDateButton).toBeVisible({ timeout: 15_000 });
-    await futureDateButton.click();
 
     // ── Step 5: Submit ──
     const publishButton = page.getByTestId("publish-button");
@@ -285,12 +290,19 @@ test.describe("Publish integration (staging)", () => {
     await expect(publishButton).toHaveAttribute("data-publish-ready", "true", {
       timeout: 10_000,
     });
-    // Start waiting before the click so the redirect cannot race the assertion.
+    // Publishing now shows the post-publish promotion upsell modal instead of
+    // an immediate redirect. Wait for the modal, then dismiss via "keep it
+    // free" (this test's intent: verify the plain publish → detail page path
+    // still works).
+    await publishButton.click();
+    const upsellModal = page.getByTestId("promote-upsell-modal");
+    await expect(upsellModal).toBeVisible({ timeout: 30_000 });
+
     await Promise.all([
       page.waitForURL((url) => !url.pathname.includes("/publica"), {
         timeout: 60_000,
       }),
-      publishButton.click(),
+      page.getByTestId("promote-modal-keep-free").click(),
     ]);
 
     // ── Step 6: Wait for success ──
@@ -424,5 +436,50 @@ test.describe("Publish integration (staging)", () => {
         },
       )
       .toBe(true);
+  });
+
+  test("login → publish event → promote upsell links to the promote page", async ({
+    page,
+  }) => {
+    await loginViaUI(page, email!, password!);
+    await expect(page.getByTestId("user-avatar-button")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const promoteTestTitle = `${TEST_EVENT_TITLE} Promote`;
+    await fillPublishForm(page, {
+      title: promoteTestTitle,
+      description: `Automated E2E test event for promote flow, created at ${new Date().toISOString()}. Safe to delete.`,
+      url: "https://example.com/e2e-test-promote",
+      location: "Test Venue - E2E Promote",
+    });
+
+    const publishButton = page.getByTestId("publish-button");
+    await expect(publishButton).toBeVisible({ timeout: 10_000 });
+    await expect(publishButton).toHaveAttribute("data-publish-ready", "true", {
+      timeout: 10_000,
+    });
+    await publishButton.click();
+
+    const upsellModal = page.getByTestId("promote-upsell-modal");
+    await expect(upsellModal).toBeVisible({ timeout: 30_000 });
+
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.includes("/promote"), {
+        timeout: 30_000,
+      }),
+      page.getByTestId("promote-upsell-modal-action-button").click(),
+    ]);
+
+    expect(page.url()).toContain("/promote");
+
+    // Cleanup: this test creates its own event, separate from the suite-level
+    // afterAll cleanup (which only tracks TEST_EVENT_TITLE). The DELETE route
+    // resolves by slug internally — same simple pattern already used for
+    // createdEventSlug in afterAll above — so no extra id lookup is needed.
+    const slugMatch = page.url().match(/\/e\/([^/]+)\/promote/);
+    if (slugMatch) {
+      await cleanupEvent(page, slugMatch[1]);
+    }
   });
 });

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -290,20 +290,22 @@ test.describe("Publish integration (staging)", () => {
     await expect(publishButton).toHaveAttribute("data-publish-ready", "true", {
       timeout: 10_000,
     });
-    // Publishing now shows the post-publish promotion upsell modal instead of
-    // an immediate redirect. Wait for the modal, then dismiss via "keep it
-    // free" (this test's intent: verify the plain publish → detail page path
-    // still works).
-    await publishButton.click();
-    const upsellModal = page.getByTestId("promote-upsell-modal");
-    await expect(upsellModal).toBeVisible({ timeout: 30_000 });
-
+    // Publishing redirects straight to the created event's detail page (with
+    // a one-time ?promote=1 marker); the promotion upsell modal then appears
+    // there rather than blocking navigation. Wait for the redirect first,
+    // then dismiss the modal via "keep it free" (this test's intent: verify
+    // the plain publish → detail page path still works).
     await Promise.all([
       page.waitForURL((url) => !url.pathname.includes("/publica"), {
         timeout: 60_000,
       }),
-      page.getByTestId("promote-modal-keep-free").click(),
+      publishButton.click(),
     ]);
+
+    const upsellModal = page.getByTestId("promote-upsell-modal");
+    await expect(upsellModal).toBeVisible({ timeout: 15_000 });
+    await page.getByTestId("promote-modal-keep-free").click();
+    await expect(upsellModal).not.toBeVisible({ timeout: 10_000 });
 
     // ── Step 6: Wait for success ──
     // The URL assertion above proves the publish action completed and redirected
@@ -459,10 +461,18 @@ test.describe("Publish integration (staging)", () => {
     await expect(publishButton).toHaveAttribute("data-publish-ready", "true", {
       timeout: 10_000,
     });
-    await publishButton.click();
+
+    // Publishing redirects straight to the created event's detail page
+    // (?promote=1 marker); the modal appears there, not before navigating.
+    await Promise.all([
+      page.waitForURL((url) => !url.pathname.includes("/publica"), {
+        timeout: 60_000,
+      }),
+      publishButton.click(),
+    ]);
 
     const upsellModal = page.getByTestId("promote-upsell-modal");
-    await expect(upsellModal).toBeVisible({ timeout: 30_000 });
+    await expect(upsellModal).toBeVisible({ timeout: 15_000 });
 
     await Promise.all([
       page.waitForURL((url) => url.pathname.includes("/promote"), {

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -381,9 +381,14 @@ export async function createPromotionCheckout(
   if (!response.ok) {
     const errorText = await response.text();
     console.error("createPromotionCheckout: error response:", errorText);
-    throw new Error(
+    const err = new Error(
       `HTTP error! status: ${response.status}, body: ${errorText}`,
     );
+    // Propagate the HTTP status the same way requireMutationAuth's own 401
+    // does, so a backend-rejected (expired) token is classified as
+    // stale-session too, not only a missing local access token.
+    (err as Error & { status: number }).status = response.status;
+    throw err;
   }
 
   const payload = await response.json();

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -357,6 +357,45 @@ export async function deleteEventById(id: string): Promise<void> {
   }
 }
 
+export async function createPromotionCheckout(
+  id: string,
+  successUrl: string,
+  cancelUrl: string,
+): Promise<{ url: string }> {
+  const { apiUrl, authToken } = await requireMutationAuth();
+
+  const response = await fetchWithHmac(
+    `${apiUrl}/events/${id}/promotions/checkout`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify({ successUrl, cancelUrl }),
+      skipBodySigning: true,
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("createPromotionCheckout: error response:", errorText);
+    throw new Error(
+      `HTTP error! status: ${response.status}, body: ${errorText}`,
+    );
+  }
+
+  const payload = await response.json();
+  if (!payload || typeof payload.url !== "string") {
+    throw new Error(
+      "createPromotionCheckout: backend response missing url field",
+    );
+  }
+
+  return { url: payload.url };
+}
+
 export async function createEvent(
   data: EventCreateRequestDTO,
   e2eExtras?: E2EEventExtras,

--- a/lib/api/promotedEvents.ts
+++ b/lib/api/promotedEvents.ts
@@ -1,0 +1,88 @@
+import type { z } from "zod";
+import { fetchWithHmac } from "./fetch-wrapper";
+import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
+import {
+  EventSummaryResponseDTOSchema,
+  enhanceEventImage,
+} from "@lib/validation/event";
+import type { EventSummaryResponseDTO } from "types/api/event";
+import type { PromotionScope } from "types/event";
+
+export type { PromotionScope } from "types/event";
+
+const MAX_PROMOTED_EVENTS = 8;
+
+function buildScopeQuery(scope: PromotionScope): string {
+  const params = new URLSearchParams({ scope: scope.type });
+  if (scope.type !== "homepage") {
+    params.set("slug", scope.slug);
+  }
+  return params.toString();
+}
+
+/**
+ * Provisional, isolated contract: the backend endpoint this calls does not exist yet
+ * (Gerard's promotion-checkout endpoint shipped in phase 1; the "list active promoted
+ * events" read side is still undecided). A field-name or shape mismatch once it ships
+ * is a one-file fix, confined to this function.
+ */
+export async function getActivePromotedEvents(
+  scope: PromotionScope,
+): Promise<EventSummaryResponseDTO[]> {
+  if (process.env.PROMOTED_EVENTS_ENABLED !== "true") {
+    return [];
+  }
+
+  if (!isApiUrlConfigured()) {
+    return [];
+  }
+
+  try {
+    const apiUrl = getApiUrl();
+    const finalUrl = `${apiUrl}/events/promotions/active?${buildScopeQuery(scope)}`;
+
+    // NEVER add `next: { revalidate, tags }` here — external wrappers must not opt
+    // into the Next fetch cache (high-cardinality per-scope URLs caused a 146k-entry
+    // cache explosion, see docs/incidents/2026-01-20-fetch-cache-explosion.md).
+    const response = await fetchWithHmac(finalUrl, {
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `getActivePromotedEvents: HTTP ${response.status} for ${finalUrl}`,
+      );
+      return [];
+    }
+
+    const data = await response.json();
+    const content = Array.isArray(data?.content) ? data.content : [];
+
+    // Validate each item individually rather than the array atomically — one
+    // malformed item (wherever it falls in the response) should be dropped,
+    // not discard every valid promotion alongside it.
+    const events: EventSummaryResponseDTO[] = [];
+    let invalidCount = 0;
+    let firstError: z.ZodError | undefined;
+    for (const item of content) {
+      const parsed = EventSummaryResponseDTOSchema.safeParse(item);
+      if (parsed.success) {
+        events.push(parsed.data as EventSummaryResponseDTO);
+      } else {
+        invalidCount++;
+        firstError ??= parsed.error;
+      }
+    }
+    if (invalidCount > 0) {
+      console.warn(
+        `getActivePromotedEvents: dropped ${invalidCount} invalid content item(s)`,
+        firstError,
+      );
+    }
+
+    return events.map(enhanceEventImage).slice(0, MAX_PROMOTED_EVENTS);
+  } catch (error) {
+    console.warn("getActivePromotedEvents: fetch failed", error);
+    return [];
+  }
+}

--- a/lib/i18n/client-namespaces.ts
+++ b/lib/i18n/client-namespaces.ts
@@ -11,7 +11,7 @@
  * namespace is missing from these lists. Update both places together.
  */
 
-export const CLIENT_APP_KEYS = ["EditProfile", "Error", "EventEdit", "NotFound", "Publish"] as const;
+export const CLIENT_APP_KEYS = ["EditProfile", "Error", "EventEdit", "EventPromote", "NotFound", "Publish"] as const;
 
 export const CLIENT_COMPONENT_KEYS = [
   "AdBoard",

--- a/lib/validation/event.ts
+++ b/lib/validation/event.ts
@@ -224,7 +224,7 @@ export function parseCategorizedEvents(
   return Object.fromEntries(normalizedEntries) as CategorizedEvents;
 }
 
-function enhanceEventImage<
+export function enhanceEventImage<
   T extends { imageUrl?: string | null; hash?: string | null; updatedAt?: string }
 >(event: T): T {
   const cacheKey = event.hash || event.updatedAt;

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -210,6 +210,31 @@
       "myEvents": "Els meus esdeveniments",
       "requiredNote": "* camps obligatoris"
     },
+    "EventPromote": {
+      "title": "Promociona el teu esdeveniment",
+      "description": "Arriba a més gent promocionant el teu esdeveniment a Esdeveniments.cat.",
+      "heading": "Promociona el teu esdeveniment",
+      "subheading": "Destaca't per arribar a més gent i aparèixer als primers llocs.",
+      "benefit1": "Més visibilitat a l'agenda",
+      "benefit2": "Prioritat davant d'altres esdeveniments",
+      "benefit3": "Més persones interessades",
+      "priceLabel": "Preu",
+      "priceNote": "Tarifa plana, pagament únic.",
+      "confirmButton": "Confirma i paga",
+      "confirmButtonLoading": "Redirigint a pagament...",
+      "backToEvent": "Tornar a l'esdeveniment",
+      "errorGeneric": "Alguna cosa ha fallat. Torna-ho a intentar.",
+      "successPage": {
+        "title": "Gràcies!",
+        "subtitle": "El teu esdeveniment ja està promocionat.",
+        "backToEvent": "Veure el teu esdeveniment"
+      },
+      "cancelPage": {
+        "title": "Pagament cancel·lat",
+        "subtitle": "El teu esdeveniment continua sent gratuït.",
+        "backToEvent": "Tornar a l'esdeveniment"
+      }
+    },
     "PublishPage": {
       "metaTitle": "Publica el teu esdeveniment gratis a Catalunya | Agenda cultural - Esdeveniments.cat",
       "metaDescription": "Afegeix el teu concert, exposició, teatre o activitat a l'agenda de Catalunya. Publicació gratuïta i ràpida. Arriba a milers de persones interessades en cultura i oci.",
@@ -313,6 +338,12 @@
       "subheading": "Afegeix el teu concert, exposició, teatre, taller o activitat cultural a l'agenda més gran de Catalunya. És gratuït!",
       "sponsorTitle": "Tens un negoci local?",
       "sponsorLink": "Veure opcions de patrocini",
+      "promoteUpsell": {
+        "title": "Impulsa el teu esdeveniment!",
+        "description": "Promociona el teu esdeveniment ara per arribar a molta més gent i aparèixer als primers llocs de la plataforma.",
+        "promoteButton": "Promocionar esdeveniment",
+        "keepFreeButton": "Mantenir gratuït"
+      },
       "benefits": {
         "title": "Per què publicar a Esdeveniments.cat?",
         "free": "100% gratuït - sense costos ocults",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -224,6 +224,7 @@
       "confirmButtonLoading": "Redirigint a pagament...",
       "backToEvent": "Tornar a l'esdeveniment",
       "errorGeneric": "Alguna cosa ha fallat. Torna-ho a intentar.",
+      "errorStaleSession": "La teva sessió ha caducat. Torna a iniciar sessió.",
       "successPage": {
         "title": "Gràcies!",
         "subtitle": "El teu esdeveniment ja està promocionat.",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -859,6 +859,10 @@
       "badge": "Patrocinat",
       "activeUntil": "Promoció activa fins al {date}"
     },
+    "PromotedEvents": {
+      "title": "Esdeveniments destacats",
+      "badge": "Patrocinat"
+    },
     "WhereToEatSection": {
       "title": "On pots menjar",
       "promote": "Promociona el teu restaurant",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -945,6 +945,7 @@
     "EventPage": {
       "sponsored": "Contingut patrocinat",
       "editEvent": "Editar esdeveniment",
+      "promoteEvent": "Promocionar",
       "editTitle": "Edita: {title}",
       "editError": "Error en actualitzar l'esdeveniment",
       "editSave": "Desa canvis",

--- a/messages/en.json
+++ b/messages/en.json
@@ -851,6 +851,10 @@
       "badge": "Sponsored",
       "activeUntil": "Promotion active until {date}"
     },
+    "PromotedEvents": {
+      "title": "Featured events",
+      "badge": "Sponsored"
+    },
     "WhereToEatSection": {
       "showPhoto": "Show photo",
       "title": "Where you can eat",

--- a/messages/en.json
+++ b/messages/en.json
@@ -210,6 +210,31 @@
       "myEvents": "My events",
       "requiredNote": "* required fields"
     },
+    "EventPromote": {
+      "title": "Promote your event",
+      "description": "Reach more people by promoting your event on Esdeveniments.cat.",
+      "heading": "Promote your event",
+      "subheading": "Stand out to reach more people and appear at the top.",
+      "benefit1": "More visibility in the agenda",
+      "benefit2": "Priority over other events",
+      "benefit3": "More interested people",
+      "priceLabel": "Price",
+      "priceNote": "Flat fee, one-time payment.",
+      "confirmButton": "Confirm and pay",
+      "confirmButtonLoading": "Redirecting to payment...",
+      "backToEvent": "Back to event",
+      "errorGeneric": "Something went wrong. Please try again.",
+      "successPage": {
+        "title": "Thank you!",
+        "subtitle": "Your event is now promoted.",
+        "backToEvent": "View your event"
+      },
+      "cancelPage": {
+        "title": "Payment canceled",
+        "subtitle": "Your event remains free.",
+        "backToEvent": "Back to event"
+      }
+    },
     "PublishPage": {
       "metaTitle": "Publish your event for free in Catalonia | Cultural agenda - Esdeveniments.cat",
       "metaDescription": "Add your concert, exhibition, theatre or activity to the Catalonia agenda. Free and fast publication. Reach thousands of people interested in culture and leisure.",
@@ -313,6 +338,12 @@
       "subheading": "Add your concert, exhibition, theatre, workshop or cultural activity to Catalonia's largest agenda. It's free!",
       "sponsorTitle": "Have a local business?",
       "sponsorLink": "See sponsorship options",
+      "promoteUpsell": {
+        "title": "Boost your event!",
+        "description": "Promote your event now to reach way more people and appear at the top of the platform.",
+        "promoteButton": "Promote Event",
+        "keepFreeButton": "Keep it free"
+      },
       "benefits": {
         "title": "Why publish on Esdeveniments.cat?",
         "free": "100% free - no hidden costs",

--- a/messages/en.json
+++ b/messages/en.json
@@ -224,6 +224,7 @@
       "confirmButtonLoading": "Redirecting to payment...",
       "backToEvent": "Back to event",
       "errorGeneric": "Something went wrong. Please try again.",
+      "errorStaleSession": "Your session has expired. Please sign in again.",
       "successPage": {
         "title": "Thank you!",
         "subtitle": "Your event is now promoted.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -937,6 +937,7 @@
     "EventPage": {
       "sponsored": "Sponsored content",
       "editEvent": "Edit event",
+      "promoteEvent": "Promote",
       "editTitle": "Edit: {title}",
       "editError": "Error updating event",
       "editSave": "Save changes",

--- a/messages/es.json
+++ b/messages/es.json
@@ -210,6 +210,31 @@
       "myEvents": "Mis eventos",
       "requiredNote": "* campos obligatorios"
     },
+    "EventPromote": {
+      "title": "Promociona tu evento",
+      "description": "Llega a más gente promocionando tu evento en Esdeveniments.cat.",
+      "heading": "Promociona tu evento",
+      "subheading": "Destaca para llegar a más gente y aparecer en los primeros puestos.",
+      "benefit1": "Más visibilidad en la agenda",
+      "benefit2": "Prioridad frente a otros eventos",
+      "benefit3": "Más personas interesadas",
+      "priceLabel": "Precio",
+      "priceNote": "Tarifa plana, pago único.",
+      "confirmButton": "Confirmar y pagar",
+      "confirmButtonLoading": "Redirigiendo al pago...",
+      "backToEvent": "Volver al evento",
+      "errorGeneric": "Algo ha fallado. Inténtalo de nuevo.",
+      "successPage": {
+        "title": "¡Gracias!",
+        "subtitle": "Tu evento ya está promocionado.",
+        "backToEvent": "Ver tu evento"
+      },
+      "cancelPage": {
+        "title": "Pago cancelado",
+        "subtitle": "Tu evento sigue siendo gratuito.",
+        "backToEvent": "Volver al evento"
+      }
+    },
     "PublishPage": {
       "metaTitle": "Publica tu evento gratis en Cataluña | Agenda cultural - Esdeveniments.cat",
       "metaDescription": "Añade tu concierto, exposición, teatro o actividad a la agenda de Cataluña. Publicación gratuita y rápida. Llega a miles de personas interesadas en cultura y ocio.",
@@ -313,6 +338,12 @@
       "subheading": "Añade tu concierto, exposición, teatro, taller o actividad cultural a la agenda más grande de Cataluña. ¡Es gratis!",
       "sponsorTitle": "¿Tienes un negocio local?",
       "sponsorLink": "Ver opciones de patrocinio",
+      "promoteUpsell": {
+        "title": "¡Impulsa tu evento!",
+        "description": "Promociona tu evento ahora para llegar a mucha más gente y aparecer en los primeros puestos de la plataforma.",
+        "promoteButton": "Promocionar evento",
+        "keepFreeButton": "Mantener gratis"
+      },
       "benefits": {
         "title": "¿Por qué publicar en Esdeveniments.cat?",
         "free": "100% gratuito - sin costes ocultos",

--- a/messages/es.json
+++ b/messages/es.json
@@ -224,6 +224,7 @@
       "confirmButtonLoading": "Redirigiendo al pago...",
       "backToEvent": "Volver al evento",
       "errorGeneric": "Algo ha fallado. Inténtalo de nuevo.",
+      "errorStaleSession": "Tu sesión ha caducado. Inicia sesión de nuevo.",
       "successPage": {
         "title": "¡Gracias!",
         "subtitle": "Tu evento ya está promocionado.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -937,6 +937,7 @@
     "EventPage": {
       "sponsored": "Contenido patrocinado",
       "editEvent": "Editar evento",
+      "promoteEvent": "Promocionar",
       "editTitle": "Editar: {title}",
       "editError": "Error al actualizar el evento",
       "editSave": "Guardar cambios",

--- a/messages/es.json
+++ b/messages/es.json
@@ -851,6 +851,10 @@
       "badge": "Patrocinado",
       "activeUntil": "Promoción activa hasta el {date}"
     },
+    "PromotedEvents": {
+      "title": "Eventos destacados",
+      "badge": "Patrocinado"
+    },
     "WhereToEatSection": {
       "showPhoto": "Ver foto",
       "title": "Dónde puedes comer",

--- a/test/event-client-promote-upsell.test.tsx
+++ b/test/event-client-promote-upsell.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { useState, useEffect, type ComponentType } from "react";
 import type { EventClientProps } from "types/props";
 
@@ -46,8 +46,17 @@ vi.mock("@utils/analytics", () => ({
 
 vi.mock("../app/[locale]/e/[eventId]/components/PromoteUpsellModal", () => ({
   __esModule: true,
-  default: ({ slug }: { slug: string }) => (
-    <div data-testid="promote-upsell-modal">{slug}</div>
+  default: ({
+    slug,
+    setOpen,
+  }: {
+    slug: string;
+    setOpen: (open: boolean) => void;
+  }) => (
+    <div data-testid="promote-upsell-modal">
+      {slug}
+      <button data-testid="mock-close" onClick={() => setOpen(false)} />
+    </div>
   ),
 }));
 
@@ -117,6 +126,32 @@ describe("EventClient promote upsell wiring", () => {
     expect(mockSendGoogleEvent).toHaveBeenCalledWith("promote_modal_shown", {
       event_slug: "my-event",
       source: "event_detail",
+    });
+  });
+
+  it("strips only the promote marker on close, preserving other query params", async () => {
+    mockSearchParams = new URLSearchParams("promote=1&edit_suggested=true");
+    render(<EventClient event={buildEvent()} />);
+
+    const modal = await screen.findByTestId("promote-upsell-modal");
+    fireEvent.click(screen.getByTestId("mock-close"));
+
+    expect(modal).toBeDefined();
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/en/e/my-event?edit_suggested=true",
+      { scroll: false },
+    );
+  });
+
+  it("strips the promote marker on close with no other params, leaving a bare pathname", async () => {
+    mockSearchParams = new URLSearchParams("promote=1");
+    render(<EventClient event={buildEvent()} />);
+
+    await screen.findByTestId("promote-upsell-modal");
+    fireEvent.click(screen.getByTestId("mock-close"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/en/e/my-event", {
+      scroll: false,
     });
   });
 });

--- a/test/event-client-promote-upsell.test.tsx
+++ b/test/event-client-promote-upsell.test.tsx
@@ -18,9 +18,6 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
-vi.mock("./hooks/useEventAnalytics", () => ({
-  useEventAnalytics: () => {},
-}));
 vi.mock("../app/[locale]/e/[eventId]/hooks/useEventAnalytics", () => ({
   useEventAnalytics: () => {},
 }));
@@ -42,6 +39,12 @@ vi.mock("@heroicons/react/24/outline", () => ({
 const mockSendGoogleEvent = vi.fn();
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: (...args: unknown[]) => mockSendGoogleEvent(...args),
+}));
+
+const OWNER_ID = "owner-uuid-1";
+let mockAuthUser: { id: string } | null = { id: OWNER_ID };
+vi.mock("@components/hooks/useAuth", () => ({
+  useAuth: () => ({ user: mockAuthUser }),
 }));
 
 vi.mock("../app/[locale]/e/[eventId]/components/PromoteUpsellModal", () => ({
@@ -96,6 +99,7 @@ function buildEvent(): EventClientProps["event"] {
     placeSlug: "barcelona",
     hasImage: false,
     origin: "MANUAL",
+    ownerId: OWNER_ID,
   };
 }
 
@@ -103,6 +107,7 @@ describe("EventClient promote upsell wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = new URLSearchParams();
+    mockAuthUser = { id: OWNER_ID };
   });
 
   it("does not show the promote upsell modal when there is no promote marker", async () => {
@@ -133,10 +138,9 @@ describe("EventClient promote upsell wiring", () => {
     mockSearchParams = new URLSearchParams("promote=1&edit_suggested=true");
     render(<EventClient event={buildEvent()} />);
 
-    const modal = await screen.findByTestId("promote-upsell-modal");
+    await screen.findByTestId("promote-upsell-modal");
     fireEvent.click(screen.getByTestId("mock-close"));
 
-    expect(modal).toBeDefined();
     expect(mockReplace).toHaveBeenCalledWith(
       "/en/e/my-event?edit_suggested=true",
       { scroll: false },
@@ -153,5 +157,29 @@ describe("EventClient promote upsell wiring", () => {
     expect(mockReplace).toHaveBeenCalledWith("/en/e/my-event", {
       scroll: false,
     });
+  });
+
+  it("does not show the modal for a signed-in user who is not the event owner, even with ?promote=1", () => {
+    mockSearchParams = new URLSearchParams("promote=1");
+    mockAuthUser = { id: "someone-else" };
+    render(<EventClient event={buildEvent()} />);
+
+    expect(screen.queryByTestId("promote-upsell-modal")).toBeNull();
+    expect(mockSendGoogleEvent).not.toHaveBeenCalledWith(
+      "promote_modal_shown",
+      expect.anything(),
+    );
+  });
+
+  it("does not show the modal for a logged-out visitor, even with ?promote=1", () => {
+    mockSearchParams = new URLSearchParams("promote=1");
+    mockAuthUser = null;
+    render(<EventClient event={buildEvent()} />);
+
+    expect(screen.queryByTestId("promote-upsell-modal")).toBeNull();
+    expect(mockSendGoogleEvent).not.toHaveBeenCalledWith(
+      "promote_modal_shown",
+      expect.anything(),
+    );
   });
 });

--- a/test/event-client-promote-upsell.test.tsx
+++ b/test/event-client-promote-upsell.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useState, useEffect, type ComponentType } from "react";
+import type { EventClientProps } from "types/props";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const mockReplace = vi.fn();
+vi.mock("@i18n/routing", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/en/e/my-event",
+}));
+
+let mockSearchParams = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("./hooks/useEventAnalytics", () => ({
+  useEventAnalytics: () => {},
+}));
+vi.mock("../app/[locale]/e/[eventId]/hooks/useEventAnalytics", () => ({
+  useEventAnalytics: () => {},
+}));
+
+vi.mock("components/ui/adArticle", () => ({
+  __esModule: true,
+  default: () => <div data-testid="ad-article" />,
+}));
+
+vi.mock("@components/ui/common/SectionHeading", () => ({
+  __esModule: true,
+  default: () => <div data-testid="section-heading" />,
+}));
+
+vi.mock("@heroicons/react/24/outline", () => ({
+  MegaphoneIcon: () => <svg data-testid="megaphone-icon" />,
+}));
+
+const mockSendGoogleEvent = vi.fn();
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: (...args: unknown[]) => mockSendGoogleEvent(...args),
+}));
+
+vi.mock("../app/[locale]/e/[eventId]/components/PromoteUpsellModal", () => ({
+  __esModule: true,
+  default: ({ slug }: { slug: string }) => (
+    <div data-testid="promote-upsell-modal">{slug}</div>
+  ),
+}));
+
+// next/dynamic's real loader resolves asynchronously. Mirror the existing
+// project convention (see navigation-filters-modal tests) of resolving the
+// dynamic import in tests — using real state so the resolution triggers a
+// re-render, since findByTestId below needs to observe it.
+vi.mock("next/dynamic", () => ({
+  default: (loader: () => Promise<{ default: ComponentType<Record<string, unknown>> }>) => {
+    return function DynamicMock(props: Record<string, unknown>) {
+      const [Component, setComponent] = useState<ComponentType<
+        Record<string, unknown>
+      > | null>(null);
+      useEffect(() => {
+        let active = true;
+        loader().then((mod) => {
+          if (active) setComponent(() => mod.default);
+        });
+        return () => {
+          active = false;
+        };
+      }, []);
+      return Component ? <Component {...props} /> : null;
+    };
+  },
+}));
+
+import EventClient from "../app/[locale]/e/[eventId]/EventClient";
+
+function buildEvent(): EventClientProps["event"] {
+  return {
+    id: "event-uuid-1",
+    slug: "my-event",
+    title: "My Event",
+    endDate: "2026-09-01",
+    categorySlug: undefined,
+    placeSlug: "barcelona",
+    hasImage: false,
+    origin: "MANUAL",
+  };
+}
+
+describe("EventClient promote upsell wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("does not show the promote upsell modal when there is no promote marker", async () => {
+    render(<EventClient event={buildEvent()} />);
+    // The modal is only ever rendered when showPromoteUpsell is true, so its
+    // dynamic import never even loads here — no async wait needed.
+    expect(screen.queryByTestId("promote-upsell-modal")).toBeNull();
+    expect(mockSendGoogleEvent).not.toHaveBeenCalledWith(
+      "promote_modal_shown",
+      expect.anything(),
+    );
+  });
+
+  it("shows the promote upsell modal and fires analytics when ?promote=1 is present", async () => {
+    mockSearchParams = new URLSearchParams("promote=1");
+    render(<EventClient event={buildEvent()} />);
+
+    expect(
+      await screen.findByTestId("promote-upsell-modal"),
+    ).toHaveTextContent("my-event");
+    expect(mockSendGoogleEvent).toHaveBeenCalledWith("promote_modal_shown", {
+      event_slug: "my-event",
+      source: "event_detail",
+    });
+  });
+});

--- a/test/event-details-section-promote-action.test.tsx
+++ b/test/event-details-section-promote-action.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { EventDetailResponseDTO } from "types/api/event";
+import type { AuthUser } from "types/auth";
+
+const OWNER_ID = "owner-uuid-1";
+
+let mockAuthUser: AuthUser | null = null;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => {
+    const t = (key: string) => key;
+    t.rich = (key: string) => key;
+    return t;
+  },
+}));
+
+vi.mock("@i18n/routing", () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@heroicons/react/24/outline", () => ({
+  GlobeAltIcon: () => <svg data-testid="globe-icon" />,
+  ClockIcon: () => <svg data-testid="clock-icon" />,
+  UserIcon: () => <svg data-testid="user-icon" />,
+  MegaphoneIcon: () => <svg data-testid="megaphone-icon" />,
+}));
+
+vi.mock("@components/ui/common/SectionHeading", () => ({
+  __esModule: true,
+  default: () => <div data-testid="section-heading" />,
+}));
+
+vi.mock("@components/ui/primitives/PressableAnchor", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+vi.mock("@components/hooks/useAuth", () => ({
+  useAuth: () => ({ user: mockAuthUser }),
+}));
+
+import EventDetailsSection from "@app/[locale]/e/[eventId]/components/EventDetailsSection";
+
+function buildEvent(
+  overrides: Partial<EventDetailResponseDTO> = {},
+): EventDetailResponseDTO {
+  return {
+    id: "event-uuid-1",
+    hash: "hash",
+    slug: "my-event",
+    title: "My Event",
+    type: "FREE",
+    url: "",
+    description: "desc",
+    imageUrl: "",
+    startDate: "2026-09-01",
+    startTime: null,
+    endDate: "2026-09-01",
+    endTime: null,
+    location: "Location",
+    visits: 0,
+    origin: "MANUAL",
+    owner: {
+      id: OWNER_ID,
+      displayName: "Creator",
+      username: "creator",
+      avatarUrl: null,
+      organizerVerified: false,
+    },
+    city: {
+      id: 1,
+      name: "City",
+      slug: "city",
+      latitude: 0,
+      longitude: 0,
+      postalCode: "08001",
+      rssFeed: null,
+      enabled: true,
+    },
+    region: { id: 1, name: "Region", slug: "region" },
+    province: { id: 1, name: "Region", slug: "region" },
+    categories: [],
+    ...overrides,
+  };
+}
+
+describe("EventDetailsSection promote action (mobile)", () => {
+  beforeEach(() => {
+    mockAuthUser = null;
+  });
+
+  it("shows the promote link on the mobile details section when the signed-in user owns the event", () => {
+    mockAuthUser = {
+      id: OWNER_ID,
+      email: "a@b.com",
+      name: "A",
+      username: "a",
+    };
+    render(<EventDetailsSection event={buildEvent()} />);
+
+    const link = screen.getByTestId("event-promote-link");
+    expect(link.getAttribute("href")).toBe("/e/my-event/promote");
+  });
+
+  it("does not show the promote link when the signed-in user is not the owner", () => {
+    mockAuthUser = {
+      id: "someone-else",
+      email: "b@c.com",
+      name: "B",
+      username: "b",
+    };
+    render(<EventDetailsSection event={buildEvent()} />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+
+  it("does not show the promote link when logged out", () => {
+    mockAuthUser = null;
+    render(<EventDetailsSection event={buildEvent()} />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+});

--- a/test/event-promote-action.test.tsx
+++ b/test/event-promote-action.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { AuthUser } from "types/auth";
+
+const OWNER_ID = "e10c6a5f-306c-487f-9e71-876f67c7bbb2";
+const OTHER_USER_ID = "different-user-uuid";
+
+let authUser: AuthUser | null = null;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@i18n/routing", () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@heroicons/react/24/outline", () => ({
+  MegaphoneIcon: () => <svg data-testid="megaphone-icon" />,
+}));
+
+vi.mock("@components/hooks/useAuth", () => ({
+  useAuth: () => ({ user: authUser }),
+}));
+
+import EventPromoteAction from "@app/[locale]/e/[eventId]/components/EventPromoteAction";
+
+describe("EventPromoteAction", () => {
+  beforeEach(() => {
+    authUser = null;
+  });
+
+  it("shows the promote link when the signed-in user owns the event", () => {
+    authUser = { id: OWNER_ID, email: "a@b.com", name: "A", username: "a" };
+    render(<EventPromoteAction ownerId={OWNER_ID} slug="my-event" />);
+
+    const link = screen.getByTestId("event-promote-link");
+    expect(link.getAttribute("href")).toBe("/e/my-event/promote");
+  });
+
+  it("renders nothing when the signed-in user is not the owner", () => {
+    authUser = { id: OTHER_USER_ID, email: "b@c.com", name: "B", username: "b" };
+    render(<EventPromoteAction ownerId={OWNER_ID} slug="my-event" />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+
+  it("renders nothing when logged out", () => {
+    authUser = null;
+    render(<EventPromoteAction ownerId={OWNER_ID} slug="my-event" />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+
+  it("renders nothing when the event has no owner (e.g. scraped/RSS events)", () => {
+    authUser = { id: OWNER_ID, email: "a@b.com", name: "A", username: "a" };
+    render(<EventPromoteAction ownerId={undefined} slug="my-event" />);
+
+    expect(screen.queryByTestId("event-promote-link")).toBeNull();
+  });
+});

--- a/test/lib/api/events.createPromotionCheckout.test.ts
+++ b/test/lib/api/events.createPromotionCheckout.test.ts
@@ -75,6 +75,18 @@ describe("createPromotionCheckout", () => {
     ).rejects.toThrow(/404/);
   });
 
+  it("attaches the backend's HTTP status to the thrown error, so a 401 the backend itself rejects is classified the same as a locally-expired token", async () => {
+    mockFetchWithHmac.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Token expired",
+    });
+
+    await expect(
+      createPromotionCheckout("event-uuid-1", "https://x/success", "https://x/cancel"),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
   it("throws when no valid access token is available", async () => {
     mockGetValidAccessToken.mockResolvedValue(null);
 

--- a/test/lib/api/events.createPromotionCheckout.test.ts
+++ b/test/lib/api/events.createPromotionCheckout.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetValidAccessToken = vi.fn();
+const mockGetApiUrl = vi.fn();
+const mockIsApiUrlConfigured = vi.fn();
+const mockFetchWithHmac = vi.fn();
+
+vi.mock("@utils/auth-cookies", () => ({
+  getAccessTokenFromCookies: vi.fn(),
+  getValidAccessToken: () => mockGetValidAccessToken(),
+}));
+
+vi.mock("@utils/api-helpers", () => ({
+  getInternalApiUrl: vi.fn(),
+  buildEventsQuery: vi.fn(),
+  getVercelProtectionBypassHeaders: () => ({}),
+  getApiUrl: () => mockGetApiUrl(),
+  isApiUrlConfigured: () => mockIsApiUrlConfigured(),
+}));
+
+vi.mock("../../../lib/api/fetch-wrapper", () => ({
+  fetchWithHmac: (url: string, options: RequestInit) =>
+    mockFetchWithHmac(url, options),
+}));
+
+import { createPromotionCheckout } from "../../../lib/api/events";
+
+describe("createPromotionCheckout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsApiUrlConfigured.mockReturnValue(true);
+    mockGetApiUrl.mockReturnValue("https://api.test");
+    mockGetValidAccessToken.mockResolvedValue("test-token");
+  });
+
+  it("POSTs to /events/{id}/promotions/checkout with skipBodySigning and returns the url", async () => {
+    mockFetchWithHmac.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/session123" }),
+    });
+
+    const result = await createPromotionCheckout(
+      "event-uuid-1",
+      "https://www.esdeveniments.cat/e/my-event/promote/success",
+      "https://www.esdeveniments.cat/e/my-event/promote/cancel",
+    );
+
+    expect(mockFetchWithHmac).toHaveBeenCalledWith(
+      "https://api.test/events/event-uuid-1/promotions/checkout",
+      expect.objectContaining({
+        method: "POST",
+        skipBodySigning: true,
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+    const [, callOptions] = mockFetchWithHmac.mock.calls[0];
+    expect(JSON.parse(callOptions.body as string)).toEqual({
+      successUrl: "https://www.esdeveniments.cat/e/my-event/promote/success",
+      cancelUrl: "https://www.esdeveniments.cat/e/my-event/promote/cancel",
+    });
+    expect(result).toEqual({ url: "https://checkout.stripe.com/session123" });
+  });
+
+  it("throws when the backend responds with a non-2xx status", async () => {
+    mockFetchWithHmac.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "Not found",
+    });
+
+    await expect(
+      createPromotionCheckout("event-uuid-1", "https://x/success", "https://x/cancel"),
+    ).rejects.toThrow(/404/);
+  });
+
+  it("throws when no valid access token is available", async () => {
+    mockGetValidAccessToken.mockResolvedValue(null);
+
+    await expect(
+      createPromotionCheckout("event-uuid-1", "https://x/success", "https://x/cancel"),
+    ).rejects.toThrow("Authentication required");
+  });
+});

--- a/test/lib/api/promotedEvents.test.ts
+++ b/test/lib/api/promotedEvents.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getActivePromotedEvents } from "../../../lib/api/promotedEvents";
+import * as fetchWrapper from "../../../lib/api/fetch-wrapper";
+import type { EventSummaryResponseDTO } from "types/api/event";
+
+const originalEnv = { ...process.env };
+
+const baseEvent: EventSummaryResponseDTO = {
+  id: "event-1",
+  hash: "hash-1",
+  slug: "event-one",
+  title: "Event One",
+  type: "FREE",
+  url: "https://example.com/event-one",
+  description: "Description",
+  imageUrl: "https://example.com/image.jpg",
+  startDate: "2099-01-01",
+  startTime: null,
+  endDate: "2099-01-01",
+  endTime: null,
+  location: "Barcelona",
+  visits: 0,
+  origin: "MANUAL",
+  categories: [],
+};
+
+describe("getActivePromotedEvents", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: "https://api.example.com" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns [] with no network call when the feature flag is off", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "false";
+    const fetchSpy = vi.spyOn(fetchWrapper, "fetchWithHmac");
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns [] with no network call when the flag is unset", async () => {
+    delete process.env.PROMOTED_EVENTS_ENABLED;
+    const fetchSpy = vi.spyOn(fetchWrapper, "fetchWithHmac");
+
+    const result = await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds the right query string for a homepage scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response(JSON.stringify({ content: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const fetchSpy = vi
+      .spyOn(fetchWrapper, "fetchWithHmac")
+      .mockResolvedValue(mockResponse);
+
+    await getActivePromotedEvents({ type: "homepage" });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain("scope=homepage");
+    expect(url).not.toContain("slug=");
+  });
+
+  it("builds the right query string for a town scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response(JSON.stringify({ content: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const fetchSpy = vi
+      .spyOn(fetchWrapper, "fetchWithHmac")
+      .mockResolvedValue(mockResponse);
+
+    await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain("scope=town");
+    expect(url).toContain("slug=cardedeu");
+  });
+
+  it("returns [] (not a throw) on a non-2xx response", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response("not found", { status: 404 });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] (not a throw) when fetchWithHmac rejects", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockRejectedValue(
+      new Error("network down"),
+    );
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] (not a throw) when content items don't match EventSummaryResponseDTOSchema", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response(
+      JSON.stringify({ content: [{ id: "malformed", title: "missing required fields" }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("drops individually invalid items without discarding the valid ones around them", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const content = [
+      { ...baseEvent, id: "valid-1", slug: "valid-1" },
+      { id: "malformed", title: "missing required fields" },
+      { ...baseEvent, id: "valid-2", slug: "valid-2" },
+    ];
+    const mockResponse = new Response(JSON.stringify({ content }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result.map((e) => e.id)).toEqual(["valid-1", "valid-2"]);
+  });
+
+  it("caps results at MAX_PROMOTED_EVENTS", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const content = Array.from({ length: 20 }, (_, i) => ({
+      ...baseEvent,
+      id: `event-${i}`,
+      hash: `hash-${i}`,
+      slug: `event-${i}`,
+      title: `Event ${i}`,
+    }));
+    const mockResponse = new Response(JSON.stringify({ content }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toHaveLength(8);
+  });
+
+  it("does not call console.error/Sentry for a routine non-2xx", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockResponse = new Response("not found", { status: 404 });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    await getActivePromotedEvents({ type: "homepage" });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/test/lib/api/promotedEvents.test.ts
+++ b/test/lib/api/promotedEvents.test.ts
@@ -160,7 +160,7 @@ describe("getActivePromotedEvents", () => {
     expect(result).toHaveLength(8);
   });
 
-  it("does not call console.error/Sentry for a routine non-2xx", async () => {
+  it("does not call console.error for a routine non-2xx (getActivePromotedEvents never reports to Sentry)", async () => {
     process.env.PROMOTED_EVENTS_ENABLED = "true";
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/test/lib/validation/event.test.ts
+++ b/test/lib/validation/event.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   parsePagedEvents,
   parseEventDetail,
+  enhanceEventImage,
 } from "@lib/validation/event";
 
 const baseSummary = {
@@ -107,6 +108,39 @@ describe("parseEventDetail", () => {
     expect(result).not.toBeNull();
     expect(result?.imageUrl).toContain("v=detail-hash");
     expect(result?.relatedEvents?.[0].imageUrl).toContain("v=related-hash");
+  });
+});
+
+describe("enhanceEventImage", () => {
+  it("appends a cache key derived from hash", () => {
+    const event = { imageUrl: "https://cdn.example.com/e.jpg", hash: "h1" };
+    expect(enhanceEventImage(event).imageUrl).toContain("v=h1");
+  });
+
+  it("falls back to updatedAt when hash is empty", () => {
+    const event = {
+      imageUrl: "https://cdn.example.com/e.jpg",
+      hash: "",
+      updatedAt: "2024-01-02T00:00:00Z",
+    };
+    expect(enhanceEventImage(event).imageUrl).toContain(
+      "v=2024-01-02T00%3A00%3A00Z"
+    );
+  });
+
+  it("returns the event unchanged when there is no cache key", () => {
+    const event = { imageUrl: "https://cdn.example.com/e.jpg" };
+    expect(enhanceEventImage(event)).toBe(event);
+  });
+
+  it("returns the event unchanged when imageUrl is missing", () => {
+    const event = { hash: "h1" };
+    expect(enhanceEventImage(event)).toBe(event);
+  });
+
+  it("returns the event unchanged when imageUrl is an empty string", () => {
+    const event = { imageUrl: "", hash: "h1" };
+    expect(enhanceEventImage(event)).toBe(event);
   });
 });
 

--- a/test/promote-checkout-action.test.ts
+++ b/test/promote-checkout-action.test.ts
@@ -142,4 +142,24 @@ describe("createPromotionCheckoutAction", () => {
       error: "Something went wrong. Please try again.",
     });
   });
+
+  it("returns a distinct stale-session result on a tagged 401 from requireMutationAuth", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+    const authError = new Error("Authentication required");
+    (authError as Error & { status: number }).status = 401;
+    mockCreatePromotionCheckout.mockRejectedValue(authError);
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Your session has expired. Please sign in again.",
+      reason: "stale-session",
+    });
+  });
 });

--- a/test/promote-checkout-action.test.ts
+++ b/test/promote-checkout-action.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EventDetailResponseDTO } from "types/api/event";
+
+const mockCreatePromotionCheckout = vi.fn();
+const mockFetchEventBySlug = vi.fn();
+const mockGetCurrentUser = vi.fn();
+
+vi.mock("@lib/api/events", () => ({
+  createPromotionCheckout: (id: string, successUrl: string, cancelUrl: string) =>
+    mockCreatePromotionCheckout(id, successUrl, cancelUrl),
+  fetchEventBySlug: (slug: string) => mockFetchEventBySlug(slug),
+}));
+
+vi.mock("@lib/auth/session", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+import { createPromotionCheckoutAction } from "../app/[locale]/e/[eventId]/promote/actions";
+
+const CREATOR_ID = "creator-uuid-1";
+
+function buildEvent(overrides: Partial<EventDetailResponseDTO> = {}): EventDetailResponseDTO {
+  return {
+    id: "event-uuid-1",
+    hash: "hash",
+    slug: "my-event",
+    title: "My Event",
+    type: "FREE",
+    url: "",
+    description: "desc",
+    imageUrl: "",
+    startDate: "2026-09-01",
+    startTime: null,
+    endDate: "2026-09-01",
+    endTime: null,
+    location: "Location",
+    visits: 0,
+    origin: "MANUAL",
+    owner: {
+      id: CREATOR_ID,
+      displayName: "Creator",
+      username: "creator",
+      avatarUrl: null,
+      organizerVerified: false,
+    },
+    city: { id: 1, name: "City", slug: "city", latitude: 0, longitude: 0, postalCode: "08001", rssFeed: null, enabled: true },
+    region: { id: 1, name: "Region", slug: "region" },
+    province: { id: 1, name: "Region", slug: "region" },
+    categories: [],
+    ...overrides,
+  };
+}
+
+describe("createPromotionCheckoutAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the checkout url when the caller owns the event", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+    mockCreatePromotionCheckout.mockResolvedValue({
+      url: "https://checkout.stripe.com/session123",
+    });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: true,
+      url: "https://checkout.stripe.com/session123",
+    });
+    expect(mockCreatePromotionCheckout).toHaveBeenCalledWith(
+      "event-uuid-1",
+      expect.stringContaining("/e/my-event/promote/success"),
+      expect.stringContaining("/e/my-event/promote/cancel"),
+    );
+  });
+
+  it("rejects when the provided eventId does not match the resolved event's id", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent({ id: "different-uuid" }));
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    });
+    expect(mockCreatePromotionCheckout).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the signed-in user does not own the event", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: "someone-else" });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    });
+  });
+
+  it("rejects when the event does not exist", async () => {
+    mockFetchEventBySlug.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({ success: false, error: "Event not found" });
+  });
+
+  it("converts a thrown backend error into a generic result instead of throwing", async () => {
+    mockFetchEventBySlug.mockResolvedValue(buildEvent());
+    mockGetCurrentUser.mockResolvedValue({ id: CREATOR_ID });
+    mockCreatePromotionCheckout.mockRejectedValue(new Error("HTTP error! status: 404"));
+
+    const result = await createPromotionCheckoutAction(
+      "event-uuid-1",
+      "my-event",
+      "ca",
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "Something went wrong. Please try again.",
+    });
+  });
+});

--- a/test/promote-event-client.test.tsx
+++ b/test/promote-event-client.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockCreatePromotionCheckoutAction = vi.fn();
+const mockUseLocale = vi.fn(() => "ca");
+
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+  useLocale: () => mockUseLocale(),
+}));
+
+vi.mock("../app/[locale]/e/[eventId]/promote/actions", () => ({
+  createPromotionCheckoutAction: (eventId: string, slug: string, locale: string) =>
+    mockCreatePromotionCheckoutAction(eventId, slug, locale),
+}));
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // @ts-expect-error -- overriding a readonly for the test
+  delete window.location;
+  Object.defineProperty(window, "location", {
+    value: { href: "" },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+});
+
+import PromoteEventClient from "../app/[locale]/e/[eventId]/promote/PromoteEventClient";
+
+describe("PromoteEventClient", () => {
+  it("redirects to the returned Stripe url on success", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: true,
+      url: "https://checkout.stripe.com/session123",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("https://checkout.stripe.com/session123");
+    });
+  });
+
+  it("shows a generic error and does not redirect when the action fails", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: false,
+      error: "Unauthorized: only the event creator can promote this event",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(window.location.href).toBe("");
+  });
+
+  it("rejects a non-https url instead of redirecting", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: true,
+      url: "/undefined",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(window.location.href).toBe("");
+  });
+
+  it("renders the price from getEventPromotionOptions rather than a hardcoded value", () => {
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+
+    // 5 is today's only entry from getEventPromotionOptions() — asserting
+    // against the rendered text (not re-importing the config function) keeps
+    // this test honest about what the user actually sees.
+    expect(screen.getByText("5€")).toBeInTheDocument();
+  });
+});

--- a/test/promote-event-client.test.tsx
+++ b/test/promote-event-client.test.tsx
@@ -18,8 +18,10 @@ vi.mock("../app/[locale]/e/[eventId]/promote/actions", () => ({
     mockCreatePromotionCheckoutAction(eventId, slug, locale),
 }));
 
+const mockEnsureGtag = vi.fn();
 vi.mock("@utils/analytics", () => ({
   sendGoogleEvent: (...args: unknown[]) => mockSendGoogleEvent(...args),
+  ensureGtag: (...args: unknown[]) => mockEnsureGtag(...args),
 }));
 
 vi.mock("@config/pricing", () => ({
@@ -99,12 +101,17 @@ describe("PromoteEventClient", () => {
   });
 
   it("renders the price from getEventPromotionOptions rather than a hardcoded value", () => {
+    // Deliberately not 5 (config's real current value) — a component that
+    // hardcoded "5€" instead of reading getEventPromotionOptions() would
+    // still pass this test if the mock returned the same value as the
+    // hardcode, so the fixture uses a distinguishing price instead.
+    mockGetEventPromotionOptions.mockReturnValue([
+      { id: "standard", priceEur: 7 },
+    ]);
+
     render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
 
-    // 5 is today's only entry from getEventPromotionOptions() — asserting
-    // against the rendered text (not re-importing the config function) keeps
-    // this test honest about what the user actually sees.
-    expect(screen.getByText("5€")).toBeInTheDocument();
+    expect(screen.getByText("7€")).toBeInTheDocument();
   });
 
   it("resets isSubmitting and shows an error when the action itself rejects (not just returns success:false)", async () => {
@@ -153,6 +160,7 @@ describe("PromoteEventClient", () => {
     render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
 
     expect(screen.getByTestId("promote-confirm-button")).toBeDisabled();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.queryByText("5€")).toBeNull();
   });
 
@@ -180,5 +188,9 @@ describe("PromoteEventClient", () => {
       "promote_checkout_redirect",
       { event_slug: "my-event" },
     );
+    // Exact count, not just toHaveBeenCalledWith, so a regression that fires
+    // any of the three events twice (e.g. a missing one-shot guard) fails
+    // this test instead of passing alongside the correct calls.
+    expect(mockSendGoogleEvent).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/promote-event-client.test.tsx
+++ b/test/promote-event-client.test.tsx
@@ -127,6 +127,26 @@ describe("PromoteEventClient", () => {
     });
   });
 
+  it("shows the stale-session message (not the generic one) when the action reports an expired session", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: false,
+      error: "Your session has expired. Please sign in again.",
+      reason: "stale-session",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("App.EventPromote.errorStaleSession"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("App.EventPromote.errorGeneric"),
+    ).toBeNull();
+  });
+
   it("disables the confirm button and shows an error when no promotion option is available", () => {
     mockGetEventPromotionOptions.mockReturnValue([]);
 

--- a/test/promote-event-client.test.tsx
+++ b/test/promote-event-client.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 const mockCreatePromotionCheckoutAction = vi.fn();
 const mockUseLocale = vi.fn(() => "ca");
+const mockSendGoogleEvent = vi.fn();
+const mockGetEventPromotionOptions = vi.fn(() => [
+  { id: "standard", priceEur: 5 },
+]);
 
 vi.mock("next-intl", () => ({
   useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
@@ -14,10 +18,21 @@ vi.mock("../app/[locale]/e/[eventId]/promote/actions", () => ({
     mockCreatePromotionCheckoutAction(eventId, slug, locale),
 }));
 
+vi.mock("@utils/analytics", () => ({
+  sendGoogleEvent: (...args: unknown[]) => mockSendGoogleEvent(...args),
+}));
+
+vi.mock("@config/pricing", () => ({
+  getEventPromotionOptions: () => mockGetEventPromotionOptions(),
+}));
+
 const originalLocation = window.location;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetEventPromotionOptions.mockReturnValue([
+    { id: "standard", priceEur: 5 },
+  ]);
   // @ts-expect-error -- overriding a readonly for the test
   delete window.location;
   Object.defineProperty(window, "location", {
@@ -90,5 +105,60 @@ describe("PromoteEventClient", () => {
     // against the rendered text (not re-importing the config function) keeps
     // this test honest about what the user actually sees.
     expect(screen.getByText("5€")).toBeInTheDocument();
+  });
+
+  it("resets isSubmitting and shows an error when the action itself rejects (not just returns success:false)", async () => {
+    mockCreatePromotionCheckoutAction.mockRejectedValue(
+      new Error("unexpected server action failure"),
+    );
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+    const button = screen.getByTestId("promote-confirm-button");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    // The button must not stay permanently disabled/loading after a rejection.
+    expect(button).not.toBeDisabled();
+    expect(mockSendGoogleEvent).toHaveBeenCalledWith("promote_checkout_error", {
+      event_slug: "my-event",
+      reason: "unexpected-rejection",
+    });
+  });
+
+  it("disables the confirm button and shows an error when no promotion option is available", () => {
+    mockGetEventPromotionOptions.mockReturnValue([]);
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+
+    expect(screen.getByTestId("promote-confirm-button")).toBeDisabled();
+    expect(screen.queryByText("5€")).toBeNull();
+  });
+
+  it("fires the checkout funnel analytics events", async () => {
+    mockCreatePromotionCheckoutAction.mockResolvedValue({
+      success: true,
+      url: "https://checkout.stripe.com/session123",
+    });
+
+    render(<PromoteEventClient eventId="event-uuid-1" slug="my-event" />);
+
+    expect(mockSendGoogleEvent).toHaveBeenCalledWith("promote_page_view", {
+      event_slug: "my-event",
+    });
+
+    fireEvent.click(screen.getByTestId("promote-confirm-button"));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("https://checkout.stripe.com/session123");
+    });
+    expect(mockSendGoogleEvent).toHaveBeenCalledWith("promote_checkout_click", {
+      event_slug: "my-event",
+    });
+    expect(mockSendGoogleEvent).toHaveBeenCalledWith(
+      "promote_checkout_redirect",
+      { event_slug: "my-event" },
+    );
   });
 });

--- a/test/promote-upsell-modal.test.tsx
+++ b/test/promote-upsell-modal.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const mockPush = vi.fn();
+vi.mock("@i18n/routing", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Minimal Modal stub mirroring the real component's close/actionButton contract:
+// calls setOpen(false) after onActionButtonClick resolves, unless it returns false.
+vi.mock("@components/ui/common/modal", () => ({
+  __esModule: true,
+  default: ({
+    open,
+    setOpen,
+    title,
+    children,
+    actionButton,
+    onActionButtonClick,
+  }: {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    title: string;
+    children: ReactNode;
+    actionButton?: ReactNode;
+    onActionButtonClick?: () => boolean | void | Promise<boolean | void>;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        {children}
+        {actionButton && (
+          <button
+            data-testid="modal-action-button"
+            onClick={async () => {
+              const result = await onActionButtonClick?.();
+              if (result !== false) setOpen(false);
+            }}
+          >
+            {actionButton}
+          </button>
+        )}
+      </div>
+    );
+  },
+}));
+
+import PromoteUpsellModal from "../app/[locale]/publica/PromoteUpsellModal";
+
+describe("PromoteUpsellModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates to the promote page and keeps working even if Modal also calls setOpen", () => {
+    const setOpen = vi.fn();
+    render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("modal-action-button"));
+
+    expect(mockPush).toHaveBeenCalledWith("/e/my-event/promote");
+  });
+
+  it("navigates to the event detail page and closes the modal on 'keep it free'", () => {
+    const setOpen = vi.fn();
+    render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("promote-modal-keep-free"));
+
+    expect(setOpen).toHaveBeenCalledWith(false);
+    expect(mockPush).toHaveBeenCalledWith("/e/my-event");
+  });
+});

--- a/test/promote-upsell-modal.test.tsx
+++ b/test/promote-upsell-modal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 
 vi.mock("next-intl", () => ({
@@ -7,15 +7,8 @@ vi.mock("next-intl", () => ({
 }));
 
 const mockPush = vi.fn();
-const mockReplace = vi.fn();
 vi.mock("@i18n/routing", () => ({
-  useRouter: () => ({ push: mockPush, replace: mockReplace }),
-  usePathname: () => "/en/e/my-event",
-}));
-
-let mockSearchParams = new URLSearchParams();
-vi.mock("next/navigation", () => ({
-  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
 }));
 
 vi.mock("@heroicons/react/24/outline", () => ({
@@ -68,14 +61,20 @@ import PromoteUpsellModal from "../app/[locale]/e/[eventId]/components/PromoteUp
 describe("PromoteUpsellModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSearchParams = new URLSearchParams("promote=1");
+    window.history.pushState({}, "", "/en/e/my-event?promote=1");
   });
 
-  it("navigates to the promote page without letting Modal's own setOpen(false) fire on the same click", () => {
+  it("navigates to the promote page without letting Modal's own setOpen(false) fire on the same click", async () => {
     const setOpen = vi.fn();
     render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
 
-    fireEvent.click(screen.getByTestId("modal-action-button"));
+    // Awaited via act: the stub's onClick is async (awaits onActionButtonClick
+    // before deciding whether to call setOpen), so asserting setOpen
+    // immediately after a bare fireEvent.click would pass regardless of the
+    // component's return value — the continuation hasn't run yet.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("modal-action-button"));
+    });
 
     expect(mockPush).toHaveBeenCalledWith("/e/my-event/promote");
     // The stubbed Modal only calls setOpen when onActionButtonClick's return
@@ -84,14 +83,15 @@ describe("PromoteUpsellModal", () => {
     expect(setOpen).not.toHaveBeenCalled();
   });
 
-  it("strips the promote marker from the current URL before navigating to the promote page", () => {
+  it("strips the promote marker from the current URL before navigating to the promote page", async () => {
     render(<PromoteUpsellModal open setOpen={vi.fn()} slug="my-event" />);
 
-    fireEvent.click(screen.getByTestId("modal-action-button"));
-
-    expect(mockReplace).toHaveBeenCalledWith("/en/e/my-event", {
-      scroll: false,
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("modal-action-button"));
     });
+
+    expect(window.location.pathname).toBe("/en/e/my-event");
+    expect(window.location.search).toBe("");
   });
 
   it("closes the modal without navigating on 'keep it free' (already on the event detail page)", () => {

--- a/test/promote-upsell-modal.test.tsx
+++ b/test/promote-upsell-modal.test.tsx
@@ -7,8 +7,15 @@ vi.mock("next-intl", () => ({
 }));
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 vi.mock("@i18n/routing", () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  usePathname: () => "/en/e/my-event",
+}));
+
+let mockSearchParams = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@heroicons/react/24/outline", () => ({
@@ -61,15 +68,30 @@ import PromoteUpsellModal from "../app/[locale]/e/[eventId]/components/PromoteUp
 describe("PromoteUpsellModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams("promote=1");
   });
 
-  it("navigates to the promote page and keeps working even if Modal also calls setOpen", () => {
+  it("navigates to the promote page without letting Modal's own setOpen(false) fire on the same click", () => {
     const setOpen = vi.fn();
     render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
 
     fireEvent.click(screen.getByTestId("modal-action-button"));
 
     expect(mockPush).toHaveBeenCalledWith("/e/my-event/promote");
+    // The stubbed Modal only calls setOpen when onActionButtonClick's return
+    // value isn't `false` — asserting setOpen was never called is what
+    // actually proves the component's `return false` reached the stub.
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it("strips the promote marker from the current URL before navigating to the promote page", () => {
+    render(<PromoteUpsellModal open setOpen={vi.fn()} slug="my-event" />);
+
+    fireEvent.click(screen.getByTestId("modal-action-button"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/en/e/my-event", {
+      scroll: false,
+    });
   });
 
   it("closes the modal without navigating on 'keep it free' (already on the event detail page)", () => {

--- a/test/promote-upsell-modal.test.tsx
+++ b/test/promote-upsell-modal.test.tsx
@@ -11,6 +11,11 @@ vi.mock("@i18n/routing", () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+vi.mock("@heroicons/react/24/outline", () => ({
+  RocketLaunchIcon: () => <svg data-testid="rocket-icon" />,
+  CheckCircleIcon: () => <svg data-testid="check-icon" />,
+}));
+
 // Minimal Modal stub mirroring the real component's close/actionButton contract:
 // calls setOpen(false) after onActionButtonClick resolves, unless it returns false.
 vi.mock("@components/ui/common/modal", () => ({
@@ -51,7 +56,7 @@ vi.mock("@components/ui/common/modal", () => ({
   },
 }));
 
-import PromoteUpsellModal from "../app/[locale]/publica/PromoteUpsellModal";
+import PromoteUpsellModal from "../app/[locale]/e/[eventId]/components/PromoteUpsellModal";
 
 describe("PromoteUpsellModal", () => {
   beforeEach(() => {
@@ -67,13 +72,21 @@ describe("PromoteUpsellModal", () => {
     expect(mockPush).toHaveBeenCalledWith("/e/my-event/promote");
   });
 
-  it("navigates to the event detail page and closes the modal on 'keep it free'", () => {
+  it("closes the modal without navigating on 'keep it free' (already on the event detail page)", () => {
     const setOpen = vi.fn();
     render(<PromoteUpsellModal open setOpen={setOpen} slug="my-event" />);
 
     fireEvent.click(screen.getByTestId("promote-modal-keep-free"));
 
     expect(setOpen).toHaveBeenCalledWith(false);
-    expect(mockPush).toHaveBeenCalledWith("/e/my-event");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows the benefit list reusing the promote page's own copy", () => {
+    render(<PromoteUpsellModal open setOpen={vi.fn()} slug="my-event" />);
+
+    expect(screen.getByText("benefit1")).toBeInTheDocument();
+    expect(screen.getByText("benefit2")).toBeInTheDocument();
+    expect(screen.getByText("benefit3")).toBeInTheDocument();
   });
 });

--- a/test/server-events-categorized.test.tsx
+++ b/test/server-events-categorized.test.tsx
@@ -25,6 +25,14 @@ vi.mock("@components/ui/eventsAround/EventsAroundServer", () => ({
   ),
 }));
 
+// PromotedEventsSection is async (calls getActivePromotedEvents) — RTL's render()
+// can't handle an unmocked async Server Component. It's irrelevant to what these
+// tests cover (category-matching logic), so stub it to null, matching its real
+// behavior with PROMOTED_EVENTS_ENABLED unset (the default in every test env here).
+vi.mock("@components/ui/promotedEvents/PromotedEventsSection", () => ({
+  default: () => null,
+}));
+
 vi.mock("@components/ui/common/badge", () => ({
   default: ({
     href,

--- a/types/common.ts
+++ b/types/common.ts
@@ -349,6 +349,7 @@ export interface CardHorizontalServerProps {
   event: EventSummaryResponseDTO;
   isPriority?: boolean;
   initialIsFavorite?: boolean;
+  isPromoted?: boolean;
 }
 
 export interface CardShareButtonProps {
@@ -378,6 +379,7 @@ export interface EventsAroundServerProps extends EventsAroundProps {
   showJsonLd?: boolean;
   jsonLdId?: string;
   analyticsCategory?: string;
+  isPromoted?: boolean;
 }
 
 export interface BaseLayoutProps {

--- a/types/event.ts
+++ b/types/event.ts
@@ -371,10 +371,25 @@ export type CreateEventActionResult =
  * (not a thrown error) — same convention as EditEventResult and
  * CreateEventActionResult above: the client always gets a value it can
  * branch on, never an opaque Server Action rejection.
+ *
+ * `reason: "stale-session"` mirrors CreateEventActionResult's own 401
+ * handling above (createEventAction) — the backend Bearer token expired
+ * mid-session, which is a distinct, actionable case from a generic failure.
  */
 export type PromotionCheckoutResult =
   | { success: true; url: string }
-  | { success: false; error: string };
+  | { success: false; error: string; reason?: "stale-session" };
+
+/**
+ * A single purchasable promotion tier. MVP: exactly one flat-fee option
+ * (see getEventPromotionOptions in config/pricing.ts); structured as a list
+ * so the promote page already renders "whatever this returns" rather than a
+ * hardcoded line once real duration/geo-scope tiers exist.
+ */
+export interface EventPromotionOption {
+  id: string;
+  priceEur: number;
+}
 
 export interface UseEventsOptions {
   place?: string;

--- a/types/event.ts
+++ b/types/event.ts
@@ -391,6 +391,17 @@ export interface EventPromotionOption {
   priceEur: number;
 }
 
+/**
+ * Query-side surface descriptor for `getActivePromotedEvents`
+ * (lib/api/promotedEvents.ts): "which page is asking", not "what the buyer
+ * paid for". Auto-derived from the event's own location for the MVP — not a
+ * purchasable choice yet. `"town" | "region"` matches this codebase's own
+ * `PlaceType` (types/common.ts), not "comarca".
+ */
+export type PromotionScope =
+  | { type: "homepage" }
+  | { type: "town" | "region"; slug: string };
+
 export interface UseEventsOptions {
   place?: string;
   category?: string;

--- a/types/event.ts
+++ b/types/event.ts
@@ -366,6 +366,16 @@ export type CreateEventActionResult =
   | { success: true; event: EventDetailResponseDTO }
   | { success: false; reason: "profile-incomplete" | "stale-session" };
 
+/**
+ * Result returned by createPromotionCheckoutAction. A discriminated union
+ * (not a thrown error) — same convention as EditEventResult and
+ * CreateEventActionResult above: the client always gets a value it can
+ * branch on, never an opaque Server Action rejection.
+ */
+export type PromotionCheckoutResult =
+  | { success: true; url: string }
+  | { success: false; error: string };
+
 export interface UseEventsOptions {
   place?: string;
   category?: string;

--- a/types/props.ts
+++ b/types/props.ts
@@ -948,6 +948,7 @@ export interface EventClientPayload {
   placeSlug?: string;
   hasImage: boolean;
   origin: EventSummaryResponseDTO["origin"];
+  ownerId?: string;
 }
 
 export interface EventClientProps {

--- a/types/props.ts
+++ b/types/props.ts
@@ -987,6 +987,24 @@ export interface EditEventClientProps {
   regions: import("./api/region").RegionsGroupedByCitiesResponseDTO[] | null;
 }
 
+// Owner-only promote action, event detail sidebar client island
+export interface EventPromoteActionProps {
+  ownerId?: string;
+  slug: string;
+}
+
+// /e/[eventId]/promote client page
+export interface PromoteEventClientProps {
+  eventId: string;
+  slug: string;
+}
+
+export interface PromoteUpsellModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  slug: string;
+}
+
 // Social proof counter
 export interface SocialProofCounterProps {
   visits: number;

--- a/types/props.ts
+++ b/types/props.ts
@@ -68,6 +68,7 @@ import { RegionsGroupedByCitiesResponseDTO } from "types/api/region";
 import { RouteSegments, URLQueryParams } from "types/url-filters";
 import type { NewsEventItemDTO, NewsSummaryResponseDTO } from "types/api/news";
 import type { AppLocale } from "types/i18n";
+import type { PromotionScope } from "types/event";
 
 // Google Scripts and WebsiteSchema no longer require nonce props (relaxed CSP)
 
@@ -1028,4 +1029,8 @@ export interface PwaBackButtonProps {
 // EventsListSkeleton/PlacePageSkeleton usage.
 export interface EventsGridSkeletonProps {
   count?: number;
+}
+
+export interface PromotedEventsSectionProps {
+  scope: PromotionScope;
 }


### PR DESCRIPTION
## Summary

- Adds a post-publish "boost your event" upsell modal, shown on the event's own detail page right after publishing (not blocking the publish form).
- Adds a dedicated `/e/[eventId]/promote` page: benefits, an MVP flat fee, and a "Confirm and Pay" button.
- Adds an owner-only "Promote" entry point in the event detail sidebar (mirrors the existing "Edit" action) so an owner can promote later, not just right after publishing.
- Confirm-and-pay hands off to a Server Action that calls the backend's `POST /events/{id}/promotions/checkout` (per Gerard's own description of the flow) and redirects to the returned Stripe URL. All payment logic (Stripe session, PENDING order, webhook, fulfillment) lives in the backend — this repo only shows the upsell, collects confirmation, and redirects.
- Adds static `/e/[eventId]/promote/success` and `/cancel` return pages (no verification — per Stripe's own docs, fulfillment must come from the backend's webhook, not the redirect).
- Pricing is intentionally provisional: `getEventPromotionOptions()` in `config/pricing.ts` returns a single flat-fee entry today; it's a list-returning function (not a bare constant) so it can grow into real duration/geo-scope tiers once the backend defines them, without its callers changing shape.

## Notable fixes bundled during implementation

- `fix(e2e): make publish flow login and submit deterministic` — pre-existing local WIP (not authored as part of this feature) that was sitting uncommitted before this branch started; committed here as its own clearly-labeled commit rather than left mixed into the feature diff.
- `fix(promote): whitelist EventPromote namespace for client messages provider` — caught by `test/i18n-client-namespaces.test.ts`; without it `PromoteEventClient` would throw `MISSING_MESSAGE` at render time in production.
- `fix(promote): show the upsell modal on the event detail page, not /publica` — the modal originally blocked navigation on the publish form itself; corrected to redirect first (same `?promote=1` one-time-marker convention already used by `newEvent`/`edit_suggested` in `EventClient.tsx`), then show the modal on the arrived-at event page, with a rocket icon + benefit checklist for a less bare UI.
- `fix(promote): preserve other query params when dismissing the upsell modal` — the close handler was stripping the whole query string via `router.replace(pathname, ...)`, not just its own `promote=1` marker; fixed to only delete that one key.

## Explicitly out of scope

- Pricing methodology (duration/geo-scope tiers) — confirmed still undecided on the backend side.
- "Already promoted" / duplicate-checkout guard — no lookup endpoint exists for this yet.
- Any change to event list sorting, ranking, or a "Promoted" badge — backend-owned, not decided.
- Non-owner promotion.
- Any Stripe SDK, webhook, or secret in this repo — two other unrelated Stripe integrations already exist (sponsor banners, restaurant promotion leads); this feature is a third, backend-owned pattern and doesn't touch either.

## Test plan

- [x] `yarn typecheck` — 0 errors
- [x] `yarn lint` — 0 errors (178 pre-existing warnings, unchanged)
- [x] `yarn test` — 2328/2328 passing (196 files)
- [x] `yarn i18n:check` — no missing/invalid keys across ca/es/en
- [x] Manual server-rendered verification against a real backend event: detail page renders with no owner (Edit/Promote links correctly absent), `/promote` 404s when logged out (ownership gate), `/promote/success` and `/promote/cancel` render with working links
- [ ] Manual click-through of the full owner flow (upsell modal → promote page → checkout) requires real login credentials against staging and Gerard's backend endpoint, which doesn't exist yet — not verifiable pre-merge
- [ ] `e2e/publish-integration.spec.ts`'s new "Promote Event" test only runs with `E2E_STAGING_EMAIL`/`E2E_STAGING_PASSWORD` against real staging (per `.github/workflows/e2e-integration.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post‑publish “Promote your event” upsell with an owner‑only checkout that redirects to Stripe via the backend, plus a feature‑flagged “Promoted events” carousel on the homepage and listing pages (off by default; also shows on the homepage when organic sections are empty).

- **New Features**
  - Post‑publish upsell modal on the event page (owner‑gated; one‑time via `?promote=1`) leading to `/e/[eventId]/promote`.
  - Server Action calls backend `POST /events/{id}/promotions/checkout`, redirects to Stripe; return pages at `/e/[eventId]/promote/success` and `/cancel`.
  - Owner‑only “Promote” links in the sidebar and a mobile‑visible action in event details.
  - Centralized MVP pricing via `getEventPromotionOptions()` (flat fee) with analytics: `promote_page_view`, `checkout_click`, `checkout_redirect`, `checkout_error`.
  - Feature‑flagged “Promoted events” carousel with a “Promoted” badge; gated by `PROMOTED_EVENTS_ENABLED` (short‑circuits when off) and rendered on the homepage even with no organic events.

- **Bug Fixes**
  - Deterministic publish flow: session polling after login and a `data-publish-ready` signal on the publish button.
  - i18n: whitelisted the `EventPromote` namespace for client rendering.
  - Upsell shows on the event detail page and is lazy‑loaded; dismissal only removes `promote=1`; the marker is stripped before navigating to `/promote` to avoid back‑button retriggers; fixed a router race via `history.replaceState`.
  - Guarded empty pricing with a friendly error; 401s from checkout are treated as `stale-session` and backend HTTP status is propagated; hardened ownership checks; initialized analytics with `ensureGtag()` and avoided double‑fires under React Strict Mode.

<sup>Written for commit 7776e06c2b79a460982ae96dceac4909e2a4d00b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event creators can promote published events for €5 through a dedicated checkout flow.
  * Added owner-only “Promote” actions and localized promotion, success, and cancellation pages.
  * Published events now show a promotion upsell with clear benefits.
  * Added promoted-event sections and badges on homepage and location listings, controlled by a feature flag.
* **Bug Fixes**
  * Improved publishing and login flow reliability with clearer readiness checks and diagnostics.
* **Documentation**
  * Added documentation for promotion checkout and promoted-event displays.
* **Tests**
  * Added coverage for promotion, checkout, upsell, publishing, authentication, and promoted-event displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->