### PR TITLE
feat(navbar): move mobile auth to header, drop redundant hamburger

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -165,6 +165,7 @@ motion:
 breakpoints:
   xs: "360px"
   sm: "576px"
+  nav: "950px"
   md: "768px"
   lg: "1024px"
   xl: "1280px"
@@ -653,13 +654,13 @@ titles vary.
 Z-layers are explicit: 10 sticky chrome, 100 dropdowns, 900 modals, 1000
 tooltips. Anything above 1000 is forbidden.
 
-Navigation is a top sticky bar on desktop, a fixed bottom tab bar on mobile
-— a deliberate native-app affordance for a product that's used walking
-around towns. The desktop bar is 56px tall with a backdrop blur and a
-hairline border. The mobile bar is 64px tall with five circular icon-only
-buttons (Home, Agenda, Favorites, Publish, News), each at least 44×44 px;
-the active route fills with `colors.primary-tint` and tints its icon
-primary red.
+Navigation is a top sticky bar on desktop, a fixed bottom tab bar below the
+950px navigation breakpoint — a deliberate native-app affordance for a
+product that's used walking around towns. The desktop bar is 56px tall with
+a backdrop blur and a hairline border. The mobile bar is 64px tall with five
+circular icon-only buttons (Home, Agenda, Favorites, Publish, News), each at
+least 44×44 px; the active route fills with `colors.primary-tint` and tints
+its icon primary red.
 
 ## Elevation & Depth
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -165,8 +165,8 @@ motion:
 breakpoints:
   xs: "360px"
   sm: "576px"
-  nav: "950px"
   md: "768px"
+  nav: "950px"
   lg: "1024px"
   xl: "1280px"
 

--- a/app/[locale]/perfil/edita/EditProfileForm.tsx
+++ b/app/[locale]/perfil/edita/EditProfileForm.tsx
@@ -14,7 +14,12 @@ const BIO_MAX = 500;
 
 export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
   const t = useTranslations("App.EditProfile");
-  const { user, refetchUser } = useAuth();
+  // Reuses the navbar's logout copy: this is a profile-owner page whose
+  // only auth entry point is the navbar avatar, and it has no dropdown of
+  // its own to put a logout action in — see ProfileOwnerActions for the
+  // equivalent on /perfil/[username].
+  const tAuth = useTranslations("Components.Navbar.auth");
+  const { user, refetchUser, logout } = useAuth();
   const router = useRouter();
   // Matches the check in NavbarClient: `=== false`, not falsy, so a
   // transient backend enrichment blip (profileCompleted undefined) doesn't
