### PR TITLE
feat(promoted-events): promoted events carousel (phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,10 @@ CLOUDFLARE_ZONE_ID=
 CLOUDFLARE_API_TOKEN=
 CLOUDFRONT_DISTRIBUTION_ID=
 LHCI_GITHUB_APP_TOKEN=
+
+# ── Feature flags ───────────────────────────────────────────────────
+# Gates lib/api/promotedEvents.ts's active-promotions fetch (homepage +
+# listing-page "Promoted events" carousel). Keep false/unset until the
+# backend's GET /events/promotions/active endpoint exists — while off,
+# getActivePromotedEvents short-circuits with no network call at all.
+PROMOTED_EVENTS_ENABLED=false

--- a/components/partials/PlacePageShell.tsx
+++ b/components/partials/PlacePageShell.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { JSX } from "react";
 import dynamic from "next/dynamic";
 import HybridEventsList from "@components/ui/hybridEventsList";
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
 import JsonLdServer from "./JsonLdServer";
 import { EventsListSkeleton } from "@components/ui/common/skeletons";
 import { FilterLoadingProvider } from "@components/context/FilterLoadingContext";
@@ -351,6 +352,12 @@ async function PlacePageContent({
       ))}
 
       <FilterLoadingGate>
+        {placeTypeLabel.type && (
+          <PromotedEventsSection
+            scope={{ type: placeTypeLabel.type, slug: place }}
+          />
+        )}
+
         <HybridEventsList
           initialEvents={events}
           placeTypeLabel={placeTypeLabel}

