### PR TITLE
fix(e2e): handle Logto passkey onboarding

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -329,7 +329,7 @@ components:
     itemBorderBottom: "2px solid transparent"
     countFontSize: "{typography.heading-3.fontSize}"
     countFontWeight: "{typography.heading-3.fontWeight}"
-    labelFontSize: "{typography.body-small.fontSize}"
+    labelFontSize: "{typography.heading-3.fontSize}"
     color: "{colors.foreground}"
     opacity: 0.8
   tab-bar-active:
@@ -725,9 +725,9 @@ Passats), not a client-side tabpanel switch — each item is a link to its own
 route. A full-width hairline rail (`border-border`) carries items with a
 2px bottom border; the active item's border goes solid red with
 `foreground-strong` text, inactive items sit at `foreground/80` on a
-transparent border. The count renders above the label in `heading-3`,
-label below in `body-small`. Wrapped in the horizontal-scroll primitive on
-narrow screens so it never breaks the rail's height.
+transparent border. The count and label both use `heading-3` for a stronger, consistent tab hierarchy.
+Wrapped in the horizontal-scroll primitive on narrow screens so it never
+breaks the rail's height.
 
 **Empty states** (e.g. "no events yet") center a title + description with
 generous vertical padding (`spacing.3xl`) and an optional primary-pill CTA

--- a/components/ui/common/tabs/index.tsx
+++ b/components/ui/common/tabs/index.tsx
@@ -38,7 +38,7 @@ export default function Tabs({ items, active, ariaLabel }: TabsProps) {
                   {item.count !== undefined && (
                     <span className="heading-3">{item.count}</span>
                   )}
-                  <span className="body-small">{item.label}</span>
+                  <span className="heading-3">{item.label}</span>
                 </Link>
               </div>
             );

--- a/components/ui/profile/ProfileHeader.tsx
+++ b/components/ui/profile/ProfileHeader.tsx
@@ -129,7 +129,7 @@ export default async function ProfileHeader({ profile }: ProfileHeaderProps) {
           )}
 
         {joinedDateText && (
-          <p className="body-small text-foreground/50 italic">
+          <p className="body-small-italic text-foreground/50">
             {t("joinedDate", { date: joinedDateText })}
           </p>
         )}

--- a/components/ui/profile/ProfileHeader.tsx
+++ b/components/ui/profile/ProfileHeader.tsx
@@ -95,41 +95,41 @@ export default async function ProfileHeader({ profile }: ProfileHeaderProps) {
         {(profile.eventCount !== undefined ||
           profile.upcomingEventCount !== undefined ||
           profile.totalEventVisits !== undefined) && (
-          <div
-            className="flex items-center gap-element-gap mb-element-gap"
-            data-testid="profile-stats"
-          >
-            {profile.eventCount !== undefined && (
-              <div className="flex flex-col items-center">
-                <span className="heading-3 text-foreground-strong">
-                  {profile.eventCount}
-                </span>
-                <span className="body-small text-foreground/60">
-                  {t("statsPublished")}
-                </span>
-              </div>
-            )}
-            {profile.upcomingEventCount !== undefined && (
-              <div className="flex flex-col items-center">
-                <span className="heading-3 text-foreground-strong">
-                  {profile.upcomingEventCount}
-                </span>
-                <span className="body-small text-foreground/60">
-                  {t("statsUpcoming")}
-                </span>
-              </div>
-            )}
-            {profile.totalEventVisits !== undefined && (
-              <ProfileVisitsStat
-                username={profile.username}
-                visits={profile.totalEventVisits}
-              />
-            )}
-          </div>
-        )}
+            <div
+              className="flex items-center gap-element-gap mb-element-gap"
+              data-testid="profile-stats"
+            >
+              {profile.eventCount !== undefined && (
+                <div className="flex flex-col items-center">
+                  <span className="heading-3 text-foreground-strong">
+                    {profile.eventCount}
+                  </span>
+                  <span className="body-small text-foreground/60">
+                    {t("statsPublished")}
+                  </span>
+                </div>
+              )}
+              {profile.upcomingEventCount !== undefined && (
+                <div className="flex flex-col items-center">
+                  <span className="heading-3 text-foreground-strong">
+                    {profile.upcomingEventCount}
+                  </span>
+                  <span className="body-small text-foreground/60">
+                    {t("statsUpcoming")}
+                  </span>
+                </div>
+              )}
+              {profile.totalEventVisits !== undefined && (
+                <ProfileVisitsStat
+                  username={profile.username}
+                  visits={profile.totalEventVisits}
+                />
+              )}
+            </div>
+          )}
 
         {joinedDateText && (
-          <p className="body-small text-foreground/50">
+          <p className="body-small text-foreground/50 italic">
             {t("joinedDate", { date: joinedDateText })}
           </p>
         )}

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,5 +1,44 @@
 import type { Page } from "@playwright/test";
 