@@ -147,6 +152,14 @@ export default function EditProfileForm({ redirectTo }: EditProfileFormProps) {
           <p className="body-normal text-foreground/80">
             {t(isOnboarding ? "onboardingSubheading" : "subheading")}
           </p>
+          <button
+            type="button"
+            onClick={() => logout()}
+            className="btn-outline btn-sm self-center"
+            data-analytics-action="edit_profile_logout_cta"
+          >
+            {tAuth("logout")}
+          </button>
         </div>
 
         {submitError && (

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -73,12 +73,12 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
   return (
     <nav
       id="site-navbar"
-      className="w-full bg-background md:sticky md:top-0 z-50 border-b border-border/50 md:shadow-sm md:backdrop-blur-sm"
+      className="w-full bg-background nav:sticky nav:top-0 z-50 border-b border-border/50 nav:shadow-sm nav:backdrop-blur-sm"
     >
-      <div className="container bg-background py-2 h-14">
+      <div className="bg-background py-2 h-14">
         <div className="h-full flex flex-col justify-center">
           <div className="flex justify-between items-center">
-            <div className="flex flex-1 md:w-1/2 justify-start items-center py-2 px-3">
+            <div className="flex flex-1 nav:w-1/2 justify-start items-center py-2 px-3">
               <PressableLink
                 href="/"
                 prefetch={false}
@@ -88,7 +88,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
               >
                 <Image
                   src="/static/images/logo-esdeveniments.webp"
-                  className="bg-background flex justify-center items-center cursor-pointer"
+                  className="bg-background flex justify-center items-center cursor-pointer !w-[clamp(140px,20vw,190px)] !h-auto max-w-full aspect-[190/18]"
                   alt={logoAlt}
                   width={190}
                   height={18}
@@ -97,15 +97,20 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
               </PressableLink>
             </div>
 
-            {/* Mobile header: language switcher + direct link to profile/login.
-                No dropdown, logout lives on the profile page itself (see
-                ProfileOwnerActions). Nav items live in the bottom bar only. */}
-            <div className="flex md:hidden justify-end items-center gap-2 px-3">
+            {/* Compact header: language switcher + direct link to profile/login.
+                Used below the desktop navigation breakpoint; nav items live in the bottom bar.
+                Logout lives on the profile page itself (see ProfileOwnerActions). */}
+            <div
+              className="flex nav:hidden justify-end items-center gap-2"
+              data-testid="compact-navbar-actions"
+            >
               <LanguageSwitcher />
               {!isLoading && (
                 isAuthenticated && user && !user.profileEnrichmentFailed ? (
-                  <ActiveLink
+                  <PressableLink
                     href={profileHref || "/perfil/edita"}
+                    prefetch={false}
+                    variant="inline"
                     className="flex-center w-11 h-11 rounded-full bg-primary text-white text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                     aria-label={labels.myProfile}
                     data-testid="mobile-avatar-link"
@@ -119,7 +124,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                     ) : (
                       (user.name || user.email).charAt(0).toUpperCase()
                     )}
-                  </ActiveLink>
+                  </PressableLink>
                 ) : (
                   <ActiveLink
                     href="/iniciar-sessio"
@@ -132,13 +137,16 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                     data-testid="mobile-login-link"
                     data-analytics-action="navbar_login_mobile_header"
                   >
-                    <UserCircleIcon className="h-6 w-6" />
+                    <UserCircleIcon className="h-10 w-10" />
                   </ActiveLink>
                 )
               )}
             </div>
 
-            <div className="hidden md:flex md:w-1/2 justify-end items-center gap-3">
+            <div
+              className="hidden nav:flex nav:w-1/2 justify-end items-center gap-3"
+              data-testid="desktop-navbar-actions"
+            >
               <div className="flex-center gap-1">
                 {navigation.map((item) => (
                   <ActiveLink
@@ -155,68 +163,68 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
               {!isLoading && (
                 isAuthenticated && user ? (
                   <div className="relative" ref={userMenuRef}>
-                      <button
-                        type="button"
-                        onClick={() => setIsUserMenuOpen((prev) => !prev)}
-                        className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold hover:opacity-90 transition-interactive focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-                        aria-label={labels.userMenu}
-                        aria-expanded={isUserMenuOpen}
-                        data-testid="user-avatar-button"
-                      >
-                        {user.avatarUrl ? (
-                          // bg-background: the button behind this is bg-primary (for
-                          // the fallback-letter case). A transparent-background
-                          // upload (e.g. a logo) would otherwise let that red bleed
-                          // through instead of showing the actual image cleanly.
-                          <img
-                            src={user.avatarUrl}
-                            alt=""
-                            className="w-9 h-9 rounded-full object-cover bg-background"
-                          />
-                        ) : (
-                          (user.name || user.email).charAt(0).toUpperCase()
-                        )}
-                      </button>
-                      {isUserMenuOpen && (
-                        <div className="absolute right-0 mt-2 w-48 card-bordered card-body shadow-md bg-background z-50 rounded-lg" data-testid="user-dropdown-menu">
-                          <p className="body-small text-foreground/60 truncate mb-2">
-                            {user.name || user.email}
-                          </p>
-                          {/* Surface "incomplete session" when the id_token is
+                    <button
+                      type="button"
+                      onClick={() => setIsUserMenuOpen((prev) => !prev)}
+                      className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold hover:opacity-90 transition-interactive focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                      aria-label={labels.userMenu}
+                      aria-expanded={isUserMenuOpen}
+                      data-testid="user-avatar-button"
+                    >
+                      {user.avatarUrl ? (
+                        // bg-background: the button behind this is bg-primary (for
+                        // the fallback-letter case). A transparent-background
+                        // upload (e.g. a logo) would otherwise let that red bleed
+                        // through instead of showing the actual image cleanly.
+                        <img
+                          src={user.avatarUrl}
+                          alt=""
+                          className="w-9 h-9 rounded-full object-cover bg-background"
+                        />
+                      ) : (
+                        (user.name || user.email).charAt(0).toUpperCase()
+                      )}
+                    </button>
+                    {isUserMenuOpen && (
+                      <div className="absolute right-0 mt-2 w-48 card-bordered card-body shadow-md bg-background z-50 rounded-lg" data-testid="user-dropdown-menu">
+                        <p className="body-small text-foreground/60 truncate mb-2">
+                          {user.name || user.email}
+                        </p>
+                        {/* Surface "incomplete session" when the id_token is
                               valid but the backend rejected our Bearer (or was
                               unreachable). Without this, the user sees an empty
                               dropdown — no profile link, only logout — and
                               can't tell why. Clicking logout re-enters the
                               Logto flow and may fix a stale cookie. */}
-                          {user.profileEnrichmentFailed && (
-                            <p
-                              className="body-small text-error mb-1 py-1"
-                              data-testid="navbar-session-warning"
-                              role="status"
-                              aria-live="polite"
-                            >
-                              {labels.incompleteProfile}
-                            </p>
-                          )}
-                          {profileHref && !user.profileEnrichmentFailed && (
-                            <ActiveLink
-                              href={profileHref}
-                              className="block w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
-                            >
-                              {labels.myProfile}
-                            </ActiveLink>
-                          )}
-                          <button
-                            type="button"
-                            onClick={() => { logout(); setIsUserMenuOpen(false); }}
-                            className="w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
-                            data-analytics-action="navbar_logout_desktop"
+                        {user.profileEnrichmentFailed && (
+                          <p
+                            className="body-small text-error mb-1 py-1"
+                            data-testid="navbar-session-warning"
+                            role="status"
+                            aria-live="polite"
                           >
-                            {labels.logout}
-                          </button>
-                        </div>
-                      )}
-                    </div>
+                            {labels.incompleteProfile}
+                          </p>
+                        )}
+                        {profileHref && !user.profileEnrichmentFailed && (
+                          <ActiveLink
+                            href={profileHref}
+                            className="block w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
+                          >
+                            {labels.myProfile}
+                          </ActiveLink>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => { logout(); setIsUserMenuOpen(false); }}
+                          className="w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
+                          data-analytics-action="navbar_logout_desktop"
+                        >
+                          {labels.logout}
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 ) : (
                   <ActiveLink
                     href="/iniciar-sessio"
@@ -232,7 +240,10 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
             </div>
           </div>
 
-          <div className="fixed bottom-0 left-0 right-0 h-16 border-t border-border md:hidden z-50 shadow-lg">
+          <div
+            className="fixed bottom-0 left-0 right-0 h-16 border-t border-border nav:hidden z-50 shadow-lg"
+            data-testid="mobile-bottom-nav"
+          >
             <div
               aria-hidden="true"
               className="absolute inset-0 bg-background/95 backdrop-blur-md pointer-events-none"

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { usePathname } from "next/navigation";
 import {
-  Bars3Icon as MenuIcon,
-  XMarkIcon as XIcon,
   PlusIcon,
   HomeIcon,
   CalendarIcon,
@@ -25,7 +23,6 @@ import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavbarClient({ navigation, labels }: NavbarClientProps) {
   const pathname = usePathname();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
   const { user, isAuthenticated, isLoading, logout } = useAuth();
@@ -51,16 +48,13 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
         ? `/perfil/${encodeURIComponent(profileSlug)}`
         : null;
 
-  const toggleMenu = useCallback(() => setIsMenuOpen((prev) => !prev), []);
-
-  // Close mobile menu when pathname changes (navigation occurs)
+  // Close the desktop user dropdown when pathname changes (navigation occurs)
   // This is a legitimate effect that synchronizes state with an external system (route)
   const previousPathname = useRef(pathname);
   useEffect(() => {
     if (previousPathname.current !== pathname) {
       previousPathname.current = pathname;
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Syncing menu state with route changes is intentional
-      setIsMenuOpen(false);
       setIsUserMenuOpen(false);
     }
   }, [pathname]);
@@ -103,21 +97,42 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
               </PressableLink>
             </div>
 
-            <div className="flex justify-center items-center md:hidden">
-              <button
-                type="button"
-                onClick={toggleMenu}
-                className="inline-flex items-center justify-center py-2 px-3 rounded-button hover:bg-muted transition-interactive focus:outline-none"
-                aria-expanded={isMenuOpen}
-                aria-controls="mobile-menu-panel"
-                aria-label={isMenuOpen ? labels.closeMenu : labels.openMenu}
-              >
-                {isMenuOpen ? (
-                  <XIcon className="h-5 w-5" />
+            {/* Mobile header: language switcher + direct link to profile/login.
+                No dropdown, logout lives on the profile page itself (see
+                ProfileOwnerActions). Nav items live in the bottom bar only. */}
+            <div className="flex md:hidden justify-end items-center gap-2 px-3">
+              <LanguageSwitcher />
+              {!isLoading && (
+                isAuthenticated && user && !user.profileEnrichmentFailed ? (
+                  <ActiveLink
+                    href={profileHref || "/"}
+                    className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    aria-label={labels.myProfile}
+                    data-testid="mobile-avatar-link"
+                    data-analytics-action="navbar_profile_mobile_header"
+                  >
+                    {user.avatarUrl ? (
+                      <img
+                        src={user.avatarUrl}
+                        alt=""
+                        className="w-9 h-9 rounded-full object-cover bg-background"
+                      />
+                    ) : (
+                      (user.name || user.email).charAt(0).toUpperCase()
+                    )}
+                  </ActiveLink>
                 ) : (
-                  <MenuIcon className="h-5 w-5" />
-                )}
-              </button>
+                  <ActiveLink
+                    href="/iniciar-sessio"
+                    className="flex-center p-2 rounded-button hover:bg-muted transition-interactive focus:outline-none"
+                    aria-label={labels.login}
+                    data-testid="mobile-login-link"
+                    data-analytics-action="navbar_login_mobile_header"
+                  >
+                    <UserCircleIcon className="h-6 w-6" />
+                  </ActiveLink>
+                )
+              )}
             </div>
 
             <div className="hidden md:flex md:w-1/2 justify-end items-center gap-3">
@@ -243,26 +258,14 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
               </div>
 
               <div className="flex-center">
-                {!isLoading && isAuthenticated ? (
-                  <ActiveLink
-                    href="/preferits"
-                    activeLinkClass="text-primary bg-primary/10"
-                    className="flex-center p-3 rounded-full hover:bg-muted transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 min-w-[44px] min-h-[44px]"
-                    aria-label={labels.favorites}
-                  >
-                    <HeartIcon className="h-6 w-6" />
-                  </ActiveLink>
-                ) : !isLoading ? (
-                  <ActiveLink
-                    href="/iniciar-sessio"
-                    activeLinkClass="text-primary bg-primary/10"
-                    className="flex-center p-3 rounded-full hover:bg-muted transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 min-w-[44px] min-h-[44px]"
-                    aria-label={labels.login}
-                    data-analytics-action="navbar_login_mobile_icon"
-                  >
-                    <UserCircleIcon className="h-6 w-6" />
-                  </ActiveLink>
-                ) : null}
+                <ActiveLink
+                  href="/preferits"
+                  activeLinkClass="text-primary bg-primary/10"
+                  className="flex-center p-3 rounded-full hover:bg-muted transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 min-w-[44px] min-h-[44px]"
+                  aria-label={labels.favorites}
+                >
+                  <HeartIcon className="h-6 w-6" />
+                </ActiveLink>
               </div>
 
               <div className="flex-center">
@@ -293,79 +296,6 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
           </div>
         </div>
       </div>
-
-      {isMenuOpen && (
-        <div
-          id="mobile-menu-panel"
-          className="md:hidden relative z-50 bg-background border-b border-border shadow-md"
-        >
-          <div className="w-full flex flex-col items-stretch bg-background py-3 px-section-x gap-2">
-            {navigation.map((item) => (
-              <ActiveLink
-                href={item.href}
-                key={item.name}
-                className="label font-semibold px-button-x py-3 border-b-2 border-b-background hover:bg-muted/50 rounded-lg transition-all text-center"
-              >
-                {item.name}
-              </ActiveLink>
-            ))}
-
-            {/* Auth section */}
-            {!isLoading && (
-              <div className="pt-3 border-t border-border flex flex-col gap-2">
-                {isAuthenticated && user ? (
-                  <>
-                    <p className="body-small text-foreground/60 text-center truncate">
-                      {user.name || user.email}
-                    </p>
-                    {/* Surface "incomplete session" inside the mobile panel too,
-                        so the warning is visible without opening the desktop
-                        dropdown. See desktop variant for rationale. */}
-                    {user.profileEnrichmentFailed && (
-                      <p
-                        className="body-small text-error text-center py-1"
-                        data-testid="navbar-session-warning-mobile"
-                        role="status"
-                        aria-live="polite"
-                      >
-                        {labels.incompleteProfile}
-                      </p>
-                    )}
-                    {profileHref && !user.profileEnrichmentFailed && (
-                      <ActiveLink
-                        href={profileHref}
-                        className="label font-semibold px-button-x py-3 hover:bg-muted/50 rounded-lg transition-all text-center"
-                      >
-                        {labels.myProfile}
-                      </ActiveLink>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => { logout(); setIsMenuOpen(false); }}
-                      className="label font-semibold px-button-x py-3 hover:bg-muted/50 rounded-lg transition-all text-center"
-                      data-analytics-action="navbar_logout_mobile"
-                    >
-                      {labels.logout}
-                    </button>
-                  </>
-                ) : (
-                  <ActiveLink
-                    href="/iniciar-sessio"
-                    className="label font-semibold px-button-x py-3 hover:bg-muted/50 rounded-lg transition-all text-center"
-                    data-analytics-action="navbar_login_mobile_menu"
-                  >
-                    {labels.login}
-                  </ActiveLink>
-                )}
-              </div>
-            )}
-
-            <div className="pt-3 border-t border-border flex justify-end items-center">
-              <LanguageSwitcher />
-            </div>
-          </div>
-        </div>
-      )}
     </nav>
   );
 }

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -105,11 +105,10 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
               {!isLoading && (
                 isAuthenticated && user && !user.profileEnrichmentFailed ? (
                   <ActiveLink
-                    href={profileHref || "/"}
+                    href={profileHref || "/perfil/edita"}
                     className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                     aria-label={labels.myProfile}
                     data-testid="mobile-avatar-link"
-                    data-analytics-action="navbar_profile_mobile_header"
                   >
                     {user.avatarUrl ? (
                       <img
@@ -125,7 +124,11 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                   <ActiveLink
                     href="/iniciar-sessio"
                     className="flex-center p-2 rounded-button hover:bg-muted transition-interactive focus:outline-none"
-                    aria-label={labels.login}
+                    aria-label={
+                      user?.profileEnrichmentFailed
+                        ? labels.incompleteProfile
+                        : labels.login
+                    }
                     data-testid="mobile-login-link"
                     data-analytics-action="navbar_login_mobile_header"
                   >

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -106,7 +106,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                 isAuthenticated && user && !user.profileEnrichmentFailed ? (
                   <ActiveLink
                     href={profileHref || "/perfil/edita"}
-                    className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    className="flex-center w-11 h-11 rounded-full bg-primary text-white text-sm font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                     aria-label={labels.myProfile}
                     data-testid="mobile-avatar-link"
                   >
@@ -114,7 +114,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                       <img
                         src={user.avatarUrl}
                         alt=""
-                        className="w-9 h-9 rounded-full object-cover bg-background"
+                        className="w-11 h-11 rounded-full object-cover bg-background"
                       />
                     ) : (
                       (user.name || user.email).charAt(0).toUpperCase()
@@ -123,7 +123,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                 ) : (
                   <ActiveLink
                     href="/iniciar-sessio"
-                    className="flex-center p-2 rounded-button hover:bg-muted transition-interactive focus:outline-none"
+                    className="flex-center w-11 h-11 rounded-button hover:bg-muted transition-interactive focus:outline-none"
                     aria-label={
                       user?.profileEnrichmentFailed
                         ? labels.incompleteProfile

--- a/components/ui/common/navbar/index.tsx
+++ b/components/ui/common/navbar/index.tsx
@@ -19,8 +19,6 @@ export default async function Navbar() {
     navigation,
     labels: {
       logoAlt: t("logoAlt"),
-      openMenu: t("aria.openMenu"),
-      closeMenu: t("aria.closeMenu"),
       home: t("aria.home"),
       agenda: t("aria.agenda"),
       favorites: t("aria.favorites"),

--- a/components/ui/profile/ProfileOwnerActions.tsx
+++ b/components/ui/profile/ProfileOwnerActions.tsx
@@ -9,17 +9,26 @@ import type { ProfileOwnerActionsProps } from "types/props";
 export default function ProfileOwnerActions({
   username,
 }: ProfileOwnerActionsProps) {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const t = useTranslations("Components.Profile");
+  const tAuth = useTranslations("Components.Navbar.auth");
   const { ref: ctaRef, trackClick } = useTrackedCta<HTMLDivElement>("profile_edit_cta");
 
   if (user?.username !== username) return null;
 
   return (
-    <div ref={ctaRef} className="inline-block">
+    <div ref={ctaRef} className="inline-flex items-center gap-2">
       <Link href="/perfil/edita" className="btn-outline btn-sm" onClick={trackClick}>
         {t("editProfile")}
       </Link>
+      <button
+        type="button"
+        onClick={() => logout()}
+        className="btn-outline btn-sm"
+        data-analytics-action="profile_logout_cta"
+      >
+        {tAuth("logout")}
+      </button>
     </div>
   );
 }

--- a/components/ui/profile/ProfileOwnerActions.tsx
+++ b/components/ui/profile/ProfileOwnerActions.tsx
@@ -11,6 +11,9 @@ export default function ProfileOwnerActions({
 }: ProfileOwnerActionsProps) {
   const { user, logout } = useAuth();
   const t = useTranslations("Components.Profile");
+  // Reuses the navbar's logout copy rather than duplicating the string —
+  // also read from app/[locale]/perfil/edita/EditProfileForm.tsx, so don't
+  // prune "Components.Navbar.auth.logout" for looking unused navbar-side.
   const tAuth = useTranslations("Components.Navbar.auth");
   const { ref: ctaRef, trackClick } = useTrackedCta<HTMLDivElement>("profile_edit_cta");
 

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -460,8 +460,6 @@
       },
       "logoAlt": "Logo Esdeveniments.cat",
       "aria": {
-        "openMenu": "Open menu",
-        "closeMenu": "Close menu",
         "home": "Home",
         "agenda": "Agenda",
         "favorites": "Preferits",

--- a/messages/en.json
+++ b/messages/en.json
@@ -460,8 +460,6 @@
       },
       "logoAlt": "Esdeveniments.cat logo",
       "aria": {
-        "openMenu": "Open menu",
-        "closeMenu": "Close menu",
         "home": "Home",
         "agenda": "Agenda",
         "favorites": "Favorites",

--- a/messages/es.json
+++ b/messages/es.json
@@ -460,8 +460,6 @@
       },
       "logoAlt": "Logo Esdeveniments.cat",
       "aria": {
-        "openMenu": "Abrir menú",
-        "closeMenu": "Cerrar menú",
         "home": "Inicio",
         "agenda": "Agenda",
         "favorites": "Favoritos",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,8 +49,8 @@ module.exports = {
       screens: {
         xs: "360px",
         sm: "576px",
-        nav: "950px",
         md: "768px",
+        nav: "950px",
         lg: "1024px",
         xl: "1280px",
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,7 @@ module.exports = {
       screens: {
         xs: "360px",
         sm: "576px",
+        nav: "950px",
         md: "768px",
         lg: "1024px",
         xl: "1280px",

--- a/test/edit-profile-form.test.tsx
+++ b/test/edit-profile-form.test.tsx
@@ -14,6 +14,7 @@ const baseUser: AuthUser = {
 let authUser: AuthUser = baseUser;
 
 const mockRefetchUser = vi.fn();
+const mockLogout = vi.fn();
 const mockPush = vi.fn();
 const { sendGoogleEventMock } = vi.hoisted(() => ({
   sendGoogleEventMock: vi.fn<
@@ -30,7 +31,11 @@ vi.mock("@i18n/routing", () => ({
 }));
 
 vi.mock("@components/hooks/useAuth", () => ({
-  useAuth: () => ({ user: authUser, refetchUser: mockRefetchUser }),
+  useAuth: () => ({
+    user: authUser,
+    refetchUser: mockRefetchUser,
+    logout: mockLogout,
+  }),
 }));
 
 vi.mock("@utils/analytics", () => ({
@@ -48,9 +53,21 @@ describe("EditProfileForm", () => {
   beforeEach(() => {
     authUser = baseUser;
     mockRefetchUser.mockReset().mockResolvedValue(undefined);
+    mockLogout.mockReset();
     mockPush.mockReset();
     sendGoogleEventMock.mockReset();
     vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("lets an onboarding user (no other logout entry point) log out from here", () => {
+    // NavbarClient sends profileCompleted === false users to this page, and
+    // logout otherwise only lives on the owner's completed profile page
+    // (ProfileOwnerActions) — without this, onboarding users on mobile
+    // would have no way to end their session.
+    authUser = { ...baseUser, profileCompleted: false };
+    render(<EditProfileForm />);
+    fireEvent.click(screen.getByText("logout"));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
   });
 
   it("fires edit_profile_page_view once on mount, with is_onboarding", () => {

--- a/test/navbar-avatar.test.tsx
+++ b/test/navbar-avatar.test.tsx
@@ -32,8 +32,10 @@ vi.mock("@components/ui/common/link", () => ({
 }));
 
 vi.mock("@components/ui/primitives/PressableLink", () => ({
-  default: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({ children, href, ...props }: { children: ReactNode; href: string } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
   ),
 }));
 
@@ -68,6 +70,21 @@ const labels: NavbarLabels = {
 };
 
 describe("NavbarClient avatar", () => {
+  it("keeps the logo at its aspect ratio and uses the compact layout below the nav breakpoint", () => {
+    render(<NavbarClient navigation={[]} labels={labels} />);
+    const logo = screen.getByAltText(labels.logoAlt);
+    const navbar = document.getElementById("site-navbar");
+
+    expect(logo).toHaveClass("!h-auto", "aspect-[190/18]");
+    expect(navbar).toHaveClass("nav:sticky");
+    expect(screen.getByTestId("compact-navbar-actions")).toHaveClass("nav:hidden");
+    expect(screen.getByTestId("desktop-navbar-actions")).toHaveClass("hidden", "nav:flex");
+    expect(screen.getByTestId("mobile-bottom-nav")).toHaveClass("nav:hidden");
+
+    const mobileAvatar = screen.getByTestId("mobile-avatar-link");
+    expect(mobileAvatar).not.toHaveClass("text-primary", "border-b-2", "border-primary");
+  });
+
   it("gives a transparent-background upload a neutral backdrop instead of the fallback button color", () => {
     render(<NavbarClient navigation={[]} labels={labels} />);
     const img = screen.getByTestId("user-avatar-button").querySelector("img");

--- a/test/navbar-avatar.test.tsx
+++ b/test/navbar-avatar.test.tsx
@@ -54,8 +54,6 @@ import NavbarClient from "@components/ui/common/navbar/NavbarClient";
 
 const labels: NavbarLabels = {
   logoAlt: "Esdeveniments",
-  openMenu: "Obre el menú",
-  closeMenu: "Tanca el menú",
   home: "Inici",
   agenda: "Agenda",
   favorites: "Preferits",
@@ -72,7 +70,7 @@ const labels: NavbarLabels = {
 describe("NavbarClient avatar", () => {
   it("gives a transparent-background upload a neutral backdrop instead of the fallback button color", () => {
     render(<NavbarClient navigation={[]} labels={labels} />);
-    const img = screen.getByAltText("");
+    const img = screen.getByTestId("user-avatar-button").querySelector("img");
     expect(img).toHaveAttribute("src", authUser.avatarUrl);
     expect(img).toHaveClass("bg-background");
   });

--- a/test/navbar-avatar.test.tsx
+++ b/test/navbar-avatar.test.tsx
@@ -82,6 +82,7 @@ describe("NavbarClient avatar", () => {
     expect(screen.getByTestId("mobile-bottom-nav")).toHaveClass("nav:hidden");
 
     const mobileAvatar = screen.getByTestId("mobile-avatar-link");
+    expect(mobileAvatar).toHaveAttribute("href", "/perfil/alba");
     expect(mobileAvatar).not.toHaveClass("text-primary", "border-b-2", "border-primary");
   });
 

--- a/test/navbar-profile-link.test.tsx
+++ b/test/navbar-profile-link.test.tsx
@@ -123,6 +123,25 @@ describe("NavbarClient profile link", () => {
     ).toBe("/perfil/alba");
   });
 
+  it("sends the mobile avatar to /perfil/edita instead of home when no usable slug exists", () => {
+    // getProfileSlug (utils/user-helpers.ts) rejects an email-shaped
+    // username/name — profileHref ends up null even though the user is
+    // authenticated and profileCompleted isn't explicitly false. Landing on
+    // "/" here would strand the user with no way back to their account.
+    authUser = {
+      id: OWNER_ID,
+      email: "a@b.com",
+      name: "a@b.com",
+      username: "a@b.com",
+      profileCompleted: true,
+    };
+    render(<NavbarClient navigation={[]} labels={labels} />);
+
+    expect(
+      screen.getByTestId("mobile-avatar-link").getAttribute("href")
+    ).toBe("/perfil/edita");
+  });
+
   it("falls back to the re-auth link on mobile when the session is only partially enriched", () => {
     authUser = {
       id: OWNER_ID,

--- a/test/navbar-profile-link.test.tsx
+++ b/test/navbar-profile-link.test.tsx
@@ -48,8 +48,6 @@ import NavbarClient from "@components/ui/common/navbar/NavbarClient";
 
 const labels: NavbarLabels = {
   logoAlt: "Esdeveniments",
-  openMenu: "Obre el menú",
-  closeMenu: "Tanca el menú",
   home: "Inici",
   agenda: "Agenda",
   favorites: "Preferits",
@@ -78,12 +76,13 @@ describe("NavbarClient profile link", () => {
     };
     render(<NavbarClient navigation={[]} labels={labels} />);
     fireEvent.click(screen.getByTestId("user-avatar-button"));
-    fireEvent.click(screen.getByLabelText(labels.openMenu));
 
-    const links = screen.getAllByText("El meu perfil");
-    for (const link of links) {
-      expect(link.closest("a")?.getAttribute("href")).toBe("/perfil/edita");
-    }
+    expect(
+      screen.getByText("El meu perfil").closest("a")?.getAttribute("href")
+    ).toBe("/perfil/edita");
+    expect(
+      screen.getByTestId("mobile-avatar-link").getAttribute("href")
+    ).toBe("/perfil/edita");
   });
 
   it("links to /perfil/{username} once the profile is completed", () => {
@@ -96,12 +95,13 @@ describe("NavbarClient profile link", () => {
     };
     render(<NavbarClient navigation={[]} labels={labels} />);
     fireEvent.click(screen.getByTestId("user-avatar-button"));
-    fireEvent.click(screen.getByLabelText(labels.openMenu));
 
-    const links = screen.getAllByText("El meu perfil");
-    for (const link of links) {
-      expect(link.closest("a")?.getAttribute("href")).toBe("/perfil/alba");
-    }
+    expect(
+      screen.getByText("El meu perfil").closest("a")?.getAttribute("href")
+    ).toBe("/perfil/alba");
+    expect(
+      screen.getByTestId("mobile-avatar-link").getAttribute("href")
+    ).toBe("/perfil/alba");
   });
 
   it("links to /perfil/{username} when profileCompleted is undefined (transient enrichment blip)", () => {
@@ -114,11 +114,12 @@ describe("NavbarClient profile link", () => {
     };
     render(<NavbarClient navigation={[]} labels={labels} />);
     fireEvent.click(screen.getByTestId("user-avatar-button"));
-    fireEvent.click(screen.getByLabelText(labels.openMenu));
 
-    const links = screen.getAllByText("El meu perfil");
-    for (const link of links) {
-      expect(link.closest("a")?.getAttribute("href")).toBe("/perfil/alba");
-    }
+    expect(
+      screen.getByText("El meu perfil").closest("a")?.getAttribute("href")
+    ).toBe("/perfil/alba");
+    expect(
+      screen.getByTestId("mobile-avatar-link").getAttribute("href")
+    ).toBe("/perfil/alba");
   });
 });

--- a/test/navbar-profile-link.test.tsx
+++ b/test/navbar-profile-link.test.tsx
@@ -26,8 +26,10 @@ vi.mock("@components/ui/common/link", () => ({
 }));
 
 vi.mock("@components/ui/primitives/PressableLink", () => ({
-  default: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({ children, href, ...props }: { children: ReactNode; href: string } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
   ),
 }));
 

--- a/test/navbar-profile-link.test.tsx
+++ b/test/navbar-profile-link.test.tsx
@@ -122,4 +122,59 @@ describe("NavbarClient profile link", () => {
       screen.getByTestId("mobile-avatar-link").getAttribute("href")
     ).toBe("/perfil/alba");
   });
+
+  it("falls back to the re-auth link on mobile when the session is only partially enriched", () => {
+    authUser = {
+      id: OWNER_ID,
+      email: "a@b.com",
+      name: "A",
+      username: "alba",
+      profileCompleted: true,
+      profileEnrichmentFailed: "auth",
+    };
+    render(<NavbarClient navigation={[]} labels={labels} />);
+
+    expect(
+      screen.getByTestId("mobile-login-link").getAttribute("href")
+    ).toBe("/iniciar-sessio");
+    expect(screen.queryByTestId("mobile-avatar-link")).toBeNull();
+  });
+
+  it("shows the mobile login link, not the avatar, when signed out", () => {
+    authUser = null;
+    render(<NavbarClient navigation={[]} labels={labels} />);
+
+    expect(
+      screen.getByTestId("mobile-login-link").getAttribute("href")
+    ).toBe("/iniciar-sessio");
+    expect(screen.queryByTestId("mobile-avatar-link")).toBeNull();
+    expect(screen.queryByTestId("user-avatar-button")).toBeNull();
+  });
+});
+
+describe("NavbarClient bottom bar Favoritos", () => {
+  beforeEach(() => {
+    authUser = null;
+  });
+
+  it("always links to /preferits, signed in or out", () => {
+    authUser = null;
+    const { unmount } = render(<NavbarClient navigation={[]} labels={labels} />);
+    expect(
+      screen.getByLabelText(labels.favorites).getAttribute("href")
+    ).toBe("/preferits");
+    unmount();
+
+    authUser = {
+      id: OWNER_ID,
+      email: "a@b.com",
+      name: "A",
+      username: "alba",
+      profileCompleted: true,
+    };
+    render(<NavbarClient navigation={[]} labels={labels} />);
+    expect(
+      screen.getByLabelText(labels.favorites).getAttribute("href")
+    ).toBe("/preferits");
+  });
 });

--- a/test/profile-cta-tracking.test.tsx
+++ b/test/profile-cta-tracking.test.tsx
@@ -11,6 +11,7 @@ let authState: { user: { username: string } | null; status: string } = {
   user: null,
   status: "unauthenticated",
 };
+const logoutMock = vi.fn();
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -32,7 +33,7 @@ vi.mock("@i18n/routing", () => ({
 }));
 
 vi.mock("@components/hooks/useAuth", () => ({
-  useAuth: () => authState,
+  useAuth: () => ({ ...authState, logout: logoutMock }),
 }));
 
 vi.mock("@components/hooks/useTrackedCta", () => ({
@@ -46,6 +47,7 @@ describe("ProfileOwnerActions", () => {
   beforeEach(() => {
     trackClickMock.mockReset();
     trackedCtaMock.mockClear();
+    logoutMock.mockReset();
     authState = { user: null, status: "unauthenticated" };
   });
 
@@ -53,6 +55,7 @@ describe("ProfileOwnerActions", () => {
     authState = { user: { username: "someoneElse" }, status: "authenticated" };
     render(<ProfileOwnerActions username="alex91" />);
     expect(screen.queryByText("editProfile")).toBeNull();
+    expect(screen.queryByText("logout")).toBeNull();
   });
 
   it("registers the profile_edit_cta id and tracks a click for the owner", () => {
@@ -62,6 +65,16 @@ describe("ProfileOwnerActions", () => {
     expect(trackedCtaMock).toHaveBeenCalledWith("profile_edit_cta");
     fireEvent.click(screen.getByText("editProfile"));
     expect(trackClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls logout when the owner clicks the logout button", () => {
+    authState = { user: { username: "alex91" }, status: "authenticated" };
+    render(<ProfileOwnerActions username="alex91" />);
+
+    const logoutButton = screen.getByText("logout");
+    expect(logoutButton).toHaveAttribute("data-analytics-action", "profile_logout_cta");
+    fireEvent.click(logoutButton);
+    expect(logoutMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/types/props.ts
+++ b/types/props.ts
@@ -419,8 +419,6 @@ export interface SitemapPartsRouteContext {
 
 export interface NavbarLabels {
   logoAlt: string;
-  openMenu: string;
-  closeMenu: string;
   home: string;
   agenda: string;
   favorites: string;


### PR DESCRIPTION
## Summary

- Mobile bottom bar already navigates the whole site (Inicio, Agenda, Favoritos, Publica, Noticies); the hamburger menu just re-rendered those same five links plus login/logout, so it's removed.
- Mobile header now carries the language switcher and a direct profile avatar / login link (no dropdown, matches desktop's avatar area, but taps straight through instead of opening a menu).
- Logout moves to the profile page itself via `ProfileOwnerActions`, next to "Editar perfil" — a two-item dropdown (profile / logout) isn't needed just to reach one action.
- The bottom bar's Favoritos slot no longer swaps to a login icon when signed out — `/preferits` already serves cookie-based favorites to guests, so the swap was hiding a working feature behind auth state.
- Desktop is unchanged: avatar dropdown with profile + logout stays as-is.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean (no new warnings/errors)
- [x] Full suite: 190 files / 2306 tests passing
- [x] Updated `navbar-avatar`, `navbar-profile-link`, `profile-cta-tracking` tests for the new mobile link + logout button
- [x] Verified the `profileEnrichmentFailed` edge case (backend didn't recognize access token): mobile now routes to `/iniciar-sessio` (re-auth) instead of a dead link, same recovery path the desktop dropdown already documents
- [ ] Manual mobile viewport check (not yet browser-verified in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012V8gt4wCV68mZU8NgW8gGk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved mobile auth to the header and removed the mobile hamburger to simplify nav and fix logout dead-ends. Adopted a 950px `nav` breakpoint and 44×44 touch targets for avatar/login.

- **New Features**
  - Mobile header shows language switcher and a direct profile/login link (no dropdown) in `NavbarClient`.
  - Mobile avatar links to `/perfil/{slug}` when available; falls back to `/perfil/edita`. If `profileEnrichmentFailed`, it links to `/iniciar-sessio` with the correct label.
  - Logout added to `ProfileOwnerActions` and `EditProfileForm` so onboarding users can sign out.
  - Bottom bar always shows Favorites; `/preferits` works signed in or out.

- **Refactors**
  - Adopted a content-driven `nav` breakpoint at 950px for desktop header vs. mobile bottom bar (updated `tailwind.config.js` and `DESIGN.md`).

<sup>Written for commit 2c9185ce2301a73e60cb4191afb29cb64c2fefe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logout actions to profile editing and profile-owner controls.
  * Simplified mobile navigation with direct profile or login access and language switching.
  * Favorites are now consistently available from the navigation bar.
* **Bug Fixes**
  * Improved profile links and navigation behavior across authentication states and incomplete profiles.
  * Enhanced logout tracking for profile actions.
* **Tests**
  * Expanded coverage for mobile navigation, profile links, authentication states, favorites, and logout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->