--- a/components/partials/PlacePageShell.tsx
+++ b/components/partials/PlacePageShell.tsx
@@ -353,9 +353,11 @@ async function PlacePageContent({
 
       <FilterLoadingGate>
         {placeTypeLabel.type && (
-          <PromotedEventsSection
-            scope={{ type: placeTypeLabel.type, slug: place }}
-          />
+          <Suspense fallback={null}>
+            <PromotedEventsSection
+              scope={{ type: placeTypeLabel.type, slug: place }}
+            />
+          </Suspense>
         )}
 
         <HybridEventsList

--- a/components/ui/cardHorizontal/CardHorizontalServer.tsx
+++ b/components/ui/cardHorizontal/CardHorizontalServer.tsx
@@ -12,11 +12,13 @@ const CardHorizontalServer = async ({
   event,
   isPriority = false,
   initialIsFavorite,
+  isPromoted = false,
 }: CardHorizontalServerProps) => {
   const locale = await getLocaleSafely();
   const tCard = await getTranslations({ locale, namespace: "Components.CardContent" });
   const tTime = await getTranslations({ locale, namespace: "Utils.EventTime" });
   const tCategories = await getTranslations({ locale, namespace: "Config.Categories" });
+  const tPromoted = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
 
   const {
     title,
@@ -81,6 +83,9 @@ const CardHorizontalServer = async ({
       </div>
 
       <div className="flex-1 flex flex-col px-3.5 pt-2.5 pb-3.5 pointer-events-none">
+        {isPromoted && (
+          <span className="badge-primary mb-1 w-fit">{tPromoted("badge")}</span>
+        )}
         <CategoryBadge label={categoryLabel} />
 
         <p className="text-xs text-muted-foreground mb-1 truncate">

--- a/components/ui/cardHorizontal/CardHorizontalServer.tsx
+++ b/components/ui/cardHorizontal/CardHorizontalServer.tsx
@@ -18,7 +18,9 @@ const CardHorizontalServer = async ({
   const tCard = await getTranslations({ locale, namespace: "Components.CardContent" });
   const tTime = await getTranslations({ locale, namespace: "Utils.EventTime" });
   const tCategories = await getTranslations({ locale, namespace: "Config.Categories" });
-  const tPromoted = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  const tPromoted = isPromoted
+    ? await getTranslations({ locale, namespace: "Components.PromotedEvents" })
+    : null;
 
   const {
     title,
@@ -83,7 +85,7 @@ const CardHorizontalServer = async ({
       </div>
 
       <div className="flex-1 flex flex-col px-3.5 pt-2.5 pb-3.5 pointer-events-none">
-        {isPromoted && (
+        {isPromoted && tPromoted && (
           <span className="badge-primary mb-1 w-fit">{tPromoted("badge")}</span>
         )}
         <CategoryBadge label={categoryLabel} />

--- a/components/ui/eventsAround/EventsAroundServer.tsx
+++ b/components/ui/eventsAround/EventsAroundServer.tsx
@@ -43,6 +43,7 @@ async function EventsAroundServer({
   showJsonLd = false,
   jsonLdId,
   title,
+  isPromoted = false,
 }: EventsAroundServerProps) {
   const locale = await getLocaleSafely();
   const uniqueEvents = dedupeEvents(events);
@@ -141,6 +142,7 @@ async function EventsAroundServer({
                 <CardHorizontalServer
                   event={event}
                   isPriority={usePriority && index <= 2}
+                  isPromoted={isPromoted}
                 />
               </div>
             ))}

--- a/components/ui/promotedEvents/PromotedEventsSection.tsx
+++ b/components/ui/promotedEvents/PromotedEventsSection.tsx
@@ -1,0 +1,52 @@
+import { getTranslations } from "next-intl/server";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import SectionHeading from "@components/ui/common/SectionHeading";
+import { getActivePromotedEvents } from "@lib/api/promotedEvents";
+import { getLocaleSafely } from "@utils/i18n-seo";
+import type { PromotionScope } from "types/event";
+
+function scopeKey(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}`;
+}
+
+function scopePlaceSlug(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : scope.slug;
+}
+
+export default async function PromotedEventsSection({
+  scope,
+}: {
+  scope: PromotionScope;
+}) {
+  const promotedEvents = await getActivePromotedEvents(scope);
+  if (promotedEvents.length === 0) {
+    return null;
+  }
+
+  const locale = await getLocaleSafely();
+  const t = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  const key = scopeKey(scope);
+
+  return (
+    <div className="container content-auto-section">
+      <section className="py-section-y border-b">
+        <SectionHeading title={t("title")} titleClassName="heading-2 text-foreground" />
+        <div
+          data-analytics-container="true"
+          data-analytics-context="promoted_carousel"
+          data-analytics-place-slug={scopePlaceSlug(scope)}
+        >
+          <EventsAroundServer
+            events={promotedEvents}
+            layout="horizontal"
+            usePriority={false}
+            isPromoted
+            showJsonLd
+            title={t("title")}
+            jsonLdId={`promoted-events-${key}`}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/ui/serverEventsCategorized/index.tsx
+++ b/components/ui/serverEventsCategorized/index.tsx
@@ -509,7 +509,9 @@ export async function ServerEventsCategorizedContent({
 
   return (
     <>
-      <PromotedEventsSection scope={{ type: "homepage" }} />
+      <Suspense fallback={null}>
+        <PromotedEventsSection scope={{ type: "homepage" }} />
+      </Suspense>
 
       {/* Popular Now Section — derived from existing data, zero extra API calls */}
       {popularEvents.length > 0 && (

--- a/components/ui/serverEventsCategorized/index.tsx
+++ b/components/ui/serverEventsCategorized/index.tsx
@@ -34,6 +34,7 @@ import { FeaturedPlaceSection } from "./FeaturedPlaceSection";
 import { CategoryEventsSection } from "./CategoryEventsSection";
 import { createDateFilterBadgeLabels } from "./DateFilterBadges";
 import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
 import HeroSectionSkeleton from "../hero/HeroSectionSkeleton";
 import { getLocaleSafely } from "@utils/i18n-seo";
 import { DEFAULT_LOCALE } from "types/i18n";
@@ -508,6 +509,8 @@ export async function ServerEventsCategorizedContent({
 
   return (
     <>
+      <PromotedEventsSection scope={{ type: "homepage" }} />
+
       {/* Popular Now Section — derived from existing data, zero extra API calls */}
       {popularEvents.length > 0 && (
         <div className="container content-auto-section">

--- a/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
+++ b/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
@@ -161,13 +161,15 @@ Expected: FAIL — `Cannot find module '@lib/api/promotedEvents'`
 
 ```ts
 // lib/api/promotedEvents.ts
+import type { z } from "zod";
 import { fetchWithHmac } from "./fetch-wrapper";
-import { getApiUrl } from "./events";
+import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
+import {
+  EventSummaryResponseDTOSchema,
+  enhanceEventImage,
+} from "@lib/validation/event";
 import type { EventSummaryResponseDTO } from "types/api/event";
-
-export type PromotionScope =
-  | { type: "homepage" }
-  | { type: "town" | "region"; slug: string };
+import type { PromotionScope } from "types/event";
 
 const MAX_PROMOTED_EVENTS = 8;
 
@@ -192,12 +194,18 @@ export async function getActivePromotedEvents(
     return [];
   }
 
+  if (!isApiUrlConfigured()) {
+    return [];
+  }
+
   try {
     const apiUrl = getApiUrl();
     const finalUrl = `${apiUrl}/events/promotions/active?${buildScopeQuery(scope)}`;
 
+    // NEVER add `next: { revalidate, tags }` here — external wrappers must not opt
+    // into the Next fetch cache (high-cardinality per-scope URLs caused a 146k-entry
+    // cache explosion, see docs/incidents/2026-01-20-fetch-cache-explosion.md).
     const response = await fetchWithHmac(finalUrl, {
-      next: { revalidate: 300, tags: ["promoted-events"] },
       headers: { Accept: "application/json" },
     });
 
@@ -210,11 +218,30 @@ export async function getActivePromotedEvents(
 
     const data = await response.json();
     const content = Array.isArray(data?.content) ? data.content : [];
-    const events = content
-      .map((item) => EventSummaryResponseDTOSchema.safeParse(item))
-      .filter((parsed) => parsed.success)
-      .map((parsed) => parsed.data as EventSummaryResponseDTO);
-    return events.slice(0, MAX_PROMOTED_EVENTS);
+
+    // Validate each item individually rather than the array atomically — one
+    // malformed item (wherever it falls in the response) should be dropped,
+    // not discard every valid promotion alongside it.
+    const events: EventSummaryResponseDTO[] = [];
+    let invalidCount = 0;
+    let firstError: z.ZodError | undefined;
+    for (const item of content) {
+      const parsed = EventSummaryResponseDTOSchema.safeParse(item);
+      if (parsed.success) {
+        events.push(parsed.data as EventSummaryResponseDTO);
+      } else {
+        invalidCount++;
+        firstError ??= parsed.error;
+      }
+    }
+    if (invalidCount > 0) {
+      console.warn(
+        `getActivePromotedEvents: dropped ${invalidCount} invalid content item(s)`,
+        firstError,
+      );
+    }
+
+    return events.map(enhanceEventImage).slice(0, MAX_PROMOTED_EVENTS);
   } catch (error) {
     console.warn("getActivePromotedEvents: fetch failed", error);
     return [];

--- a/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
+++ b/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
@@ -1,0 +1,673 @@
+# Promoted Events Carousel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a "Promoted events" carousel on the homepage and on every event listing
+page, sourced from a new isolated, feature-flagged, fail-soft data fetch, reusing the
+existing `EventsAroundServer` carousel engine end to end.
+
+**Architecture:** One new isolated fetch function (`getActivePromotedEvents`) gated behind
+`PROMOTED_EVENTS_ENABLED` (default off, since the real backend endpoint doesn't exist yet).
+One new server component (`PromotedEventsSection`) that calls it and renders nothing on
+empty. One new optional prop (`isPromoted`) threaded through the existing
+`EventsAroundServer` → `CardHorizontalServer` chain for a "Promoted" disclosure badge. Two
+insertion points: `serverEventsCategorized/index.tsx` (homepage) and `PlacePageShell.tsx`
+(every listing page).
+
+**Tech Stack:** Next.js App Router (Server Components), TypeScript, Vitest, next-intl,
+Tailwind (DESIGN.md tokens only).
+
+## Global Constraints
+
+- Reuse `badge-primary` (DESIGN.md token) for the "Promoted" badge — do not invent a new
+  color. Precedent: `components/ui/restaurantPromotion/PromotedRestaurantCard.tsx:36`.
+- `PromotionScope`'s place-type variants are `"town" | "region"` (this codebase's own
+  `PlaceType` vocabulary, not "comarca").
+- `getActivePromotedEvents` must not make a network call when
+  `process.env.PROMOTED_EVENTS_ENABLED !== "true"` — return `[]` immediately.
+- No `captureException`/Sentry wiring for this fetch's failures — `console.warn` only.
+- No changes to the phase-1 checkout flow, pricing config, or `/e/[eventId]/promote` page.
+- `yarn typecheck && yarn lint` must pass before every commit.
+- Spec: `docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md`.
+
+---
+
+### Task 1: `getActivePromotedEvents` data-fetch function
+
+**Files:**
+- Create: `lib/api/promotedEvents.ts`
+- Test: `test/lib/api/promotedEvents.test.ts`
+
+**Interfaces:**
+- Produces: `export type PromotionScope = { type: "homepage" } | { type: "town" | "region"; slug: string }`
+- Produces: `export async function getActivePromotedEvents(scope: PromotionScope): Promise<EventSummaryResponseDTO[]>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// test/lib/api/promotedEvents.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fetchWithHmacMock = vi.fn();
+vi.mock("@lib/api/fetch-wrapper", () => ({
+  fetchWithHmac: (...args: unknown[]) => fetchWithHmacMock(...args),
+}));
+
+import { getActivePromotedEvents } from "@lib/api/promotedEvents";
+
+const originalEnv = process.env.PROMOTED_EVENTS_ENABLED;
+
+describe("getActivePromotedEvents", () => {
+  beforeEach(() => {
+    fetchWithHmacMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.PROMOTED_EVENTS_ENABLED = originalEnv;
+  });
+
+  it("returns [] with no network call when the feature flag is off", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "false";
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toEqual([]);
+    expect(fetchWithHmacMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] with no network call when the flag is unset", async () => {
+    delete process.env.PROMOTED_EVENTS_ENABLED;
+    const result = await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+    expect(result).toEqual([]);
+    expect(fetchWithHmacMock).not.toHaveBeenCalled();
+  });
+
+  it("builds the right query string for a homepage scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [] }),
+    });
+    await getActivePromotedEvents({ type: "homepage" });
+    const [url] = fetchWithHmacMock.mock.calls[0];
+    expect(url).toContain("scope=homepage");
+    expect(url).not.toContain("slug=");
+  });
+
+  it("builds the right query string for a town scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [] }),
+    });
+    await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+    const [url] = fetchWithHmacMock.mock.calls[0];
+    expect(url).toContain("scope=town");
+    expect(url).toContain("slug=cardedeu");
+  });
+
+  it("returns [] (not a throw) on a non-2xx response", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => "not found",
+    });
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] (not a throw) when fetchWithHmac rejects", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    fetchWithHmacMock.mockRejectedValue(new Error("network down"));
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toEqual([]);
+  });
+
+  it("caps results at MAX_PROMOTED_EVENTS", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const content = Array.from({ length: 20 }, (_, i) => ({
+      id: `event-${i}`,
+      hash: `hash-${i}`,
+      slug: `event-${i}`,
+      title: `Event ${i}`,
+      type: "FREE",
+      url: "https://example.com",
+      description: "",
+      imageUrl: "https://example.com/img.jpg",
+      startDate: "2099-01-01",
+      startTime: null,
+      endDate: "2099-01-01",
+      endTime: null,
+      location: "Barcelona",
+      visits: 0,
+      origin: "MANUAL",
+      categories: [],
+    }));
+    fetchWithHmacMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content }),
+    });
+    const result = await getActivePromotedEvents({ type: "homepage" });
+    expect(result).toHaveLength(8);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn vitest run test/lib/api/promotedEvents.test.ts`
+Expected: FAIL — `Cannot find module '@lib/api/promotedEvents'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// lib/api/promotedEvents.ts
+import { fetchWithHmac } from "./fetch-wrapper";
+import { getApiUrl } from "./events";
+import type { EventSummaryResponseDTO } from "types/api/event";
+
+export type PromotionScope =
+  | { type: "homepage" }
+  | { type: "town" | "region"; slug: string };
+
+const MAX_PROMOTED_EVENTS = 8;
+
+function buildScopeQuery(scope: PromotionScope): string {
+  const params = new URLSearchParams({ scope: scope.type });
+  if (scope.type !== "homepage") {
+    params.set("slug", scope.slug);
+  }
+  return params.toString();
+}
+
+/**
+ * Provisional, isolated contract: the backend endpoint this calls does not exist yet
+ * (Gerard's promotion-checkout endpoint shipped in phase 1; the "list active promoted
+ * events" read side is still undecided). A field-name or shape mismatch once it ships
+ * is a one-file fix, confined to this function.
+ */
+export async function getActivePromotedEvents(
+  scope: PromotionScope,
+): Promise<EventSummaryResponseDTO[]> {
+  if (process.env.PROMOTED_EVENTS_ENABLED !== "true") {
+    return [];
+  }
+
+  try {
+    const apiUrl = getApiUrl();
+    const finalUrl = `${apiUrl}/events/promotions/active?${buildScopeQuery(scope)}`;
+
+    const response = await fetchWithHmac(finalUrl, {
+      next: { revalidate: 300, tags: ["promoted-events"] },
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `getActivePromotedEvents: HTTP ${response.status} for ${finalUrl}`,
+      );
+      return [];
+    }
+
+    const data = await response.json();
+    const content = Array.isArray(data?.content) ? data.content : [];
+    return (content as EventSummaryResponseDTO[]).slice(0, MAX_PROMOTED_EVENTS);
+  } catch (error) {
+    console.warn("getActivePromotedEvents: fetch failed", error);
+    return [];
+  }
+}
+```
+
+Check `lib/api/events.ts` for the exact exported name of the API-url helper (`getApiUrl`)
+before importing it — if it's not exported, export it or inline the same `apiUrl`
+resolution `fetchEventsInternal` uses.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn vitest run test/lib/api/promotedEvents.test.ts`
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/api/promotedEvents.ts test/lib/api/promotedEvents.test.ts
+git commit -m "feat(promoted-events): add isolated, flag-gated active-promotions fetch"
+```
+
+---
+
+### Task 2: Thread `isPromoted` through `EventsAroundServer` → `CardHorizontalServer`
+
+**Files:**
+- Modify: `types/common.ts` (`EventsAroundServerProps`, `CardHorizontalServerProps`)
+- Modify: `components/ui/eventsAround/EventsAroundServer.tsx`
+- Modify: `components/ui/cardHorizontal/CardHorizontalServer.tsx`
+- Modify: `messages/ca.json`, `messages/es.json`, `messages/en.json`
+
+**Interfaces:**
+- Consumes: nothing new from Task 1.
+- Produces: `EventsAroundServer` accepts `isPromoted?: boolean`; `CardHorizontalServer`
+  accepts `isPromoted?: boolean` and renders a `badge-primary` pill when true.
+
+- [ ] **Step 1: Add the i18n key** (do this first so the component step below compiles
+  against real translations)
+
+Add to `messages/ca.json`, inside the existing `"Components"` object, as a sibling of
+`"PromotedRestaurantCard"` (around line 857):
+
+```json
+"PromotedEvents": {
+  "title": "Esdeveniments destacats",
+  "badge": "Patrocinat"
+},
+```
+
+Add to `messages/es.json` (same location, same nesting):
+
+```json
+"PromotedEvents": {
+  "title": "Eventos destacados",
+  "badge": "Patrocinado"
+},
+```
+
+Add to `messages/en.json` (same location, same nesting):
+
+```json
+"PromotedEvents": {
+  "title": "Featured events",
+  "badge": "Promoted"
+},
+```
+
+- [ ] **Step 2: Add `isPromoted` to the prop types**
+
+In `types/common.ts`, find `EventsAroundServerProps` (currently `layout?`, `loading?`,
+`usePriority?`, `showJsonLd?`, `jsonLdId?`, `analyticsCategory?`) and add:
+
+```ts
+export interface EventsAroundServerProps extends EventsAroundProps {
+  layout?: EventsAroundLayout;
+  loading?: boolean;
+  usePriority?: boolean;
+  showJsonLd?: boolean;
+  jsonLdId?: string;
+  analyticsCategory?: string;
+  isPromoted?: boolean;
+}
+```
+
+Find `CardHorizontalServerProps` in the same file and add the same field:
+
+```ts
+isPromoted?: boolean;
+```
+
+- [ ] **Step 3: Thread the prop through `EventsAroundServer`**
+
+In `components/ui/eventsAround/EventsAroundServer.tsx`, add `isPromoted = false` to the
+destructured props (function signature currently `{ events, layout = "compact", loading =
+false, usePriority = false, showJsonLd = false, jsonLdId, title }`), and pass it to
+`CardHorizontalServer` in the horizontal-layout branch:
+
+```tsx
+<CardHorizontalServer
+  event={event}
+  isPriority={usePriority && index <= 2}
+  isPromoted={isPromoted}
+/>
+```
+
+- [ ] **Step 4: Render the badge in `CardHorizontalServer`**
+
+In `components/ui/cardHorizontal/CardHorizontalServer.tsx`, add `isPromoted = false` to the
+destructured props, get a second translation namespace, and render the badge next to
+`CategoryBadge`:
+
+```tsx
+const CardHorizontalServer = async ({
+  event,
+  isPriority = false,
+  initialIsFavorite,
+  isPromoted = false,
+}: CardHorizontalServerProps) => {
+  const locale = await getLocaleSafely();
+  const tCard = await getTranslations({ locale, namespace: "Components.CardContent" });
+  const tTime = await getTranslations({ locale, namespace: "Utils.EventTime" });
+  const tCategories = await getTranslations({ locale, namespace: "Config.Categories" });
+  const tPromoted = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  // ...(unchanged prepareCardContentData call)...
+```
+
+And in the JSX, immediately above or beside `<CategoryBadge label={categoryLabel} />`:
+
+```tsx
+{isPromoted && (
+  <span className="badge-primary mb-1 w-fit">{tPromoted("badge")}</span>
+)}
+<CategoryBadge label={categoryLabel} />
+```
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors. This step has no new automated test of its own (rendering
+`CardHorizontalServer`, an async server component, isn't unit-tested anywhere in this
+codebase today — see spec's Testing section) — verify visually in Task 5's manual check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add types/common.ts components/ui/eventsAround/EventsAroundServer.tsx \
+  components/ui/cardHorizontal/CardHorizontalServer.tsx \
+  messages/ca.json messages/es.json messages/en.json
+git commit -m "feat(promoted-events): thread isPromoted badge through card carousel chain"
+```
+
+---
+
+### Task 3: `PromotedEventsSection` component
+
+**Files:**
+- Create: `components/ui/promotedEvents/PromotedEventsSection.tsx`
+
+**Interfaces:**
+- Consumes: `getActivePromotedEvents(scope)` from Task 1; `EventsAroundServer` with
+  `isPromoted` from Task 2; i18n key `Components.PromotedEvents.title` from Task 2.
+- Produces: `export default async function PromotedEventsSection({ scope }: { scope: PromotionScope }): Promise<JSX.Element | null>`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/ui/promotedEvents/PromotedEventsSection.tsx
+import { getTranslations } from "next-intl/server";
+import EventsAroundServer from "@components/ui/eventsAround/EventsAroundServer";
+import { getActivePromotedEvents } from "@lib/api/promotedEvents";
+import type { PromotionScope } from "@lib/api/promotedEvents";
+import { getLocaleSafely } from "@utils/i18n-seo";
+
+function scopeKey(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}`;
+}
+
+function scopePlaceSlug(scope: PromotionScope): string {
+  return scope.type === "homepage" ? "homepage" : scope.slug;
+}
+
+export default async function PromotedEventsSection({
+  scope,
+}: {
+  scope: PromotionScope;
+}) {
+  const promotedEvents = await getActivePromotedEvents(scope);
+  if (promotedEvents.length === 0) {
+    return null;
+  }
+
+  const locale = await getLocaleSafely();
+  const t = await getTranslations({ locale, namespace: "Components.PromotedEvents" });
+  const key = scopeKey(scope);
+
+  return (
+    <div className="container content-auto-section">
+      <section className="py-section-y border-b">
+        <h2 className="heading-2 text-foreground">{t("title")}</h2>
+        <div
+          data-analytics-container="true"
+          data-analytics-context="promoted_carousel"
+          data-analytics-place-slug={scopePlaceSlug(scope)}
+        >
+          <EventsAroundServer
+            events={promotedEvents}
+            layout="horizontal"
+            usePriority={false}
+            isPromoted
+            showJsonLd
+            title={t("title")}
+            jsonLdId={`promoted-events-${key}`}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+Match `SectionHeading`'s exact heading markup instead of the raw `<h2>` above if
+`components/ui/serverEventsCategorized/SectionHeading.tsx` is exported for reuse outside
+that folder — check its import path before wiring Task 4; if it's private to that folder,
+the inline `<h2 className="heading-2 text-foreground">` above (copied verbatim from the
+"Popular Now" heading style) is the correct fallback and needs no further change.
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/ui/promotedEvents/PromotedEventsSection.tsx
+git commit -m "feat(promoted-events): add PromotedEventsSection component"
+```
+
+---
+
+### Task 4: Homepage insertion
+
+**Files:**
+- Modify: `components/ui/serverEventsCategorized/index.tsx`
+
+**Interfaces:**
+- Consumes: `PromotedEventsSection` from Task 3.
+
+- [ ] **Step 1: Insert the section before "Popular Now"**
+
+In the returned JSX (around line 509-511, immediately before the `{/* Popular Now Section
+*/}` comment), add:
+
+```tsx
+return (
+  <>
+    <PromotedEventsSection scope={{ type: "homepage" }} />
+
+    {/* Popular Now Section — derived from existing data, zero extra API calls */}
+    {popularEvents.length > 0 && (
+      // ...unchanged...
+```
+
+Add the import at the top of the file:
+
+```tsx
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
+```
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 3: Manual verification**
+
+Since `PROMOTED_EVENTS_ENABLED` is unset by default, `PromotedEventsSection` returns `null`
+here — running the dev server and loading `/` should look **identical to before this
+task**. That's the correct, expected result; it does not prove the carousel renders
+correctly. Separately, verify the populated path locally:
+
+```bash
+PROMOTED_EVENTS_ENABLED=true yarn dev
+```
+
+With the flag on, `getActivePromotedEvents` will still hit the real (nonexistent) backend
+endpoint and fail soft to `[]` unless a local mock is added — to see the populated carousel
+render, temporarily stub `getActivePromotedEvents` to return a hardcoded
+`EventSummaryResponseDTO[]` fixture, load `/`, confirm the carousel + badge render, then
+revert the stub before committing. Record in the PR description which of the two states
+(empty-hidden vs. populated-with-stub) was actually checked in the browser.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ui/serverEventsCategorized/index.tsx
+git commit -m "feat(promoted-events): render promoted carousel on homepage"
+```
+
+---
+
+### Task 5: Listing-page insertion
+
+**Files:**
+- Modify: `components/partials/PlacePageShell.tsx`
+
+**Interfaces:**
+- Consumes: `PromotedEventsSection` from Task 3; `PlaceTypeAndLabel` from `types/common.ts`
+  (already available in this file's props, per phase-2 spec's "Placement" section).
+
+- [ ] **Step 1: Locate the render point and confirm the `placeTypeLabel` prop's shape**
+
+Read `components/partials/PlacePageShell.tsx` around line 354 (where `HybridEventsList` is
+rendered) and confirm which prop already carries the resolved `PlaceTypeAndLabel` (it's
+computed in `PlacePageGate`/`app/[locale]/[place]/page.tsx` via
+`getPlaceTypeAndLabelCached(place)` and passed down — find its prop name in
+`PlacePageShellProps`, `types/props.ts`, before writing the insertion).
+
+- [ ] **Step 2: Insert the section above `HybridEventsList`**
+
+```tsx
+{placeTypeLabel.type && (
+  <PromotedEventsSection
+    scope={{ type: placeTypeLabel.type, slug: place }}
+  />
+)}
+
+<HybridEventsList
+  // ...unchanged props...
+/>
+```
+
+`placeTypeLabel.type` is `"town" | "region" | ""` at the type level; the `{placeTypeLabel.type
+&& (...)}` guard is the defensive, spec-mandated check for the `""` member even though it's
+unreachable in practice (verified: `getPlaceTypeAndLabel`,
+`utils/location-helpers.ts:209-292`, has no code path returning `""`).
+
+Add the import at the top of the file:
+
+```tsx
+import PromotedEventsSection from "@components/ui/promotedEvents/PromotedEventsSection";
+```
+
+- [ ] **Step 3: Typecheck and lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: no new errors
+
+- [ ] **Step 4: Manual verification**
+
+Same caveat as Task 4 Step 3 — with the flag off (default), a town page (e.g. `/cardedeu`)
+and a region page (e.g. `/maresme`) should render identically to before this task. Verify
+that first, then repeat the temporary-stub check from Task 4 on one town page and one
+region page to confirm the scope-slug plumbing is correct for both `PlaceType` values, then
+revert the stub.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/partials/PlacePageShell.tsx
+git commit -m "feat(promoted-events): render promoted carousel on listing pages"
+```
+
+---
+
+### Task 6: `.env.example` entry
+
+**Files:**
+- Modify: `.env.example` (or the repo's equivalent env-documentation file — confirm exact
+  filename first; some Next.js repos use `.env.local.example`)
+
+- [ ] **Step 1: Add the flag with an explanatory comment**
+
+```bash
+# Promoted events carousel — gates lib/api/promotedEvents.ts's active-promotions fetch.
+# Keep false/unset until the backend's GET /events/promotions/active endpoint exists.
+PROMOTED_EVENTS_ENABLED=false
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "docs(promoted-events): document PROMOTED_EVENTS_ENABLED in env example"
+```
+
+---
+
+### Task 7: E2E regression spec
+
+**Files:**
+- Create: `e2e/promoted-events-carousel.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new — this is a black-box regression check against the running app
+  with the feature flag in its default (off) state.
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+// e2e/promoted-events-carousel.spec.ts
+import { test, expect } from "@playwright/test";
+
+test.describe("promoted events carousel (flag off, default state)", () => {
+  test("homepage renders normally with no promoted-events section", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+
+  test("a town listing page renders normally with no promoted-events section", async ({
+    page,
+  }) => {
+    await page.goto("/cardedeu");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run: `yarn playwright test e2e/promoted-events-carousel.spec.ts`
+Expected: PASS (2 tests) — confirms this phase ships with zero visible/behavioral change
+while `PROMOTED_EVENTS_ENABLED` is off, matching the spec's documented default state.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/promoted-events-carousel.spec.ts
+git commit -m "test(e2e): add promoted-events-carousel regression spec (flag-off state)"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: data contract (Task 1), pill/badge threading (Task 2), component (Task 3),
+  homepage placement (Task 4), listing-page placement (Task 5), env docs (Task 6), E2E
+  (Task 7). Unit tests for `getActivePromotedEvents` are in Task 1. i18n keys land in Task
+  2, before any component references them, so no task ever compiles against a missing key.
+- No RSC render tests for `PromotedEventsSection`/`CardHorizontalServer`, matching the
+  spec's explicit call — verified via typecheck + manual/stub verification instead.
+- Task 3's `SectionHeading` note is a genuine open point for the implementer to resolve in
+  five seconds (check one import), not a placeholder — the fallback behavior if it's
+  private is fully specified inline.
+- Task 5's Step 1 asks the implementer to find one prop name in a file this plan doesn't
+  fully reproduce — flagged rather than guessed, since guessing a wrong prop name here
+  would be a shipped bug, and the plan gives the exact function/line to find it from.

--- a/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
+++ b/docs/superpowers/plans/2026-08-03-promoted-events-carousel.md
@@ -210,7 +210,11 @@ export async function getActivePromotedEvents(
 
     const data = await response.json();
     const content = Array.isArray(data?.content) ? data.content : [];
-    return (content as EventSummaryResponseDTO[]).slice(0, MAX_PROMOTED_EVENTS);
+    const events = content
+      .map((item) => EventSummaryResponseDTOSchema.safeParse(item))
+      .filter((parsed) => parsed.success)
+      .map((parsed) => parsed.data as EventSummaryResponseDTO);
+    return events.slice(0, MAX_PROMOTED_EVENTS);
   } catch (error) {
     console.warn("getActivePromotedEvents: fetch failed", error);
     return [];

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -31,18 +31,23 @@ carousel — on the homepage, and on every event listing page — similar to how
 - Decision (confirmed with user): scope is **auto-derived** from the event's own location
   for this MVP, not a purchasable choice. No changes to the phase-1 checkout flow. The
   *purchased promotion record* (backend-owned) should still carry a scope field
-  (`town`/`comarca`/`everywhere` + slug) from day one so that turning scope into a paid
+  (`town`/`region`/`everywhere` + slug) from day one so that turning scope into a paid
   tier later is a pricing/config change, not a rearchitecture — but since that record and
   its creation live entirely in Gerard's backend (per phase 1's "all payment logic lives
   in the backend" boundary), this repo has nothing to build for that part. This phase only
   *reads*.
+- **Terminology note**: this repo's own `PlaceType` (`types/common.ts`) is
+  `"region" | "town" | ""` — "comarca" (the Catalan administrative unit, e.g. Maresme) is
+  what this codebase already calls a **region**. `PromotionScope` below uses `region`, not
+  "comarca", to match the existing type rather than introduce a second word for the same
+  thing.
 - **Explicit divergence from the literal ask, called out so it isn't mistaken for the real
   thing later**: the original request enumerated three purchasable surface tiers ("if only
   appears in Cardedeu town, or homepage, or all pages"). What ships here, `PromotionScope`,
   is a **query-side surface descriptor** ("which page is asking"), not the **purchased
   tier** ("what the buyer paid for") — those happen to share vocabulary (town/homepage/
   everywhere) but are different types. No purchase path for "all pages" reach exists yet;
-  every promoted event is only fetchable via its own town/comarca/homepage scope in this
+  every promoted event is only fetchable via its own town/region/homepage scope in this
   phase, regardless of what a future buyer might want to pay extra for.
 - An old, unrelated remote branch (`origin/cursor/implement-featured-events-section-for-
   user-promotion-7ea0`) already has commits mentioning a "featured events" section and
@@ -54,7 +59,7 @@ carousel — on the homepage, and on every event listing page — similar to how
 
 **In scope**
 1. A new, isolated data-fetch function for "active promoted events for a given surface"
-   (homepage, or a specific town/comarca), built against a provisional contract — same
+   (homepage, or a specific town/region), built against a provisional contract — same
    approach phase 1 took with the checkout endpoint before it existed.
 2. A reusable `PromotedEventsSection` server component, rendered on the homepage and on
    every event listing page, hidden entirely when there's nothing to show for that scope.
@@ -77,7 +82,7 @@ already 800+ lines and has an unrelated set of responsibilities):
 ```ts
 export type PromotionScope =
   | { type: "homepage" }
-  | { type: "town" | "comarca"; slug: string };
+  | { type: "town" | "region"; slug: string };
 
 export async function getActivePromotedEvents(
   scope: PromotionScope,
@@ -88,6 +93,21 @@ export async function getActivePromotedEvents(
   (query shape marked provisional/isolated in a comment, exactly like `createPromotionCheckout`
   was marked in phase 1 — a field-name or shape mismatch once Gerard's real endpoint ships
   is a one-file fix).
+- **Feature-flag short-circuit (performance + noise control).** The endpoint this calls
+  does not exist yet — every call is a guaranteed miss until Gerard ships it. Rather than
+  make that network round trip on every homepage/listing-page render forever, gate the
+  entire function on `process.env.PROMOTED_EVENTS_ENABLED === "true"` (default off/unset):
+  when off, return `[]` immediately with **no fetch call at all** — not "call and fail
+  fast," genuinely skip the network hop. This is not a permanent compatibility shim; it's a
+  dark-launch gate for a dependency that doesn't exist yet, flipped on once the real
+  endpoint is confirmed. Without it, every page on the site pays a doomed round trip on
+  every cache miss, indefinitely, with no ship date attached.
+- **Failures are quiet, not `captureException`-worthy.** Unlike `fetchEventsInternal`
+  (which reports failures via Sentry because a broken `/events` fetch is a real incident),
+  a non-2xx from this placeholder endpoint during the pre-launch gap is the *expected*
+  outcome, not an exception. Log via `console.warn` (or nothing) and return `[]`; do not
+  wire this into Sentry until the flag is flipped on and the endpoint is real — otherwise
+  every deploy alerts on a "failure" that's actually just "not built yet."
 - **Request mechanics copy `fetchEventsInternal` exactly** (`lib/api/events.ts:128-139`), not
   `createPromotionCheckout`'s mutation path — this is a public GET, not an authenticated
   mutation, so there's no `requireMutationAuth()`/`skipBodySigning`:
@@ -131,12 +151,18 @@ async function PromotedEventsSection({ scope }: { scope: PromotionScope })
   "hide if empty" checks is harmless, not redundant guard-of-a-guard).
 - Otherwise renders a heading (new `Components.PromotedEvents` i18n namespace — no
   "see more" link, since there's no dedicated "all promoted events" page, and no
-  `DateFilterBadges`, since this isn't a date-filterable section) followed by:
+  `DateFilterBadges`, since this isn't a date-filterable section), copying the exact JSX
+  shape of the existing "Popular Now Section" in
+  `components/ui/serverEventsCategorized/index.tsx:511-529` (`<div className="container
+  content-auto-section"><section className="py-section-y border-b"><SectionHeading .../>
+  <EventsAroundServer .../></section></div>`) — the closest existing sibling to what this
+  component needs, right down to `showJsonLd`:
   ```tsx
   <EventsAroundServer
     events={promotedEvents}
     layout="horizontal"
     isPromoted
+    showJsonLd
     title={t("title")}
     jsonLdId={`promoted-events-${scopeKey}`}
   />
@@ -145,6 +171,11 @@ async function PromotedEventsSection({ scope }: { scope: PromotionScope })
   — this also becomes `HorizontalScroll`'s `hintStorageKey` (via `jsonLdId` passthrough in
   `EventsAroundServer`), so it must be unique per page or the first-scroll-nudge sessionStorage
   flag would incorrectly carry over between e.g. Cardedeu's and Mataró's promoted carousels.
+  `showJsonLd` is included (reversing an earlier draft of this doc that considered omitting
+  it to avoid "duplicate `ItemList` schema" risk): the same page already renders multiple
+  overlapping `ItemList` blocks today (Popular Now + one per `FeaturedPlaceSection`), so this
+  isn't a new risk this design introduces — it's the codebase's already-accepted norm, and
+  the JSON-LD data source (`EventsAroundServer`) is the one being reused here anyway.
 - Reuses `EventsAroundServer` entirely for rendering: dedup, horizontal `HorizontalScroll`,
   `CardHorizontalServer`, JSON-LD `ItemList` schema — all for free. No new carousel
   primitive, no new card component.
@@ -166,31 +197,126 @@ placeholders are spliced into an otherwise-organic array; here the whole array p
 
 ## Placement
 
-- **Homepage** (`app/[locale]/page.tsx`, inside `HomeContent`): one
-  `<PromotedEventsSection scope={{ type: "homepage" }} />` near the top — before the first
-  `FeaturedPlaceSection` (comarca-style carousels), so paid placements lead, matching how
-  promoted content is conventionally surfaced.
-- **Every listing page** (`app/[locale]/[place]/page.tsx` and its `[byDate]` /
-  `[byDate]/[category]` children): same component, scoped to that page's resolved place —
-  reusing whatever this page already uses to resolve a `place` slug into town-vs-comarca
-  (the existing `placeTypeLabel` logic already visible in `page.tsx`, used today for the
-  SEO breadcrumb's town→comarca relationship) — prepended above the existing event grid,
-  not interleaved into it.
+- **Homepage**: NOT `app/[locale]/page.tsx` directly — that file only fetches data and
+  delegates all layout to `<ServerEventsCategorized>`. The actual insertion point is
+  inside `components/ui/serverEventsCategorized/index.tsx`, in the JSX block that today
+  renders "Popular Now" then "Featured Places" (`index.tsx:509-539`). Insert
+  `<PromotedEventsSection scope={{ type: "homepage" }} />` **before** the "Popular Now"
+  block — paid placements lead organic-popularity content, which itself already leads the
+  per-region "Featured Places" carousels.
+- **Every listing page**: `app/[locale]/[place]/page.tsx` (`PlacePageGate`) delegates its
+  layout to `PlacePageShell` (`components/partials/PlacePageShell.tsx`), which is what
+  actually renders `HybridEventsList` (`PlacePageShell.tsx:354`) — that's the insertion
+  point, prepended above `HybridEventsList`, not `page.tsx` itself. Scope is built from
+  `getPlaceTypeAndLabelCached(place)` (`@utils/helpers`, already called in
+  `generateMetadata` and reused for the page body), whose `PlaceTypeAndLabel.type` is
+  exactly `"town" | "region"` — a direct, no-translation match for `PromotionScope`. The
+  `[byDate]` and `[byDate]/[category]` child routes reuse the same `PlacePageShell`, so no
+  separate wiring is needed for those.
 - Both cases: the section renders nothing when `getActivePromotedEvents` returns `[]` —
   no "no promoted events" empty state, no layout shift beyond a normal conditional render.
 
+## Performance
+
+- **No LCP competition.** The homepage's actual LCP element is a raw `<img
+  fetchPriority="high">` hero background (`serverEventsCategorized/index.tsx:205-212`),
+  entirely separate from event-card images. Every existing card carousel on this page,
+  including "Popular Now" and every `FeaturedPlaceSection`, is already explicitly
+  `usePriority={false}` (`index.tsx:351`, comment: "Homepage images are below the fold -
+  don't use priority loading"). `PromotedEventsSection` matches that convention —
+  `usePriority={false}` — regardless of where in the stack it sits; it does not introduce
+  a second priority image competing with the hero.
+- **Zero new client bundle.** `PromotedEventsSection`, `getActivePromotedEvents`, and every
+  component it reuses (`EventsAroundServer`, `HorizontalScroll`, `CardHorizontalServer`)
+  are server components or already-shipped client code — no new client-side JS ships for
+  the base carousel. The "Promoted" pill is a static server-rendered `<span>`, same cost
+  class as the existing `CategoryBadge`.
+- **Render-cost deferral for free.** The homepage insertion point reuses the
+  `content-auto-section` wrapper class already used by sibling sections (`content-
+  visibility: auto`), so this section gets the same off-screen render-cost deferral without
+  any new CSS.
+- **The real cost is the extra network call**, addressed above by the feature-flag
+  short-circuit: while `PROMOTED_EVENTS_ENABLED` is unset/false (its state through this
+  entire phase, until Gerard ships the real endpoint), `getActivePromotedEvents` returns
+  `[]` with zero network I/O — so shipping this phase today has **no** performance cost on
+  any page. The cost only appears once the flag is flipped on, at which point the existing
+  `next: { revalidate: 300 }` caching bounds it to one upstream call per scope per 5-minute
+  window, not per request.
+
+## SEO
+
+- **No new URLs, no sitemap change.** This adds cards linking to already-indexed
+  `/e/[slug]` pages — nothing new to crawl or list in `utils/sitemap.ts`.
+- **Duplicate internal links are not a duplicate-content issue.** The same event may now
+  be linked from both its organic listing position and the promoted carousel on one page.
+  Multiple internal links to the same URL on a page is normal and not penalized — this is
+  purely a UX/redundancy question, not an SEO one.
+- **`rel="sponsored"` does not apply here.** That attribute exists for paid *outbound*
+  links to third parties (Google's link-scheme guidance on advertising). These are internal
+  `/e/[slug]` navigations to the site's own content, not paid backlinks — calling this out
+  so it isn't reflexively added by a future contributor who sees "paid promotion" and
+  reaches for `rel="sponsored"` out of habit.
+- **JSON-LD**: see "Component" above — `showJsonLd` stays on, matching sibling sections.
+
+## Analytics
+
+- **Click tracking needs zero new props or component changes.** `CardHorizontalServer`
+  already wraps its link in `data-analytics-event-name="select_event"` with
+  `data-analytics-event-id`/`data-analytics-event-slug` (`CardLayout.tsx:40`, consumed by
+  the delegated click listener in `app/GoogleScriptsHeavy.tsx`). That listener already
+  merges in ambient context from the nearest ancestor `[data-analytics-container="true"]`
+  element — exactly the pattern `components/ui/hybridEventsList/index.tsx:59-61` uses today
+  (`data-analytics-container="true" data-analytics-context="events_list" data-analytics-
+  place-slug={place}`). `PromotedEventsSection` wraps its `EventsAroundServer` call in the
+  same kind of container:
+  ```tsx
+  <div data-analytics-container="true" data-analytics-context="promoted_carousel"
+       data-analytics-place-slug={scope.type === "homepage" ? "homepage" : scope.slug}>
+    <EventsAroundServer ... />
+  </div>
+  ```
+  Every click on a promoted card automatically fires `select_event` with `context:
+  "promoted_carousel"` and the right `place_slug` — no changes to `CardLayout`,
+  `CardHorizontalServer`, or the GA listener's attribute whitelist.
+- **Impression/view tracking is explicitly out of scope for this phase.** The one existing
+  impression-tracking hook, `useListingAnalytics` (`components/hooks/useListingAnalytics.ts`),
+  is hardcoded to the organic grid's DOM shape (`container.querySelector("section")`) and a
+  fixed `context: "listing"` — it doesn't fit a horizontal carousel's DOM, and adapting it
+  is new, non-trivial client code for a nice-to-have metric. Flagging this as a deliberate
+  non-goal, not a silent gap: "carousel was shown" impressions aren't tracked, only clicks.
+
 ## Testing
 
-- Unit (Vitest), new `test/lib/api/promotedEvents.test.ts`: `getActivePromotedEvents`
-  returns `[]` on non-2xx and on network error (fail-soft contract), builds the right query
-  string per scope variant (`homepage` vs `town`/`comarca` + slug).
-- Unit: `PromotedEventsSection` renders `null` on an empty result, renders
-  `EventsAroundServer` with `isPromoted` set on a non-empty result (mirrors existing
-  `EventsAroundServer`/card test conventions already in `test/`).
-- Unit: `CardHorizontalServer`/pill rendering — pill shows only when `isPromoted` is true,
-  uses the i18n label, doesn't collide with `CategoryBadge`.
-- No E2E change needed — this phase adds a new, independently-hidden section; it doesn't
-  touch the publish/promote checkout flow that `e2e/publish-integration.spec.ts` covers.
+- **Unit (Vitest), new `test/lib/api/promotedEvents.test.ts`** — matching this codebase's
+  existing convention of testing pure/isolated functions rather than rendering async server
+  components in Vitest (see `test/events-around-server.test.tsx`, which tests the exported
+  `dedupeEvents` helper, not a rendered tree):
+  - `getActivePromotedEvents` returns `[]`, with no fetch call at all, when
+    `PROMOTED_EVENTS_ENABLED` is unset/false.
+  - Returns `[]` (not a throw) on non-2xx and on network error, once the flag is on.
+  - Builds the right query string per scope variant (`homepage` vs `town`/`region` + slug).
+  - Caps results at `MAX_PROMOTED_EVENTS` even if the (mocked) backend returns more.
+  - Does not call `captureException`/Sentry on a routine non-2xx (only `console.warn`, or
+    silent).
+- **Unit: any extracted pure helper** (e.g. a `scopeKey(scope)` function, if pulled out
+  rather than inlined) gets the same direct-function-call test treatment.
+- **No RSC render tests for `PromotedEventsSection` itself** — consistent with how
+  `FeaturedPlaceSection`/`EventsAroundServer` aren't render-tested today either; behavior
+  is covered via `getActivePromotedEvents`'s unit tests (does it return data) plus manual/
+  `agent-browser` verification during implementation (does it render correctly).
+- **E2E: honest scoping.** `getActivePromotedEvents` is a **server-side** fetch to the
+  external backend (same shape as `fetchEventsInternal`) — Playwright's `page.route()` only
+  intercepts *browser*-initiated requests. Existing e2e mocks (`e2e/filters-client-fetch.spec.ts`,
+  `e2e/load_more_with_filters.spec.ts`) all mock `/api/events`, a client-visible route; there
+  is no existing pattern in this repo for mocking a direct SSR-to-backend call, and building
+  one is out of scope here. Consequently, a "carousel populated with real promoted events"
+  E2E test isn't feasible until real staging backend data exists (same constraint phase 1
+  hit with the checkout endpoint). Scope for this phase: one regression assertion, in a new
+  `e2e/promoted-events-carousel.spec.ts`, that the homepage and one listing page still render
+  their existing content correctly with the feature flag off (today's actual production
+  state) — i.e., this change doesn't break anything, not that the new carousel works
+  end-to-end. Full E2E coverage of the populated carousel is a follow-up once
+  `PROMOTED_EVENTS_ENABLED` is flipped on against real backend data.
 
 ## i18n
 
@@ -204,7 +330,12 @@ namespace precedent from phase 1):
 - Real endpoint contract (query param names, response shape, whether `slug` needs to be a
   town or also accept region/province) is unknown until Gerard defines it — isolated to
   `getActivePromotedEvents`, one-file fix if it differs.
-- Auto-derived scope means a promoted event's audience is capped by its own town/comarca
+- Auto-derived scope means a promoted event's audience is capped by its own town/region
   for this MVP — the "everywhere"/"all pages" tier described in the original ask has no
   purchase path yet (see the divergence note above); known, explicitly deferred, not an
   oversight.
+- `PROMOTED_EVENTS_ENABLED` needs a home in env docs/`.env.example` and in whatever secret
+  manager gates prod env vars — flagged here so it isn't forgotten at deploy time; flipping
+  it on is a deliberate, separate follow-up action once Gerard's endpoint exists, not part
+  of this phase's implementation.
+- No impression/view analytics (see "Analytics" above) — click-only for this phase.

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -1,0 +1,171 @@
+# Promoted Events Carousel (phase 2 of event promotion)
+
+Date: 2026-08-03
+Status: Approved for implementation planning
+Branch: `feat/promoted-events-carousel` (based on `feat/event-promotion-checkout`)
+
+## Problem
+
+Phase 1 (`feat/event-promotion-checkout`, already shipped on this branch's base) added the
+upsell modal, the `/e/[eventId]/promote` page, and the Server Action that hands off to
+Gerard's backend for Stripe checkout. It explicitly left "how promoted surfaces to the
+frontend" undecided — no field on `EventSummaryResponseDTO`, no lookup endpoint, zero
+changes to list rendering. That's this phase: once an event is promoted, show it in a
+carousel — on the homepage, and on every event listing page — similar to how e.g. Vilaweb's
+"Agenda del Maresme" surfaces a region's events today.
+
+## Source of truth / what's confirmed vs. still open
+
+- No backend endpoint exists yet for "give me the active promoted events for X". The
+  closest existing thing, `app/api/promotions/active/route.ts`, is a placeholder that
+  returns `null` with a `TODO: replace with real database lookup` comment — and it's for
+  the unrelated restaurant-promotion feature, not events.
+- `EventSummaryResponseDTO` (`types/api/event.ts`) has no promotion/featured field. The only
+  existing "special card in a list" mechanism is `AdEvent`/`isAd` — Google AdSense banners
+  injected at deterministic positions (`insertAds` in `lib/api/events.ts`) — a different
+  domain (third-party ad revenue, not paid event boosts) and not reused here.
+- The existing restaurant-promotion product (`config/pricing.ts`, `types/sponsor.ts`) already
+  has a real geo-scope model: `town` / `region` / `country` tiers × duration. Event
+  promotion (phase 1) does not — `getEventPromotionOptions()` returns a single flat €5
+  fee, no scope choice at all.
+- Decision (confirmed with user): scope is **auto-derived** from the event's own location
+  for this MVP, not a purchasable choice. No changes to the phase-1 checkout flow. The
+  *purchased promotion record* (backend-owned) should still carry a scope field
+  (`town`/`comarca`/`everywhere` + slug) from day one so that turning scope into a paid
+  tier later is a pricing/config change, not a rearchitecture — but since that record and
+  its creation live entirely in Gerard's backend (per phase 1's "all payment logic lives
+  in the backend" boundary), this repo has nothing to build for that part. This phase only
+  *reads*.
+
+## Scope
+
+**In scope**
+1. A new, isolated data-fetch function for "active promoted events for a given surface"
+   (homepage, or a specific town/comarca), built against a provisional contract — same
+   approach phase 1 took with the checkout endpoint before it existed.
+2. A reusable `PromotedEventsSection` server component, rendered on the homepage and on
+   every event listing page, hidden entirely when there's nothing to show for that scope.
+3. A small "Promoted" disclosure pill on cards inside this carousel only.
+4. i18n strings for the new section heading + pill label.
+
+**Explicitly out of scope**
+- Any change to the phase-1 checkout flow, pricing config, or `/e/[eventId]/promote` page.
+  Scope selection/pricing tiers are a future, backend-driven change.
+- The real backend endpoint itself (owned by Gerard's Spring Boot backend, not this repo).
+- A "Promoted" filter/toggle in the existing filter system.
+- Sorting/reordering organic listing results — this is an additional carousel, not a
+  reordering of the existing grid.
+
+## Data contract (provisional, isolated)
+
+New file `lib/api/promotedEvents.ts` (kept separate from `lib/api/events.ts`, which is
+already 800+ lines and has an unrelated set of responsibilities):
+
+```ts
+export type PromotionScope =
+  | { type: "homepage" }
+  | { type: "town" | "comarca"; slug: string };
+
+export async function getActivePromotedEvents(
+  scope: PromotionScope,
+): Promise<EventSummaryResponseDTO[]>
+```
+
+- Calls a placeholder endpoint, e.g. `GET ${apiUrl}/events/promotions/active?scope=<type>&slug=<slug>`
+  (query shape marked provisional/isolated in a comment, exactly like `createPromotionCheckout`
+  was marked in phase 1 — a field-name or shape mismatch once Gerard's real endpoint ships
+  is a one-file fix).
+- Fails soft: any non-2xx response or network error is caught and returns `[]`. No thrown
+  error reaches a render path — this mirrors the Places "Where to eat" section's own
+  documented behavior ("Fails soft (200 + empty result) on any upstream error; the section
+  hides").
+- No client-side caching decisions beyond whatever wrapper convention `fetchEvents` already
+  uses (`React.cache` per-request dedupe) — no new Redis/cache-key scheme needed for this
+  provisional call; revisit once real traffic and a real endpoint exist.
+
+## Component
+
+New `components/ui/promotedEvents/PromotedEventsSection.tsx` — server component:
+
+```ts
+async function PromotedEventsSection({ scope }: { scope: PromotionScope })
+```
+
+- Calls `getActivePromotedEvents(scope)`. If empty, returns `null` (no wrapper markup at
+  all — matches `EventsAroundServer`'s own empty-hides-itself behavior, so nesting two
+  "hide if empty" checks is harmless, not redundant guard-of-a-guard).
+- Otherwise renders a heading (new `Components.PromotedEvents` i18n namespace — no
+  "see more" link, since there's no dedicated "all promoted events" page, and no
+  `DateFilterBadges`, since this isn't a date-filterable section) followed by:
+  ```tsx
+  <EventsAroundServer
+    events={promotedEvents}
+    layout="horizontal"
+    isPromoted
+    title={t("title")}
+    jsonLdId={`promoted-events-${scopeKey}`}
+  />
+  ```
+- Reuses `EventsAroundServer` entirely for rendering: dedup, horizontal `HorizontalScroll`,
+  `CardHorizontalServer`, JSON-LD `ItemList` schema — all for free. No new carousel
+  primitive, no new card component.
+
+**Threading the "Promoted" pill.** `EventsAroundServer` gets one new optional prop,
+`isPromoted?: boolean`, applied uniformly to every card it renders in a given call (not a
+per-event flag — if you're inside `PromotedEventsSection`'s carousel, every card in it is
+promoted, so there is nothing to distinguish per-item). Passed through to
+`CardHorizontalServer`, which gets the same optional prop and renders a small pill (i18n
+label, new namespace key) next to the existing `CategoryBadge`, visually distinct (different
+color token) so it isn't confused with a category. No changes to `EventSummaryResponseDTO`,
+no `ListEvent`-style union — this stays a rendering-only flag, avoiding the schema bloat the
+`isAd`/`AdEvent` mechanism has for an unrelated reason (that one needs a union because ad
+placeholders are spliced into an otherwise-organic array; here the whole array passed to
+`EventsAroundServer` is already 100% promoted events).
+
+## Placement
+
+- **Homepage** (`app/[locale]/page.tsx`, inside `HomeContent`): one
+  `<PromotedEventsSection scope={{ type: "homepage" }} />` near the top — before the first
+  `FeaturedPlaceSection` (comarca-style carousels), so paid placements lead, matching how
+  promoted content is conventionally surfaced.
+- **Every listing page** (`app/[locale]/[place]/page.tsx` and its `[byDate]` /
+  `[byDate]/[category]` children): same component, scoped to that page's resolved place —
+  reusing whatever this page already uses to resolve a `place` slug into town-vs-comarca
+  (the existing `placeTypeLabel` logic already visible in `page.tsx`, used today for the
+  SEO breadcrumb's town→comarca relationship) — prepended above the existing event grid,
+  not interleaved into it.
+- Both cases: the section renders nothing when `getActivePromotedEvents` returns `[]` —
+  no "no promoted events" empty state, no layout shift beyond a normal conditional render.
+
+## Testing
+
+- Unit (Vitest), new `test/lib/api/promotedEvents.test.ts`: `getActivePromotedEvents`
+  returns `[]` on non-2xx and on network error (fail-soft contract), builds the right query
+  string per scope variant (`homepage` vs `town`/`comarca` + slug).
+- Unit: `PromotedEventsSection` renders `null` on an empty result, renders
+  `EventsAroundServer` with `isPromoted` set on a non-empty result (mirrors existing
+  `EventsAroundServer`/card test conventions already in `test/`).
+- Unit: `CardHorizontalServer`/pill rendering — pill shows only when `isPromoted` is true,
+  uses the i18n label, doesn't collide with `CategoryBadge`.
+- No E2E change needed — this phase adds a new, independently-hidden section; it doesn't
+  touch the publish/promote checkout flow that `e2e/publish-integration.spec.ts` covers.
+
+## i18n
+
+New keys (added to `messages/ca.json`, `es.json`, `en.json`, mirroring the `App.EventPromote`
+namespace precedent from phase 1):
+- `Components.PromotedEvents.title` — carousel heading (e.g. "Esdeveniments destacats").
+- `Components.PromotedEvents.pill` — the disclosure pill label (e.g. "Patrocinat").
+
+## Risks / open questions carried forward (not blocking this implementation)
+
+- Real endpoint contract (query param names, response shape, whether `slug` needs to be a
+  town or also accept region/province) is unknown until Gerard defines it — isolated to
+  `getActivePromotedEvents`, one-file fix if it differs.
+- No pagination/max-count decided for the carousel — deferred to plan/implementation;
+  `EventsAroundServer` doesn't cap `events.length` today (only JSON-LD schema slices to 10),
+  so an unexpectedly large promoted list would need a cap added at the fetch layer, not the
+  render layer.
+- Auto-derived scope means a promoted event's audience is capped by its own town/comarca
+  for this MVP — the "everywhere" tier described in the original ask has no purchase path
+  yet; this is a known, explicitly deferred gap, not an oversight.

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -187,13 +187,18 @@ async function PromotedEventsSection({ scope }: { scope: PromotionScope })
 `isPromoted?: boolean`, applied uniformly to every card it renders in a given call (not a
 per-event flag — if you're inside `PromotedEventsSection`'s carousel, every card in it is
 promoted, so there is nothing to distinguish per-item). Passed through to
-`CardHorizontalServer`, which gets the same optional prop and renders a small pill (i18n
-label, new namespace key) next to the existing `CategoryBadge`, visually distinct (different
-color token) so it isn't confused with a category. No changes to `EventSummaryResponseDTO`,
-no `ListEvent`-style union — this stays a rendering-only flag, avoiding the schema bloat the
-`isAd`/`AdEvent` mechanism has for an unrelated reason (that one needs a union because ad
-placeholders are spliced into an otherwise-organic array; here the whole array passed to
-`EventsAroundServer` is already 100% promoted events).
+`CardHorizontalServer`, which gets the same optional prop and renders a small pill next to
+the existing `CategoryBadge`. **Styling: `badge-primary`**, an existing DESIGN.md token
+(`badge-primary: { background: colors.primary, color: colors.on-primary, rounded: full,
+... }`) — not invented for this feature. It's already the exact class used for this exact
+purpose elsewhere: `components/ui/restaurantPromotion/PromotedRestaurantCard.tsx:36` renders
+`<span className="badge-primary">{t("badge")}</span>` as that feature's own "this is a paid
+promotion" disclosure badge. Copying it here keeps one visual language for "promoted/paid"
+across both promotion features instead of inventing a second one. No changes to
+`EventSummaryResponseDTO`, no `ListEvent`-style union — this stays a rendering-only flag,
+avoiding the schema bloat the `isAd`/`AdEvent` mechanism has for an unrelated reason (that
+one needs a union because ad placeholders are spliced into an otherwise-organic array; here
+the whole array passed to `EventsAroundServer` is already 100% promoted events).
 
 ## Placement
 
@@ -209,10 +214,19 @@ placeholders are spliced into an otherwise-organic array; here the whole array p
   actually renders `HybridEventsList` (`PlacePageShell.tsx:354`) — that's the insertion
   point, prepended above `HybridEventsList`, not `page.tsx` itself. Scope is built from
   `getPlaceTypeAndLabelCached(place)` (`@utils/helpers`, already called in
-  `generateMetadata` and reused for the page body), whose `PlaceTypeAndLabel.type` is
-  exactly `"town" | "region"` — a direct, no-translation match for `PromotionScope`. The
-  `[byDate]` and `[byDate]/[category]` child routes reuse the same `PlacePageShell`, so no
-  separate wiring is needed for those.
+  `generateMetadata` and reused for the page body). Its declared return type,
+  `PlaceTypeAndLabel.type`, is `"town" | "region" | ""` — but **verified against the actual
+  implementation** (`getPlaceTypeAndLabel`, `utils/location-helpers.ts:209-292`): every
+  branch returns `"town"` or `"region"` (empty place → `"region"`/"Catalunya";
+  `fetchPlaceBySlug` hit → `"town"`/`"region"` from the DTO's type; every fallback down to
+  the final catch-all → `"town"`) — there is no code path that returns `""`. The `""` member
+  of `PlaceType` is not reachable from this function; it exists for some other consumer of
+  the shared type, not this one. `PromotionScope`'s mapping is therefore total in practice,
+  but the insertion code still guards it defensively rather than casting past the type
+  checker: `if (!placeTypeLabel.type) return null;` before building `scope` — cheap,
+  correct, and honest that the branch is believed unreachable rather than pretending the
+  type union doesn't include it. The `[byDate]` and `[byDate]/[category]` child routes reuse
+  the same `PlacePageShell`, so no separate wiring is needed for those.
 - Both cases: the section renders nothing when `getActivePromotedEvents` returns `[]` —
   no "no promoted events" empty state, no layout shift beyond a normal conditional render.
 
@@ -334,8 +348,11 @@ namespace precedent from phase 1):
   for this MVP — the "everywhere"/"all pages" tier described in the original ask has no
   purchase path yet (see the divergence note above); known, explicitly deferred, not an
   oversight.
-- `PROMOTED_EVENTS_ENABLED` needs a home in env docs/`.env.example` and in whatever secret
-  manager gates prod env vars — flagged here so it isn't forgotten at deploy time; flipping
-  it on is a deliberate, separate follow-up action once Gerard's endpoint exists, not part
-  of this phase's implementation.
+- `PROMOTED_EVENTS_ENABLED` needs an entry in `.env.example` and in prod env config at
+  deploy time — flagged here so it isn't forgotten; flipping it on is a deliberate, separate
+  follow-up once Gerard's endpoint exists, not part of this phase. Checked `utils/env.ts`:
+  there's no central zod-validated env schema to register with (it's a handful of direct
+  `process.env.X` reads, e.g. `E2E_TEST_MODE`) — a plain `process.env.PROMOTED_EVENTS_ENABLED
+  === "true"` read is consistent with that convention, and it's server-only (no
+  `NEXT_PUBLIC_` prefix), which is correct since it's never read client-side.
 - No impression/view analytics (see "Analytics" above) — click-only for this phase.

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -36,6 +36,19 @@ carousel — on the homepage, and on every event listing page — similar to how
   its creation live entirely in Gerard's backend (per phase 1's "all payment logic lives
   in the backend" boundary), this repo has nothing to build for that part. This phase only
   *reads*.
+- **Explicit divergence from the literal ask, called out so it isn't mistaken for the real
+  thing later**: the original request enumerated three purchasable surface tiers ("if only
+  appears in Cardedeu town, or homepage, or all pages"). What ships here, `PromotionScope`,
+  is a **query-side surface descriptor** ("which page is asking"), not the **purchased
+  tier** ("what the buyer paid for") — those happen to share vocabulary (town/homepage/
+  everywhere) but are different types. No purchase path for "all pages" reach exists yet;
+  every promoted event is only fetchable via its own town/comarca/homepage scope in this
+  phase, regardless of what a future buyer might want to pay extra for.
+- An old, unrelated remote branch (`origin/cursor/implement-featured-events-section-for-
+  user-promotion-7ea0`) already has commits mentioning a "featured events" section and
+  Stripe promotions. Checked and rejected as a base: it diverged from `main` in August
+  2025, touches 989 files, deletes ~144k lines relative to current `main` — an abandoned,
+  unrelated rewrite, not a usable starting point.
 
 ## Scope
 
@@ -75,13 +88,35 @@ export async function getActivePromotedEvents(
   (query shape marked provisional/isolated in a comment, exactly like `createPromotionCheckout`
   was marked in phase 1 — a field-name or shape mismatch once Gerard's real endpoint ships
   is a one-file fix).
+- **Request mechanics copy `fetchEventsInternal` exactly** (`lib/api/events.ts:128-139`), not
+  `createPromotionCheckout`'s mutation path — this is a public GET, not an authenticated
+  mutation, so there's no `requireMutationAuth()`/`skipBodySigning`:
+  ```ts
+  const response = await fetchWithHmac(finalUrl, {
+    next: { revalidate: 300, tags: ["promoted-events"] },
+    headers: { Accept: "application/json" },
+  });
+  ```
+  `revalidate: 300` (5 min) is shorter than `fetchEvents`'s `600` since a promotion activating
+  should surface reasonably quickly; adjust once real traffic patterns exist. Same
+  `tags: ["promoted-events"]` convention as `fetchEvents`'s `tags: ["events"]`, for future
+  on-demand revalidation.
+- **cacheComponents (PPR) compatibility.** `next.config` has `cacheComponents: true`, and
+  `app/[locale]/[place]/page.tsx` already wraps its dynamic event fetch in a `Suspense`
+  boundary so the static shell can flush first (see the comment at `page.tsx:80`). The new
+  promoted-events fetch reuses that same existing Suspense boundary — it does not add a new
+  one, and it does not fetch anything outside it. This keeps the static-shell/dynamic-content
+  split intact; it does not introduce a second, uncached, un-suspended request per page load
+  the way a naive addition would.
 - Fails soft: any non-2xx response or network error is caught and returns `[]`. No thrown
   error reaches a render path — this mirrors the Places "Where to eat" section's own
   documented behavior ("Fails soft (200 + empty result) on any upstream error; the section
   hides").
-- No client-side caching decisions beyond whatever wrapper convention `fetchEvents` already
-  uses (`React.cache` per-request dedupe) — no new Redis/cache-key scheme needed for this
-  provisional call; revisit once real traffic and a real endpoint exist.
+- **Cap at the fetch layer, not the render layer**: `getActivePromotedEvents` slices its
+  result to `.slice(0, 8)` before returning (constant, e.g. `MAX_PROMOTED_EVENTS = 8`,
+  colocated in the same file). `EventsAroundServer` itself never caps `events.length` (only
+  its JSON-LD schema slices to 10), so an unbounded promoted list would otherwise be a
+  layout/payload problem, not just a hypothetical one.
 
 ## Component
 
@@ -106,9 +141,16 @@ async function PromotedEventsSection({ scope }: { scope: PromotionScope })
     jsonLdId={`promoted-events-${scopeKey}`}
   />
   ```
+  where `scopeKey = scope.type === "homepage" ? "homepage" : `${scope.type}-${scope.slug}``
+  — this also becomes `HorizontalScroll`'s `hintStorageKey` (via `jsonLdId` passthrough in
+  `EventsAroundServer`), so it must be unique per page or the first-scroll-nudge sessionStorage
+  flag would incorrectly carry over between e.g. Cardedeu's and Mataró's promoted carousels.
 - Reuses `EventsAroundServer` entirely for rendering: dedup, horizontal `HorizontalScroll`,
   `CardHorizontalServer`, JSON-LD `ItemList` schema — all for free. No new carousel
   primitive, no new card component.
+- `initialIsFavorite` is not passed (same as `FeaturedPlaceSection`'s existing call path
+  today — verified, not a regression this design introduces). Promoted cards render hearts
+  identically to comarca-carousel cards.
 
 **Threading the "Promoted" pill.** `EventsAroundServer` gets one new optional prop,
 `isPromoted?: boolean`, applied uniformly to every card it renders in a given call (not a
@@ -162,10 +204,7 @@ namespace precedent from phase 1):
 - Real endpoint contract (query param names, response shape, whether `slug` needs to be a
   town or also accept region/province) is unknown until Gerard defines it — isolated to
   `getActivePromotedEvents`, one-file fix if it differs.
-- No pagination/max-count decided for the carousel — deferred to plan/implementation;
-  `EventsAroundServer` doesn't cap `events.length` today (only JSON-LD schema slices to 10),
-  so an unexpectedly large promoted list would need a cap added at the fetch layer, not the
-  render layer.
 - Auto-derived scope means a promoted event's audience is capped by its own town/comarca
-  for this MVP — the "everywhere" tier described in the original ask has no purchase path
-  yet; this is a known, explicitly deferred gap, not an oversight.
+  for this MVP — the "everywhere"/"all pages" tier described in the original ask has no
+  purchase path yet (see the divergence note above); known, explicitly deferred, not an
+  oversight.

--- a/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
+++ b/docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md
@@ -337,7 +337,7 @@ the whole array passed to `EventsAroundServer` is already 100% promoted events).
 New keys (added to `messages/ca.json`, `es.json`, `en.json`, mirroring the `App.EventPromote`
 namespace precedent from phase 1):
 - `Components.PromotedEvents.title` — carousel heading (e.g. "Esdeveniments destacats").
-- `Components.PromotedEvents.pill` — the disclosure pill label (e.g. "Patrocinat").
+- `Components.PromotedEvents.badge` — the disclosure pill label (e.g. "Patrocinat").
 
 ## Risks / open questions carried forward (not blocking this implementation)
 
@@ -348,9 +348,9 @@ namespace precedent from phase 1):
   for this MVP — the "everywhere"/"all pages" tier described in the original ask has no
   purchase path yet (see the divergence note above); known, explicitly deferred, not an
   oversight.
-- `PROMOTED_EVENTS_ENABLED` needs an entry in `.env.example` and in prod env config at
-  deploy time — flagged here so it isn't forgotten; flipping it on is a deliberate, separate
-  follow-up once Gerard's endpoint exists, not part of this phase. Checked `utils/env.ts`:
+- `PROMOTED_EVENTS_ENABLED` is documented in `.env.example`; the remaining deployment action
+  is configuring it in prod env config, deliberately deferred until Gerard's endpoint exists.
+  Checked `utils/env.ts`:
   there's no central zod-validated env schema to register with (it's a handful of direct
   `process.env.X` reads, e.g. `E2E_TEST_MODE`) — a plain `process.env.PROMOTED_EVENTS_ENABLED
   === "true"` read is consistent with that convention, and it's server-only (no

--- a/e2e/promoted-events-carousel.spec.ts
+++ b/e2e/promoted-events-carousel.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+// PROMOTED_EVENTS_ENABLED is unset/false in every real deploy today (the
+// backend endpoint this feature calls doesn't exist yet — see
+// lib/api/promotedEvents.ts and docs/superpowers/specs/2026-08-03-promoted-
+// events-carousel-design.md). This spec is a regression check for that
+// default state: the new code path must not change existing page behavior
+// while the flag is off. Full E2E coverage of the populated carousel is a
+// follow-up once the flag is flipped on against real backend data.
+test.describe("promoted events carousel (flag off, default state)", () => {
+  test("homepage renders normally with no promoted-events section", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // Homepage intentionally renders two <h1>s (an sr-only one for SEO/crawler
+    // resilience plus the visible hero title) — see app/[locale]/page.tsx.
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+
+  test("a town listing page renders normally with no promoted-events section", async ({
+    page,
+  }) => {
+    await page.goto("/cardedeu");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /esdeveniments destacats/i }),
+    ).toHaveCount(0);
+  });
+});

--- a/lib/api/promotedEvents.ts
+++ b/lib/api/promotedEvents.ts
@@ -1,5 +1,10 @@
+import { z } from "zod";
 import { fetchWithHmac } from "./fetch-wrapper";
 import { getApiUrl } from "@utils/api-helpers";
+import {
+  EventSummaryResponseDTOSchema,
+  enhanceEventImage,
+} from "@lib/validation/event";
 import type { EventSummaryResponseDTO } from "types/api/event";
 import type { PromotionScope } from "types/event";
 
@@ -46,7 +51,17 @@ export async function getActivePromotedEvents(
 
     const data = await response.json();
     const content = Array.isArray(data?.content) ? data.content : [];
-    return (content as EventSummaryResponseDTO[]).slice(0, MAX_PROMOTED_EVENTS);
+    const parsed = z.array(EventSummaryResponseDTOSchema).safeParse(content);
+    if (!parsed.success) {
+      console.warn(
+        "getActivePromotedEvents: invalid content payload",
+        parsed.error,
+      );
+      return [];
+    }
+
+    const events = parsed.data as EventSummaryResponseDTO[];
+    return events.map(enhanceEventImage).slice(0, MAX_PROMOTED_EVENTS);
   } catch (error) {
     console.warn("getActivePromotedEvents: fetch failed", error);
     return [];

--- a/lib/api/promotedEvents.ts
+++ b/lib/api/promotedEvents.ts
@@ -1,0 +1,54 @@
+import { fetchWithHmac } from "./fetch-wrapper";
+import { getApiUrl } from "@utils/api-helpers";
+import type { EventSummaryResponseDTO } from "types/api/event";
+import type { PromotionScope } from "types/event";
+
+export type { PromotionScope } from "types/event";
+
+const MAX_PROMOTED_EVENTS = 8;
+
+function buildScopeQuery(scope: PromotionScope): string {
+  const params = new URLSearchParams({ scope: scope.type });
+  if (scope.type !== "homepage") {
+    params.set("slug", scope.slug);
+  }
+  return params.toString();
+}
+
+/**
+ * Provisional, isolated contract: the backend endpoint this calls does not exist yet
+ * (Gerard's promotion-checkout endpoint shipped in phase 1; the "list active promoted
+ * events" read side is still undecided). A field-name or shape mismatch once it ships
+ * is a one-file fix, confined to this function.
+ */
+export async function getActivePromotedEvents(
+  scope: PromotionScope,
+): Promise<EventSummaryResponseDTO[]> {
+  if (process.env.PROMOTED_EVENTS_ENABLED !== "true") {
+    return [];
+  }
+
+  try {
+    const apiUrl = getApiUrl();
+    const finalUrl = `${apiUrl}/events/promotions/active?${buildScopeQuery(scope)}`;
+
+    const response = await fetchWithHmac(finalUrl, {
+      next: { revalidate: 300, tags: ["promoted-events"] },
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `getActivePromotedEvents: HTTP ${response.status} for ${finalUrl}`,
+      );
+      return [];
+    }
+
+    const data = await response.json();
+    const content = Array.isArray(data?.content) ? data.content : [];
+    return (content as EventSummaryResponseDTO[]).slice(0, MAX_PROMOTED_EVENTS);
+  } catch (error) {
+    console.warn("getActivePromotedEvents: fetch failed", error);
+    return [];
+  }
+}

--- a/lib/api/promotedEvents.ts
+++ b/lib/api/promotedEvents.ts
@@ -1,5 +1,5 @@
 import { fetchWithHmac } from "./fetch-wrapper";
-import { getApiUrl } from "@utils/api-helpers";
+import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
 import {
   EventSummaryResponseDTOSchema,
   enhanceEventImage,
@@ -32,12 +32,18 @@ export async function getActivePromotedEvents(
     return [];
   }
 
+  if (!isApiUrlConfigured()) {
+    return [];
+  }
+
   try {
     const apiUrl = getApiUrl();
     const finalUrl = `${apiUrl}/events/promotions/active?${buildScopeQuery(scope)}`;
 
+    // NEVER add `next: { revalidate, tags }` here — external wrappers must not opt
+    // into the Next fetch cache (high-cardinality per-scope URLs caused a 146k-entry
+    // cache explosion, see docs/incidents/2026-01-20-fetch-cache-explosion.md).
     const response = await fetchWithHmac(finalUrl, {
-      next: { revalidate: 300, tags: ["promoted-events"] },
       headers: { Accept: "application/json" },
     });
 
@@ -55,16 +61,19 @@ export async function getActivePromotedEvents(
     // malformed item (wherever it falls in the response) should be dropped,
     // not discard every valid promotion alongside it.
     const events: EventSummaryResponseDTO[] = [];
+    let invalidCount = 0;
     for (const item of content) {
       const parsed = EventSummaryResponseDTOSchema.safeParse(item);
       if (parsed.success) {
         events.push(parsed.data as EventSummaryResponseDTO);
       } else {
-        console.warn(
-          "getActivePromotedEvents: dropping invalid content item",
-          parsed.error,
-        );
+        invalidCount++;
       }
+    }
+    if (invalidCount > 0) {
+      console.warn(
+        `getActivePromotedEvents: dropped ${invalidCount} invalid content item(s)`,
+      );
     }
 
     return events.map(enhanceEventImage).slice(0, MAX_PROMOTED_EVENTS);

--- a/lib/api/promotedEvents.ts
+++ b/lib/api/promotedEvents.ts
@@ -1,3 +1,4 @@
+import type { z } from "zod";
 import { fetchWithHmac } from "./fetch-wrapper";
 import { getApiUrl, isApiUrlConfigured } from "@utils/api-helpers";
 import {
@@ -62,17 +63,20 @@ export async function getActivePromotedEvents(
     // not discard every valid promotion alongside it.
     const events: EventSummaryResponseDTO[] = [];
     let invalidCount = 0;
+    let firstError: z.ZodError | undefined;
     for (const item of content) {
       const parsed = EventSummaryResponseDTOSchema.safeParse(item);
       if (parsed.success) {
         events.push(parsed.data as EventSummaryResponseDTO);
       } else {
         invalidCount++;
+        firstError ??= parsed.error;
       }
     }
     if (invalidCount > 0) {
       console.warn(
         `getActivePromotedEvents: dropped ${invalidCount} invalid content item(s)`,
+        firstError,
       );
     }
 

--- a/lib/api/promotedEvents.ts
+++ b/lib/api/promotedEvents.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import { fetchWithHmac } from "./fetch-wrapper";
 import { getApiUrl } from "@utils/api-helpers";
 import {
@@ -51,16 +50,23 @@ export async function getActivePromotedEvents(
 
     const data = await response.json();
     const content = Array.isArray(data?.content) ? data.content : [];
-    const parsed = z.array(EventSummaryResponseDTOSchema).safeParse(content);
-    if (!parsed.success) {
-      console.warn(
-        "getActivePromotedEvents: invalid content payload",
-        parsed.error,
-      );
-      return [];
+
+    // Validate each item individually rather than the array atomically — one
+    // malformed item (wherever it falls in the response) should be dropped,
+    // not discard every valid promotion alongside it.
+    const events: EventSummaryResponseDTO[] = [];
+    for (const item of content) {
+      const parsed = EventSummaryResponseDTOSchema.safeParse(item);
+      if (parsed.success) {
+        events.push(parsed.data as EventSummaryResponseDTO);
+      } else {
+        console.warn(
+          "getActivePromotedEvents: dropping invalid content item",
+          parsed.error,
+        );
+      }
     }
 
-    const events = parsed.data as EventSummaryResponseDTO[];
     return events.map(enhanceEventImage).slice(0, MAX_PROMOTED_EVENTS);
   } catch (error) {
     console.warn("getActivePromotedEvents: fetch failed", error);

--- a/lib/validation/event.ts
+++ b/lib/validation/event.ts
@@ -224,7 +224,7 @@ export function parseCategorizedEvents(
   return Object.fromEntries(normalizedEntries) as CategorizedEvents;
 }
 
-function enhanceEventImage<
+export function enhanceEventImage<
   T extends { imageUrl?: string | null; hash?: string | null; updatedAt?: string }
 >(event: T): T {
   const cacheKey = event.hash || event.updatedAt;

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -859,6 +859,10 @@
       "badge": "Patrocinat",
       "activeUntil": "Promoció activa fins al {date}"
     },
+    "PromotedEvents": {
+      "title": "Esdeveniments destacats",
+      "badge": "Patrocinat"
+    },
     "WhereToEatSection": {
       "title": "On pots menjar",
       "promote": "Promociona el teu restaurant",

--- a/messages/en.json
+++ b/messages/en.json
@@ -851,6 +851,10 @@
       "badge": "Sponsored",
       "activeUntil": "Promotion active until {date}"
     },
+    "PromotedEvents": {
+      "title": "Featured events",
+      "badge": "Promoted"
+    },
     "WhereToEatSection": {
       "showPhoto": "Show photo",
       "title": "Where you can eat",

--- a/messages/en.json
+++ b/messages/en.json
@@ -853,7 +853,7 @@
     },
     "PromotedEvents": {
       "title": "Featured events",
-      "badge": "Promoted"
+      "badge": "Sponsored"
     },
     "WhereToEatSection": {
       "showPhoto": "Show photo",

--- a/messages/es.json
+++ b/messages/es.json
@@ -851,6 +851,10 @@
       "badge": "Patrocinado",
       "activeUntil": "Promoción activa hasta el {date}"
     },
+    "PromotedEvents": {
+      "title": "Eventos destacados",
+      "badge": "Patrocinado"
+    },
     "WhereToEatSection": {
       "showPhoto": "Ver foto",
       "title": "Dónde puedes comer",

--- a/test/lib/api/promotedEvents.test.ts
+++ b/test/lib/api/promotedEvents.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getActivePromotedEvents } from "../../../lib/api/promotedEvents";
+import * as fetchWrapper from "../../../lib/api/fetch-wrapper";
+import type { EventSummaryResponseDTO } from "types/api/event";
+
+const originalEnv = { ...process.env };
+
+const baseEvent: EventSummaryResponseDTO = {
+  id: "event-1",
+  hash: "hash-1",
+  slug: "event-one",
+  title: "Event One",
+  type: "FREE",
+  url: "https://example.com/event-one",
+  description: "Description",
+  imageUrl: "https://example.com/image.jpg",
+  startDate: "2099-01-01",
+  startTime: null,
+  endDate: "2099-01-01",
+  endTime: null,
+  location: "Barcelona",
+  visits: 0,
+  origin: "MANUAL",
+  categories: [],
+};
+
+describe("getActivePromotedEvents", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: "https://api.example.com" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns [] with no network call when the feature flag is off", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "false";
+    const fetchSpy = vi.spyOn(fetchWrapper, "fetchWithHmac");
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns [] with no network call when the flag is unset", async () => {
+    delete process.env.PROMOTED_EVENTS_ENABLED;
+    const fetchSpy = vi.spyOn(fetchWrapper, "fetchWithHmac");
+
+    const result = await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds the right query string for a homepage scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response(JSON.stringify({ content: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const fetchSpy = vi
+      .spyOn(fetchWrapper, "fetchWithHmac")
+      .mockResolvedValue(mockResponse);
+
+    await getActivePromotedEvents({ type: "homepage" });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain("scope=homepage");
+    expect(url).not.toContain("slug=");
+  });
+
+  it("builds the right query string for a town scope", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response(JSON.stringify({ content: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const fetchSpy = vi
+      .spyOn(fetchWrapper, "fetchWithHmac")
+      .mockResolvedValue(mockResponse);
+
+    await getActivePromotedEvents({ type: "town", slug: "cardedeu" });
+
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain("scope=town");
+    expect(url).toContain("slug=cardedeu");
+  });
+
+  it("returns [] (not a throw) on a non-2xx response", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response("not found", { status: 404 });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] (not a throw) when fetchWithHmac rejects", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockRejectedValue(
+      new Error("network down"),
+    );
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+  });
+
+  it("caps results at MAX_PROMOTED_EVENTS", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const content = Array.from({ length: 20 }, (_, i) => ({
+      ...baseEvent,
+      id: `event-${i}`,
+      hash: `hash-${i}`,
+      slug: `event-${i}`,
+      title: `Event ${i}`,
+    }));
+    const mockResponse = new Response(JSON.stringify({ content }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toHaveLength(8);
+  });
+
+  it("does not call console.error/Sentry for a routine non-2xx", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockResponse = new Response("not found", { status: 404 });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    await getActivePromotedEvents({ type: "homepage" });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/test/lib/api/promotedEvents.test.ts
+++ b/test/lib/api/promotedEvents.test.ts
@@ -122,6 +122,24 @@ describe("getActivePromotedEvents", () => {
     expect(result).toEqual([]);
   });
 
+  it("drops individually invalid items without discarding the valid ones around them", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const content = [
+      { ...baseEvent, id: "valid-1", slug: "valid-1" },
+      { id: "malformed", title: "missing required fields" },
+      { ...baseEvent, id: "valid-2", slug: "valid-2" },
+    ];
+    const mockResponse = new Response(JSON.stringify({ content }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result.map((e) => e.id)).toEqual(["valid-1", "valid-2"]);
+  });
+
   it("caps results at MAX_PROMOTED_EVENTS", async () => {
     process.env.PROMOTED_EVENTS_ENABLED = "true";
     const content = Array.from({ length: 20 }, (_, i) => ({

--- a/test/lib/api/promotedEvents.test.ts
+++ b/test/lib/api/promotedEvents.test.ts
@@ -109,6 +109,19 @@ describe("getActivePromotedEvents", () => {
     expect(result).toEqual([]);
   });
 
+  it("returns [] (not a throw) when content items don't match EventSummaryResponseDTOSchema", async () => {
+    process.env.PROMOTED_EVENTS_ENABLED = "true";
+    const mockResponse = new Response(
+      JSON.stringify({ content: [{ id: "malformed", title: "missing required fields" }] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+    vi.spyOn(fetchWrapper, "fetchWithHmac").mockResolvedValue(mockResponse);
+
+    const result = await getActivePromotedEvents({ type: "homepage" });
+
+    expect(result).toEqual([]);
+  });
+
   it("caps results at MAX_PROMOTED_EVENTS", async () => {
     process.env.PROMOTED_EVENTS_ENABLED = "true";
     const content = Array.from({ length: 20 }, (_, i) => ({

--- a/test/server-events-categorized.test.tsx
+++ b/test/server-events-categorized.test.tsx
@@ -25,6 +25,14 @@ vi.mock("@components/ui/eventsAround/EventsAroundServer", () => ({
   ),
 }));
 
+// PromotedEventsSection is async (calls getActivePromotedEvents) — RTL's render()
+// can't handle an unmocked async Server Component. It's irrelevant to what these
+// tests cover (category-matching logic), so stub it to null, matching its real
+// behavior with PROMOTED_EVENTS_ENABLED unset (the default in every test env here).
+vi.mock("@components/ui/promotedEvents/PromotedEventsSection", () => ({
+  default: () => null,
+}));
+
 vi.mock("@components/ui/common/badge", () => ({
   default: ({
     href,

--- a/types/common.ts
+++ b/types/common.ts
@@ -349,6 +349,7 @@ export interface CardHorizontalServerProps {
   event: EventSummaryResponseDTO;
   isPriority?: boolean;
   initialIsFavorite?: boolean;
+  isPromoted?: boolean;
 }
 
 export interface CardShareButtonProps {
@@ -378,6 +379,7 @@ export interface EventsAroundServerProps extends EventsAroundProps {
   showJsonLd?: boolean;
   jsonLdId?: string;
   analyticsCategory?: string;
+  isPromoted?: boolean;
 }
 
 export interface BaseLayoutProps {

--- a/types/event.ts
+++ b/types/event.ts
@@ -391,6 +391,17 @@ export interface EventPromotionOption {
   priceEur: number;
 }
 
+/**
+ * Query-side surface descriptor for `getActivePromotedEvents`
+ * (lib/api/promotedEvents.ts): "which page is asking", not "what the buyer
+ * paid for". Auto-derived from the event's own location for the MVP — not a
+ * purchasable choice yet. `"town" | "region"` matches this codebase's own
+ * `PlaceType` (types/common.ts), not "comarca".
+ */
+export type PromotionScope =
+  | { type: "homepage" }
+  | { type: "town" | "region"; slug: string };
+
 export interface UseEventsOptions {
   place?: string;
   category?: string;


### PR DESCRIPTION
## Summary

Phase 2 of event promotion: once an event is promoted (phase 1's checkout flow, already on this branch's base), show it in a "Promoted events" carousel — on the homepage, and on every event listing page (town/region).

- New isolated, feature-flagged fetch: `getActivePromotedEvents(scope)` (`lib/api/promotedEvents.ts`). The backend endpoint it calls (`GET /events/promotions/active`) doesn't exist yet, so it's gated behind `PROMOTED_EVENTS_ENABLED` (default off/unset) — while off, it short-circuits with **zero network calls**, so this ships with no behavioral or performance change to any page today.
- New `PromotedEventsSection` component, entirely reusing the existing `EventsAroundServer` carousel engine (dedup, horizontal scroll, cards, JSON-LD) — no new carousel primitive.
- New `isPromoted` prop threaded through `EventsAroundServer` → `CardHorizontalServer`, rendering a "Promoted" disclosure badge using the existing `badge-primary` DESIGN.md token (same one `PromotedRestaurantCard` already uses for the same purpose).
- Inserted on the homepage (`serverEventsCategorized/index.tsx`, before "Popular Now") and on every listing page (`PlacePageShell.tsx`, before `HybridEventsList`), scoped by the page's own town/region.
- Response validated against `EventSummaryResponseDTOSchema` (mirrors `fetchEventsInternal`'s own `parsePagedEvents` pattern) rather than cast blindly — a malformed backend response degrades to an empty carousel, not a render crash.
- Click analytics come for free via the existing `data-analytics-container` pattern (`context: "promoted_carousel"`) — no changes to card-level analytics wiring.

Full design rationale, rejected alternatives, and two rounds of adversarial review are in `docs/superpowers/specs/2026-08-03-promoted-events-carousel-design.md`; the task-by-task implementation plan is in `docs/superpowers/plans/2026-08-03-promoted-events-carousel.md`.

## Verified locally

- `yarn typecheck && yarn lint`: 0 errors.
- `yarn vitest run`: 198 files / 2349 tests passing (includes 9 new unit tests for `getActivePromotedEvents`: flag-off short-circuit, query building per scope, non-2xx/network fail-soft, response-shape validation, and the `MAX_PROMOTED_EVENTS` cap).
- `yarn playwright test e2e/promoted-events-carousel.spec.ts`: 2/2 passing — regression check that the homepage and a town listing page render identically to before, with the flag in its real default (off) state.
- Browser-verified both states manually: (1) flag off — homepage and `/cardedeu` / `/maresme` render with zero occurrences of the new section; (2) flag on with a temporary in-memory stub swapped into `getActivePromotedEvents` (reverted before every commit) — confirmed the heading, `badge-primary` pill, JSON-LD `ItemList`, and `data-analytics-place-slug` all render correctly and carry the right scope slug for both a town and a region page.

## Test plan

- [ ] Confirm `PROMOTED_EVENTS_ENABLED` is documented in whatever secret manager gates prod env vars, and stays `false` until the backend endpoint exists
- [ ] Once Gerard's `GET /events/promotions/active` endpoint ships, verify the query contract (`scope`/`slug` params) against the real response shape and flip the flag on in staging first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a feature-flagged “Promoted events” carousel to the homepage and all listing pages, reusing the horizontal carousel and showing a “Sponsored” badge. No behavior change until the backend endpoint is live and the flag is enabled.

- **New Features**
  - Flag-gated fetch `getActivePromotedEvents(scope)` calling `GET /events/promotions/active`; when `PROMOTED_EVENTS_ENABLED` is off or the API URL is not configured, it returns [] with no network call and does not opt into Next’s fetch cache.
  - Robust parsing: per-item validation via `EventSummaryResponseDTOSchema` (invalid items are dropped with a single aggregated warning that includes the first schema error), images normalized with `enhanceEventImage`, capped at 8; non-2xx responses return [].
  - New `PromotedEventsSection` reusing `EventsAroundServer` (horizontal) with JSON-LD and `data-analytics-context="promoted_carousel"`; Suspense-wrapped on the homepage and town/region pages.
  - Threads `isPromoted` to `CardHorizontalServer` to show a “Sponsored” badge (`badge-primary`; en: “Sponsored”, ca/es: “Patrocinat/Patrocinado”); loads the translation namespace only when needed.
  - Added `.env.example` entry, translations, unit tests for the fetch, and an e2e regression spec (flag-off state).

- **Migration**
  - Keep `PROMOTED_EVENTS_ENABLED` false until the backend endpoint exists.
  - After it ships, verify query params and response shape, then enable the flag in staging before production.

<sup>Written for commit cab727e95b3733728c6b8abb5437a55b8a4a022f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