+const PASSKEY_SETUP_PATH = /\/create-passkey(?:\/|$)/;
+export const PASSKEY_NAV_CONTROL_SELECTOR = '[role="button"]';
+
+export async function getPasskeySkipControl(page: Page) {
+  const controls = page.locator(PASSKEY_NAV_CONTROL_SELECTOR);
+  // Wait for the hosted page to render at least one navigation control before
+  // checking the exact structure. A count of two is the verified Back + Skip
+  // contract, and malformed markup fails with an actionable error.
+  await controls.first().waitFor({ timeout: 15_000 });
+  const count = await controls.count();
+  if (count !== 2) {
+    throw new Error(
+      `Unexpected Logto passkey navigation controls: expected 2, found ${count}`,
+    );
+  }
+  // SecondaryPageLayout renders Back first and optional Skip second.
+  return controls.nth(1);
+}
+
+/** Return true while Logto is showing its optional passkey enrollment step. */
+export function isPasskeySetupUrl(url: URL): boolean {
+  return PASSKEY_SETUP_PATH.test(url.pathname);
+}
+
+/** Return true once Logto has redirected the browser back to this app. */
+export function isLoginCompleteUrl(
+  url: URL,
+  appOrigin?: string,
+): boolean {
+  return (
+    Boolean(appOrigin) &&
+    url.origin === appOrigin &&
+    !isPasskeySetupUrl(url) &&
+    !/\/iniciar-sessio\/?$/.test(url.pathname) &&
+    !url.pathname.startsWith("/api/auth/") &&
+    !url.searchParams.has("auth_error")
+  );
+}
+
 /**
  * Log in through Logto's hosted sign-in page (reached via the OIDC redirect
  * from /iniciar-sessio). Selectors target Logto's default sign-in experience
@@ -7,10 +46,29 @@ import type { Page } from "@playwright/test";
  * single-step and identifier-then-password layouts.
  */
 export async function loginViaUI(page: Page, email: string, password: string) {
-  await page.goto("/en/iniciar-sessio", {
-    waitUntil: "domcontentloaded",
-    timeout: 60_000,
-  });
+  // Capture the app origin from the actual login-entry request. Do not infer
+  // it from an auth-host naming convention: deployments may use any hostname.
+  let appOrigin: string | undefined;
+  const captureAppOrigin = (request: { url: () => string }) => {
+    const url = new URL(request.url());
+    if (/\/iniciar-sessio\/?$/.test(url.pathname)) {
+      appOrigin = url.origin;
+    }
+  };
+  page.on("request", captureAppOrigin);
+  try {
+    await page.goto("/en/iniciar-sessio", {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+  } finally {
+    page.off("request", captureAppOrigin);
+  }
+  if (!appOrigin) {
+    throw new Error(
+      "Could not determine the app origin from the /iniciar-sessio navigation",
+    );
+  }
 
   const identifier = page
     .locator('input[name="identifier"], input[type="email"], input[type="text"]')
@@ -31,15 +89,28 @@ export async function loginViaUI(page: Page, email: string, password: string) {
     .first()
     .click();
 
-  // Wait until Logto redirects back to the app (off the auth domain / OIDC).
+  // Logto may show an optional passkey enrollment page immediately after a
+  // successful password login. Accept that intermediate URL, dismiss the
+  // enrollment step, then wait for the normal callback redirect.
   try {
     await page.waitForURL(
       (url) =>
-        !/\/oidc\//.test(url.pathname) &&
-        !url.host.startsWith("auth-") &&
-        !url.pathname.includes("/iniciar-sessio"),
+        isLoginCompleteUrl(url, appOrigin) || isPasskeySetupUrl(url),
       { timeout: 30_000 },
     );
+
+    if (isPasskeySetupUrl(new URL(page.url()))) {
+      // Logto's PasskeySetup page renders Back and Skip as the two navigation
+      // controls with role="button". The native passkey action is a real
+      // <button>, so selecting the final role-button avoids labels, locale,
+      // and CSS-module class names altogether.
+      const skipPasskey = await getPasskeySkipControl(page);
+      await skipPasskey.click();
+      await page.waitForURL(
+        (url) => isLoginCompleteUrl(url, appOrigin),
+        { timeout: 30_000 },
+      );
+    }
   } catch (timeoutError) {
     // A stuck-on-Logto timeout is ambiguous by itself — surface the actual
     // reason (usually a stale/unverified test-user password) instead of a

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,22 +1,25 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 const PASSKEY_SETUP_PATH = /\/create-passkey(?:\/|$)/;
 export const PASSKEY_NAV_CONTROL_SELECTOR = '[role="button"]';
 
 export async function getPasskeySkipControl(page: Page) {
   const controls = page.locator(PASSKEY_NAV_CONTROL_SELECTOR);
-  // Wait for the hosted page to render at least one navigation control before
-  // checking the exact structure. A count of two is the verified Back + Skip
-  // contract, and malformed markup fails with an actionable error.
-  await controls.first().waitFor({ timeout: 15_000 });
-  const count = await controls.count();
-  if (count !== 2) {
-    throw new Error(
-      `Unexpected Logto passkey navigation controls: expected 2, found ${count}`,
-    );
-  }
-  // SecondaryPageLayout renders Back first and optional Skip second.
-  return controls.nth(1);
+  // SecondaryPageLayout renders Back first and optional Skip second. Poll for
+  // the complete pair so async hosted-UI painting cannot produce a transient
+  // one-control count.
+  await expect(controls).toHaveCount(2, { timeout: 15_000 });
+
+  // This helper always enters through `/en/iniciar-sessio`; proxy.ts passes
+  // that locale to Logto as `ui_locales=en`. Logto's verified `action.nav_skip`
+  // translation is therefore the accessible name "Skip" for this flow.
+  const skipControl = page.getByRole("button", { name: /^skip$/i });
+  await expect(skipControl).toHaveCount(1, { timeout: 15_000 });
+
+  // Also verify the second navigation item is Skip (Back, then Skip), so a
+  // future unrelated "Skip" control cannot be clicked.
+  await expect(controls.nth(1)).toHaveAccessibleName(/^skip$/i);
+  return skipControl;
 }
 
 /** Return true while Logto is showing its optional passkey enrollment step. */

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,24 +1,33 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Page, type Request } from "@playwright/test";
 
 const PASSKEY_SETUP_PATH = /\/create-passkey(?:\/|$)/;
 export const PASSKEY_NAV_CONTROL_SELECTOR = '[role="button"]';
 
-export async function getPasskeySkipControl(page: Page) {
+// The login helper enters through the English `/en/iniciar-sessio` flow, which
+// forwards `ui_locales=en` to Logto. This is the explicit hosted-UI contract
+// for the optional passkey page; fail closed if the tenant changes the label.
+const PASSKEY_SKIP_NAME = /^skip$/i;
+
+export async function getPasskeySkipControl(
+  page: Page,
+  timeout = 15_000,
+) {
   const controls = page.locator(PASSKEY_NAV_CONTROL_SELECTOR);
   // SecondaryPageLayout renders Back first and optional Skip second. Poll for
   // the complete pair so async hosted-UI painting cannot produce a transient
   // one-control count.
-  await expect(controls).toHaveCount(2, { timeout: 15_000 });
+  await expect(controls).toHaveCount(2, { timeout });
 
-  // This helper always enters through `/en/iniciar-sessio`; proxy.ts passes
-  // that locale to Logto as `ui_locales=en`. Logto's verified `action.nav_skip`
-  // translation is therefore the accessible name "Skip" for this flow.
-  const skipControl = page.getByRole("button", { name: /^skip$/i });
-  await expect(skipControl).toHaveCount(1, { timeout: 15_000 });
+  const skipControl = page.getByRole("button", {
+    name: PASSKEY_SKIP_NAME,
+  });
+  await expect(skipControl).toHaveCount(1, { timeout });
 
   // Also verify the second navigation item is Skip (Back, then Skip), so a
   // future unrelated "Skip" control cannot be clicked.
-  await expect(controls.nth(1)).toHaveAccessibleName(/^skip$/i);
+  await expect(controls.nth(1)).toHaveAccessibleName(PASSKEY_SKIP_NAME, {
+    timeout,
+  });
   return skipControl;
 }
 
@@ -52,7 +61,10 @@ export async function loginViaUI(page: Page, email: string, password: string) {
   // Capture the app origin from the actual login-entry request. Do not infer
   // it from an auth-host naming convention: deployments may use any hostname.
   let appOrigin: string | undefined;
-  const captureAppOrigin = (request: { url: () => string }) => {
+  const captureAppOrigin = (request: Request): void => {
+    if (!request.isNavigationRequest() || request.frame() !== page.mainFrame()) {
+      return;
+    }
     const url = new URL(request.url());
     if (/\/iniciar-sessio\/?$/.test(url.pathname)) {
       appOrigin = url.origin;

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,4 +1,9 @@
-import { expect, type Page, type Request } from "@playwright/test";
+import {
+  expect,
+  type Locator,
+  type Page,
+  type Request,
+} from "@playwright/test";
 
 const PASSKEY_SETUP_PATH = /\/create-passkey(?:\/|$)/;
 export const PASSKEY_NAV_CONTROL_SELECTOR = '[role="button"]';
@@ -11,7 +16,7 @@ const PASSKEY_SKIP_NAME = /^skip$/i;
 export async function getPasskeySkipControl(
   page: Page,
   timeout = 15_000,
-) {
+): Promise<Locator> {
   const controls = page.locator(PASSKEY_NAV_CONTROL_SELECTOR);
   // SecondaryPageLayout renders Back first and optional Skip second. Poll for
   // the complete pair so async hosted-UI painting cannot produce a transient

--- a/e2e/login-helper.passkey.spec.ts
+++ b/e2e/login-helper.passkey.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import { getPasskeySkipControl } from "./helpers/login";
+
+const LOGTO_PASSKEY_URL = "https://auth.example.test/create-passkey?app_id=test";
+const APP_URL = "http://app.example.test/en/publica";
+
+test("selects Logto's Skip control and returns to the app", async ({ page }) => {
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin === new URL(LOGTO_PASSKEY_URL).origin) {
+      await route.fulfill({
+        contentType: "text/html",
+        body: `
+          <button id="create-passkey" type="button">Create a passkey</button>
+          <div role="button" id="back">Back</div>
+          <div role="button" id="skip">Skip</div>
+          <script>
+            document.querySelector("#skip").addEventListener("click", () => {
+              window.location.href = "${APP_URL}";
+            });
+          </script>
+        `,
+      });
+      return;
+    }
+    if (url.origin === new URL(APP_URL).origin) {
+      await route.fulfill({ contentType: "text/html", body: "<h1>App</h1>" });
+      return;
+    }
+    await route.abort();
+  });
+
+  await page.goto(LOGTO_PASSKEY_URL);
+  const skip = await getPasskeySkipControl(page);
+  await expect(skip).toHaveAttribute("id", "skip");
+  await skip.click();
+  await expect(page).toHaveURL(APP_URL);
+});

--- a/e2e/login-helper.passkey.spec.ts
+++ b/e2e/login-helper.passkey.spec.ts
@@ -4,23 +4,14 @@ import { getPasskeySkipControl } from "./helpers/login";
 const LOGTO_PASSKEY_URL = "https://auth.example.test/create-passkey?app_id=test";
 const APP_URL = "http://app.example.test/en/publica";
 
-test("selects Logto's Skip control and returns to the app", async ({ page }) => {
+async function servePasskeyPage(
+  page: Parameters<typeof getPasskeySkipControl>[0],
+  body: string,
+) {
   await page.route("**/*", async (route) => {
     const url = new URL(route.request().url());
     if (url.origin === new URL(LOGTO_PASSKEY_URL).origin) {
-      await route.fulfill({
-        contentType: "text/html",
-        body: `
-          <button id="create-passkey" type="button">Create a passkey</button>
-          <div role="button" id="back">Back</div>
-          <div role="button" id="skip">Skip</div>
-          <script>
-            document.querySelector("#skip").addEventListener("click", () => {
-              window.location.href = "${APP_URL}";
-            });
-          </script>
-        `,
-      });
+      await route.fulfill({ contentType: "text/html", body });
       return;
     }
     if (url.origin === new URL(APP_URL).origin) {
@@ -29,10 +20,53 @@ test("selects Logto's Skip control and returns to the app", async ({ page }) => 
     }
     await route.abort();
   });
+}
+
+test("selects Logto's Skip control and returns to the app", async ({ page }) => {
+  await servePasskeyPage(
+    page,
+    `
+      <button id="create-passkey" type="button">Create a passkey</button>
+      <div role="button" id="back">Back</div>
+      <div role="button" id="skip">Skip</div>
+      <script>
+        document.querySelector("#skip").addEventListener("click", () => {
+          window.location.href = "${APP_URL}";
+        });
+      </script>
+    `,
+  );
 
   await page.goto(LOGTO_PASSKEY_URL);
   const skip = await getPasskeySkipControl(page);
   await expect(skip).toHaveAttribute("id", "skip");
   await skip.click();
   await expect(page).toHaveURL(APP_URL);
+});
+
+test("fails closed when Logto exposes an unexpected control count", async ({
+  page,
+}) => {
+  await servePasskeyPage(
+    page,
+    '<div role="button" id="back">Back</div>',
+  );
+
+  await page.goto(LOGTO_PASSKEY_URL);
+  await expect(getPasskeySkipControl(page, 250)).rejects.toThrow();
+});
+
+test("fails closed when Skip is not the second navigation control", async ({
+  page,
+}) => {
+  await servePasskeyPage(
+    page,
+    `
+      <div role="button" id="skip">Skip</div>
+      <div role="button" id="back">Back</div>
+    `,
+  );
+
+  await page.goto(LOGTO_PASSKEY_URL);
+  await expect(getPasskeySkipControl(page, 250)).rejects.toThrow();
 });

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -152,6 +152,10 @@ p {
     @apply text-sm font-normal leading-relaxed tracking-normal;
   }
 
+  .body-small-italic {
+    @apply body-small italic;
+  }
+
   /* LABEL: UI elements - Small badges, uppercase labels */
   .label {
     @apply text-xs uppercase tracking-wider font-medium;

--- a/test/e2e-login-helper.test.ts
+++ b/test/e2e-login-helper.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getPasskeySkipControl,
+  isLoginCompleteUrl,
+  isPasskeySetupUrl,
+  PASSKEY_NAV_CONTROL_SELECTOR,
+} from "../e2e/helpers/login";
+
+describe("E2E Logto login URL helpers", () => {
+  it("uses a role-based selector for Logto's passkey navigation controls", () => {
+    expect(PASSKEY_NAV_CONTROL_SELECTOR).toBe('[role="button"]');
+  });
+
+  it("requires Back and Skip controls and targets Skip", async () => {
+    const control = { waitFor: vi.fn().mockResolvedValue(undefined) };
+    const first = vi.fn(() => control);
+    const nth = vi.fn(() => control);
+    const controls = {
+      count: vi.fn().mockResolvedValue(2),
+      first,
+      nth,
+    };
+    const page = {
+      locator: (selector: string) => {
+        expect(selector).toBe('[role="button"]');
+        return controls;
+      },
+    };
+
+    await expect(getPasskeySkipControl(page as never)).resolves.toBe(control);
+    expect(first).toHaveBeenCalledOnce();
+    expect(nth).toHaveBeenCalledWith(1);
+  });
+
+  it("fails closed if Logto changes the navigation control structure", async () => {
+    const controls = {
+      count: vi.fn().mockResolvedValue(1),
+      first: () => ({ waitFor: vi.fn().mockResolvedValue(undefined) }),
+      nth: () => ({ waitFor: vi.fn().mockResolvedValue(undefined) }),
+    };
+    const page = {
+      locator: () => controls,
+    };
+
+    await expect(getPasskeySkipControl(page as never)).rejects.toThrow(
+      "expected 2, found 1",
+    );
+  });
+
+  describe("isPasskeySetupUrl", () => {
+    it("recognizes Logto's create-passkey page with query parameters", () => {
+      expect(
+        isPasskeySetupUrl(
+          new URL("https://auth-preproduction.example.com/create-passkey?app_id=test"),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not match similarly named paths", () => {
+      expect(
+        isPasskeySetupUrl(
+          new URL("https://auth-preproduction.example.com/create-passkey-help"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("isLoginCompleteUrl", () => {
+    it("accepts the app callback URL", () => {
+      expect(
+        isLoginCompleteUrl(
+          new URL("http://localhost:3000/en/publica"),
+          "http://localhost:3000",
+        ),
+      ).toBe(true);
+    });
+
+    it("requires the captured app origin and rejects login/error routes", () => {
+      const incompleteUrls = [
+        [
+          "http://another-host:3000/en/publica?auth_success=1",
+          "http://localhost:3000",
+        ],
+        [
+          "http://localhost:3000/en/iniciar-sessio",
+          "http://localhost:3000",
+        ],
+        [
+          "http://localhost:3000/?auth_error=exchange",
+          "http://localhost:3000",
+        ],
+        [
+          "https://auth-preproduction.example.com/create-passkey?app_id=test",
+          "http://localhost:3000",
+        ],
+      ] as const;
+
+      for (const [url, appOrigin] of incompleteUrls) {
+        expect(isLoginCompleteUrl(new URL(url), appOrigin)).toBe(false);
+      }
+    });
+  });
+});

--- a/test/e2e-login-helper.test.ts
+++ b/test/e2e-login-helper.test.ts
@@ -1,52 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  getPasskeySkipControl,
   isLoginCompleteUrl,
   isPasskeySetupUrl,
-  PASSKEY_NAV_CONTROL_SELECTOR,
 } from "../e2e/helpers/login";
 
 describe("E2E Logto login URL helpers", () => {
-  it("uses a role-based selector for Logto's passkey navigation controls", () => {
-    expect(PASSKEY_NAV_CONTROL_SELECTOR).toBe('[role="button"]');
-  });
-
-  it("requires Back and Skip controls and targets Skip", async () => {
-    const control = { waitFor: vi.fn().mockResolvedValue(undefined) };
-    const first = vi.fn(() => control);
-    const nth = vi.fn(() => control);
-    const controls = {
-      count: vi.fn().mockResolvedValue(2),
-      first,
-      nth,
-    };
-    const page = {
-      locator: (selector: string) => {
-        expect(selector).toBe('[role="button"]');
-        return controls;
-      },
-    };
-
-    await expect(getPasskeySkipControl(page as never)).resolves.toBe(control);
-    expect(first).toHaveBeenCalledOnce();
-    expect(nth).toHaveBeenCalledWith(1);
-  });
-
-  it("fails closed if Logto changes the navigation control structure", async () => {
-    const controls = {
-      count: vi.fn().mockResolvedValue(1),
-      first: () => ({ waitFor: vi.fn().mockResolvedValue(undefined) }),
-      nth: () => ({ waitFor: vi.fn().mockResolvedValue(undefined) }),
-    };
-    const page = {
-      locator: () => controls,
-    };
-
-    await expect(getPasskeySkipControl(page as never)).rejects.toThrow(
-      "expected 2, found 1",
-    );
-  });
-
   describe("isPasskeySetupUrl", () => {
     it("recognizes Logto's create-passkey page with query parameters", () => {
       expect(


### PR DESCRIPTION
## Summary
- handle Logto’s optional `/create-passkey` step in the shared real-login helper
- verify the passkey selector with a deterministic Playwright spec
- align profile tabs/design documentation with the requested UI styling changes

## Validation
- `yarn test --run` — 2,312 passed
- `yarn typecheck` — passed
- `yarn lint` — 0 errors (pre-existing warnings remain)
- focused Playwright passkey spec — passed

## Preproduction validation
The write-heavy `E2E Integration (preproduction)` workflow will be run against this branch. It uses the staging Logto credentials and creates/deletes a real preproduction event.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles Logto’s optional passkey onboarding in the real-login helper to keep E2E flows stable, and aligns profile tabs with the updated design. Adds deterministic tests for the Skip control, including fail-closed cases.

- **Bug Fixes**
  - Detect `/create-passkey`; require two `[role="button"]` controls, assert the second is “Skip”, click it, then wait for redirect back to the app.
  - Capture the app origin from `/iniciar-sessio`; add `isPasskeySetupUrl` and `isLoginCompleteUrl` for reliable waits and clearer timeout errors.
  - Tests: Playwright spec covers Skip and negative cases when control count/order changes; unit tests cover the URL helpers.

- **Refactors**
  - Tabs: render the label in `heading-3`; update `DESIGN.md` so count and label both use `heading-3`.
  - Profile: add `body-small-italic` and use it for the joined date.
  - Types: annotate `getPasskeySkipControl` to return `Promise<Locator>`.

<sup>Written for commit d65ce793ae966894412f194074c0c93887ee8c20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated tab labels and counts with more consistent heading typography.
  - Refined profile statistics formatting and styled joined dates in italics.

- **Sign-In Improvements**
  - Improved handling of optional passkey setup during sign-in.
  - Users can now skip passkey enrollment and return smoothly to the application without interrupted navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->