### PR TITLE
fix(nav): protect mobile bottom navigation safe area

### DIFF
--- a/app/[locale]/e/[eventId]/components/EventStickyCTA.tsx
+++ b/app/[locale]/e/[eventId]/components/EventStickyCTA.tsx
@@ -24,7 +24,8 @@ function findFavoriteButton(): HTMLButtonElement | null {
 
 /**
  * Sticky CTA bar for event detail pages on mobile.
- * Sits above the bottom navigation bar (bottom-16 = 64px to clear the h-16 nav).
+ * Sits above the bottom navigation bar using the shared mobile-nav-clearance
+ * variable, including the device safe-area inset when present.
  * Hidden on desktop (md:hidden) and only visible when user scrolls past the hero.
  *
  * The Save button delegates to the real FavoriteButton on the page to stay in sync
@@ -126,7 +127,7 @@ export default function EventStickyCTA({
   return (
     <div
       ref={ctaRef}
-      className="fixed bottom-16 left-0 right-0 z-40 md:hidden"
+      className="fixed bottom-[var(--mobile-nav-clearance)] left-0 right-0 z-40 md:hidden"
       role="toolbar"
       aria-label={t("toolbarAriaLabel")}
     >

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -111,6 +111,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  viewportFit: "cover",
   themeColor: "#D6002F",
 };
 

--- a/components/ui/common/footer/index.tsx
+++ b/components/ui/common/footer/index.tsx
@@ -64,7 +64,10 @@ export default async function Footer(): Promise<JSX.Element> {
 
   return (
     <footer className="w-full border-t border-border bg-gradient-to-b from-background to-muted/30">
-      <div className="container flex flex-col items-center gap-section-y-sm pt-section-y pb-20 md:pb-section-y px-section-x">
+      <div
+        className="container mobile-nav-content-safe-area flex flex-col items-center gap-section-y-sm pt-section-y px-section-x"
+        data-testid="mobile-nav-content-safe-area"
+      >
         {/* Social Media Section */}
         <div className="flex flex-col items-center gap-element-gap px-4 sm:px-0">
           <Social links={links} />
@@ -156,7 +159,10 @@ export default async function Footer(): Promise<JSX.Element> {
         <hr className="w-full max-w-4xl border-t border-border/50" />
 
         {/* Copyright Section */}
-        <div className="w-full flex flex-col items-center gap-element-gap-sm px-section-x">
+        <div
+          className="w-full flex flex-col items-center gap-element-gap-sm px-section-x"
+          data-testid="footer-last-content"
+        >
           <CopyrightNotice />
           <span className="text-xs text-muted-foreground text-center">
             {t("tagline")}

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -73,7 +73,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
   return (
     <nav
       id="site-navbar"
-      className="w-full bg-background nav:sticky nav:top-0 z-50 border-b border-border/50 nav:shadow-sm nav:backdrop-blur-sm"
+      className="site-navbar-safe-area w-full bg-background nav:sticky nav:top-0 z-50 border-b border-border/50 nav:shadow-sm nav:backdrop-blur-sm"
     >
       <div className="bg-background py-2 h-14">
         <div className="h-full flex flex-col justify-center">

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -77,8 +77,11 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
     >
       <div className="bg-background py-2 h-14">
         <div className="h-full flex flex-col justify-center">
-          <div className="flex justify-between items-center">
-            <div className="flex flex-1 nav:w-1/2 justify-start items-center py-2 px-3">
+          <div
+            className="flex justify-between items-center px-section-x nav:px-0"
+            data-testid="navbar-top-row"
+          >
+            <div className="flex flex-1 min-w-0 nav:w-1/2 justify-start items-center py-2 nav:px-3">
               <PressableLink
                 href="/"
                 prefetch={false}
@@ -101,11 +104,17 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                 Used below the desktop navigation breakpoint; nav items live in the bottom bar.
                 Logout lives on the profile page itself (see ProfileOwnerActions). */}
             <div
-              className="flex nav:hidden justify-end items-center gap-2"
+              className="flex nav:hidden shrink-0 justify-end items-center gap-2"
               data-testid="compact-navbar-actions"
             >
               <LanguageSwitcher />
-              {!isLoading && (
+              {isLoading ? (
+                <div
+                  className="w-11 h-11 shrink-0"
+                  aria-hidden="true"
+                  data-testid="mobile-auth-slot"
+                />
+              ) : (
                 isAuthenticated && user && !user.profileEnrichmentFailed ? (
                   <PressableLink
                     href={profileHref || "/perfil/edita"}
@@ -241,7 +250,7 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
           </div>
 
           <div
-            className="fixed bottom-0 left-0 right-0 h-16 border-t border-border nav:hidden z-50 shadow-lg"
+            className="mobile-bottom-nav fixed bottom-0 left-0 right-0 border-t border-border nav:hidden z-50 shadow-lg"
             data-testid="mobile-bottom-nav"
           >
             <div

--- a/components/ui/common/navbar/NavbarClient.tsx
+++ b/components/ui/common/navbar/NavbarClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
-import { usePathname } from "next/navigation";
+import Image from "next/image";
+
 import {
   PlusIcon,
   HomeIcon,
@@ -11,7 +11,6 @@ import {
   UserCircleIcon,
 } from "@heroicons/react/24/outline";
 const PlusSmIcon = PlusIcon;
-import Image from "next/image";
 import ActiveLink from "@components/ui/common/link";
 import PressableLink from "@components/ui/primitives/PressableLink";
 import { useAuth } from "@components/hooks/useAuth";
@@ -22,10 +21,7 @@ import type { Href } from "types/common";
 import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavbarClient({ navigation, labels }: NavbarClientProps) {
-  const pathname = usePathname();
-  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-  const userMenuRef = useRef<HTMLDivElement>(null);
-  const { user, isAuthenticated, isLoading, logout } = useAuth();
+  const { user, isAuthenticated, isLoading } = useAuth();
   const logoAlt = labels.logoAlt?.trim() || "Esdeveniments";
 
   // Build a URL-safe slug for the /perfil/{slug} URL. Prefer the
@@ -47,28 +43,6 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
       : profileSlug
         ? `/perfil/${encodeURIComponent(profileSlug)}`
         : null;
-
-  // Close the desktop user dropdown when pathname changes (navigation occurs)
-  // This is a legitimate effect that synchronizes state with an external system (route)
-  const previousPathname = useRef(pathname);
-  useEffect(() => {
-    if (previousPathname.current !== pathname) {
-      previousPathname.current = pathname;
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Syncing menu state with route changes is intentional
-      setIsUserMenuOpen(false);
-    }
-  }, [pathname]);
-
-  useEffect(() => {
-    if (!isUserMenuOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
-        setIsUserMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isUserMenuOpen]);
 
   return (
     <nav
@@ -168,76 +142,32 @@ export default function NavbarClient({ navigation, labels }: NavbarClientProps) 
                 ))}
               </div>
 
-              {/* Desktop auth: avatar dropdown with profile + logout */}
+              {/* Desktop auth: one-click profile navigation, matching the compact header. */}
               {!isLoading && (
-                isAuthenticated && user ? (
-                  <div className="relative" ref={userMenuRef}>
-                    <button
-                      type="button"
-                      onClick={() => setIsUserMenuOpen((prev) => !prev)}
-                      className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold hover:opacity-90 transition-interactive focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-                      aria-label={labels.userMenu}
-                      aria-expanded={isUserMenuOpen}
-                      data-testid="user-avatar-button"
-                    >
-                      {user.avatarUrl ? (
-                        // bg-background: the button behind this is bg-primary (for
-                        // the fallback-letter case). A transparent-background
-                        // upload (e.g. a logo) would otherwise let that red bleed
-                        // through instead of showing the actual image cleanly.
-                        <img
-                          src={user.avatarUrl}
-                          alt=""
-                          className="w-9 h-9 rounded-full object-cover bg-background"
-                        />
-                      ) : (
-                        (user.name || user.email).charAt(0).toUpperCase()
-                      )}
-                    </button>
-                    {isUserMenuOpen && (
-                      <div className="absolute right-0 mt-2 w-48 card-bordered card-body shadow-md bg-background z-50 rounded-lg" data-testid="user-dropdown-menu">
-                        <p className="body-small text-foreground/60 truncate mb-2">
-                          {user.name || user.email}
-                        </p>
-                        {/* Surface "incomplete session" when the id_token is
-                              valid but the backend rejected our Bearer (or was
-                              unreachable). Without this, the user sees an empty
-                              dropdown — no profile link, only logout — and
-                              can't tell why. Clicking logout re-enters the
-                              Logto flow and may fix a stale cookie. */}
-                        {user.profileEnrichmentFailed && (
-                          <p
-                            className="body-small text-error mb-1 py-1"
-                            data-testid="navbar-session-warning"
-                            role="status"
-                            aria-live="polite"
-                          >
-                            {labels.incompleteProfile}
-                          </p>
-                        )}
-                        {profileHref && !user.profileEnrichmentFailed && (
-                          <ActiveLink
-                            href={profileHref}
-                            className="block w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
-                          >
-                            {labels.myProfile}
-                          </ActiveLink>
-                        )}
-                        <button
-                          type="button"
-                          onClick={() => { logout(); setIsUserMenuOpen(false); }}
-                          className="w-full text-left label font-semibold text-foreground hover:text-primary transition-interactive py-1"
-                          data-analytics-action="navbar_logout_desktop"
-                        >
-                          {labels.logout}
-                        </button>
-                      </div>
+                isAuthenticated && user && !user.profileEnrichmentFailed ? (
+                  <PressableLink
+                    href={profileHref || "/perfil/edita"}
+                    prefetch={false}
+                    variant="inline"
+                    className="flex-center w-9 h-9 rounded-full bg-primary text-white text-sm font-bold hover:opacity-90 transition-interactive focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    aria-label={labels.myProfile}
+                    data-testid="desktop-avatar-link"
+                  >
+                    {user.avatarUrl ? (
+                      <img
+                        src={user.avatarUrl}
+                        alt=""
+                        className="w-9 h-9 rounded-full object-cover bg-background"
+                      />
+                    ) : (
+                      (user.name || user.email).charAt(0).toUpperCase()
                     )}
-                  </div>
+                  </PressableLink>
                 ) : (
                   <ActiveLink
                     href="/iniciar-sessio"
                     className="btn-outline label font-semibold whitespace-nowrap"
+                    data-testid="desktop-login-link"
                     data-analytics-action="navbar_login_desktop"
                   >
                     {labels.login}

--- a/components/ui/common/social/SocialFollowPopup.tsx
+++ b/components/ui/common/social/SocialFollowPopup.tsx
@@ -361,7 +361,7 @@ export default function SocialFollowPopup({ pathname }: { pathname: string }) {
   if (isMobile) {
     return (
       <div
-        className={`fixed bottom-16 inset-x-0 z-modal p-4 ${
+        className={`fixed bottom-[var(--mobile-nav-clearance)] inset-x-0 z-modal p-4 ${
           isClosing ? "animate-slide-down" : "animate-slide-up"
         }`}
         role="complementary"

--- a/e2e/navbar-responsive.spec.ts
+++ b/e2e/navbar-responsive.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Responsive navbar", () => {
+  test("keeps compact actions inside the 390px viewport gutter", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
+
+    const navigation = page.getByRole("navigation").first();
+    const topRow = page.getByTestId("navbar-top-row");
+    const compactActions = page.getByTestId("compact-navbar-actions");
+    const languageSwitcher = compactActions.getByRole("button").first();
+    const authAction = compactActions.locator(
+      '[data-testid="mobile-avatar-link"], [data-testid="mobile-login-link"], [data-testid="mobile-auth-slot"]'
+    );
+
+    await expect(navigation).toBeVisible({ timeout: 30000 });
+    await expect(topRow).toBeVisible();
+    await expect(compactActions).toBeVisible();
+    await expect(languageSwitcher).toBeVisible();
+    await expect(authAction).toHaveCount(1);
+    await expect(authAction).toBeVisible();
+
+    const geometry = await topRow.evaluate((element) => {
+      const topRowRect = element.getBoundingClientRect();
+      const actions = element.querySelector<HTMLElement>(
+        '[data-testid="compact-navbar-actions"]'
+      );
+      const language = element.querySelector<HTMLElement>(
+        '[data-testid="compact-navbar-actions"] button'
+      );
+      const auth = element.querySelector<HTMLElement>(
+        '[data-testid="mobile-avatar-link"], [data-testid="mobile-login-link"], [data-testid="mobile-auth-slot"]'
+      );
+
+      if (!actions || !language || !auth) {
+        throw new Error("Compact navbar actions or auth action is missing");
+      }
+
+      const actionsRect = actions.getBoundingClientRect();
+      const languageRect = language.getBoundingClientRect();
+      const authRect = auth.getBoundingClientRect();
+      const styles = getComputedStyle(element);
+
+      return {
+        viewportWidth: window.innerWidth,
+        topRowPaddingLeft: styles.paddingLeft,
+        topRowPaddingRight: styles.paddingRight,
+        actionsRightGap: window.innerWidth - actionsRect.right,
+        languageWithinActions:
+          languageRect.left >= actionsRect.left && languageRect.right <= actionsRect.right,
+        authRightGap: window.innerWidth - authRect.right,
+        actionsWidth: actionsRect.width,
+        authWidth: authRect.width,
+        topRowWidth: topRowRect.width,
+      };
+    });
+
+    expect(geometry.viewportWidth).toBe(390);
+    expect(geometry.topRowPaddingLeft).toBe("16px");
+    expect(geometry.topRowPaddingRight).toBe("16px");
+    expect(geometry.actionsRightGap).toBeCloseTo(16, 1);
+    expect(geometry.languageWithinActions).toBe(true);
+    expect(geometry.authRightGap).toBeCloseTo(16, 1);
+    expect(geometry.actionsWidth).toBeGreaterThan(44);
+    expect(geometry.authWidth).toBe(44);
+    expect(geometry.topRowWidth).toBe(390);
+  });
+
+  test("keeps the page end clear of the fixed mobile navigation", async ({
+    page,
+  }) => {
+    for (const width of [390, 768, 949]) {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
+
+      const mobileNav = page.getByTestId("mobile-bottom-nav");
+      const contentSafeArea = page.getByTestId("mobile-nav-content-safe-area");
+
+      await expect(mobileNav).toBeVisible({ timeout: 30000 });
+      await expect(contentSafeArea).toBeVisible();
+
+      const geometry = await page.evaluate(() => {
+        const nav = document.querySelector<HTMLElement>(
+          '[data-testid="mobile-bottom-nav"]'
+        );
+        const safeArea = document.querySelector<HTMLElement>(
+          '[data-testid="mobile-nav-content-safe-area"]'
+        );
+        const footer = document.querySelector("footer");
+        const footerLastContent = document.querySelector<HTMLElement>(
+          '[data-testid="footer-last-content"]'
+        );
+
+        if (!nav || !safeArea || !footer || !footerLastContent) {
+          throw new Error(
+            "Mobile nav, safe-area wrapper, footer, or footer content is missing"
+          );
+        }
+
+        const navRect = nav.getBoundingClientRect();
+        const footerRect = footer.getBoundingClientRect();
+        const navStyles = getComputedStyle(nav);
+        const safeAreaStyles = getComputedStyle(safeArea);
+        const clearance = getComputedStyle(document.documentElement)
+          .getPropertyValue("--mobile-nav-clearance")
+          .trim();
+
+        return {
+          navHeight: navRect.height,
+          navTop: navRect.top,
+          navBottom: navRect.bottom,
+          viewportHeight: window.innerHeight,
+          navPaddingBottom: navStyles.paddingBottom,
+          navClearance: clearance,
+          contentPaddingBottom: safeAreaStyles.paddingBottom,
+          footerBottom: footerRect.bottom,
+          footerLastContentBottom: footerLastContent.getBoundingClientRect().bottom,
+        };
+      });
+
+      expect(geometry.navBottom).toBeCloseTo(844, 1);
+      expect(geometry.navHeight).toBeGreaterThanOrEqual(64);
+      expect(geometry.navPaddingBottom).toMatch(/px$/);
+      expect(geometry.contentPaddingBottom).toMatch(/px$/);
+      expect(geometry.navClearance).toMatch(/calc\(/);
+
+      const endGeometry = await page.evaluate(() => {
+        document.body.scrollTop = document.body.scrollHeight;
+        document.documentElement.scrollTop = document.documentElement.scrollHeight;
+
+        const body = document.body;
+        const scrollingElement = document.scrollingElement;
+        const maxBodyScrollTop = body.scrollHeight - body.clientHeight;
+
+        if (body.scrollTop < maxBodyScrollTop - 1) {
+          throw new Error(
+            `Body did not reach its maximum scroll position: ${body.scrollTop} < ${maxBodyScrollTop}`
+          );
+        }
+
+        if (scrollingElement !== document.documentElement) {
+          throw new Error("Expected document.scrollingElement to be documentElement");
+        }
+
+        const nav = document.querySelector<HTMLElement>(
+          '[data-testid="mobile-bottom-nav"]'
+        );
+        const footerLastContent = document.querySelector<HTMLElement>(
+          '[data-testid="footer-last-content"]'
+        );
+        if (!nav || !footerLastContent) {
+          throw new Error("Nav or footer content is missing");
+        }
+        return {
+          navTop: nav.getBoundingClientRect().top,
+          footerLastContentBottom: footerLastContent.getBoundingClientRect().bottom,
+        };
+      });
+
+      expect(endGeometry.footerLastContentBottom).toBeLessThanOrEqual(
+        endGeometry.navTop + 1
+      );
+    }
+  });
+
+  test("switches from compact to desktop navigation at 950px", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 949, height: 844 });
+    await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
+
+    const compactActions = page.getByTestId("compact-navbar-actions");
+    const desktopActions = page.getByTestId("desktop-navbar-actions");
+
+    await expect(compactActions).toBeVisible({ timeout: 30000 });
+    await expect(desktopActions).toBeHidden();
+
+    await page.setViewportSize({ width: 950, height: 844 });
+
+    await expect(compactActions).toBeHidden();
+    await expect(desktopActions).toBeVisible();
+
+    const desktopClearance = await page.evaluate(() => {
+      const rootStyles = getComputedStyle(document.documentElement);
+      const contentSafeArea = document.querySelector<HTMLElement>(
+        '[data-testid="mobile-nav-content-safe-area"]'
+      );
+      if (!contentSafeArea) throw new Error("Safe-area wrapper is missing");
+      return {
+        clearance: rootStyles.getPropertyValue("--mobile-nav-clearance").trim(),
+        paddingBottom: getComputedStyle(contentSafeArea).paddingBottom,
+      };
+    });
+
+    expect(desktopClearance).toEqual({
+      clearance: "0px",
+      paddingBottom: "48px",
+    });
+  });
+});

--- a/e2e/navbar-responsive.spec.ts
+++ b/e2e/navbar-responsive.spec.ts
@@ -127,21 +127,19 @@ test.describe("Responsive navbar", () => {
       expect(geometry.navClearance).toMatch(/calc\(/);
 
       const endGeometry = await page.evaluate(() => {
-        document.body.scrollTop = document.body.scrollHeight;
-        document.documentElement.scrollTop = document.documentElement.scrollHeight;
-
         const body = document.body;
-        const scrollingElement = document.scrollingElement;
-        const maxBodyScrollTop = body.scrollHeight - body.clientHeight;
+        const documentElement = document.documentElement;
+        const scrollRoot =
+          body.scrollHeight > body.clientHeight
+            ? body
+            : document.scrollingElement ?? documentElement;
+        const maxScrollTop = scrollRoot.scrollHeight - scrollRoot.clientHeight;
+        scrollRoot.scrollTop = maxScrollTop;
 
-        if (body.scrollTop < maxBodyScrollTop - 1) {
+        if (scrollRoot.scrollTop < maxScrollTop - 1) {
           throw new Error(
-            `Body did not reach its maximum scroll position: ${body.scrollTop} < ${maxBodyScrollTop}`
+            `Scroll root did not reach its maximum position: ${scrollRoot.scrollTop} < ${maxScrollTop}`
           );
-        }
-
-        if (scrollingElement !== document.documentElement) {
-          throw new Error("Expected document.scrollingElement to be documentElement");
         }
 
         const nav = document.querySelector<HTMLElement>(

--- a/e2e/navbar-responsive.spec.ts
+++ b/e2e/navbar-responsive.spec.ts
@@ -169,6 +169,7 @@ test.describe("Responsive navbar", () => {
     await page.setViewportSize({ width: 949, height: 844 });
     await page.goto("/", { waitUntil: "domcontentloaded", timeout: 90000 });
 
+    const navbar = page.locator("#site-navbar");
     const compactActions = page.getByTestId("compact-navbar-actions");
     const desktopActions = page.getByTestId("desktop-navbar-actions");
 
@@ -179,6 +180,7 @@ test.describe("Responsive navbar", () => {
 
     await expect(compactActions).toBeHidden();
     await expect(desktopActions).toBeVisible();
+    await expect(navbar).toHaveClass(/site-navbar-safe-area/);
 
     const desktopClearance = await page.evaluate(() => {
       const rootStyles = getComputedStyle(document.documentElement);

--- a/e2e/publish-integration.spec.ts
+++ b/e2e/publish-integration.spec.ts
@@ -82,7 +82,7 @@ test.describe("Publish integration (staging)", () => {
 
     // Verify we're logged in (avatar button visible in navbar)
     await expect(
-      page.getByTestId("user-avatar-button")
+      page.getByTestId("desktop-avatar-link")
     ).toBeVisible({ timeout: 15_000 });
 
     // Sanity check that we're logged in as *some* real account before

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,11 +59,6 @@ html {
 }
 
 @media (min-width: 950px) {
-  .site-navbar-safe-area {
-    padding-top: 0;
-    padding-inline: 0;
-  }
-
   .mobile-nav-content-safe-area {
     padding-bottom: 3rem;
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -39,6 +39,13 @@ html {
   }
 }
 
+.site-navbar-safe-area {
+  box-sizing: border-box;
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-inline-start: env(safe-area-inset-left, 0px);
+  padding-inline-end: env(safe-area-inset-right, 0px);
+}
+
 .mobile-nav-content-safe-area {
   padding-bottom: var(--mobile-nav-clearance);
 }
@@ -47,9 +54,16 @@ html {
   box-sizing: border-box;
   height: var(--mobile-nav-clearance);
   padding-bottom: var(--mobile-nav-safe-area);
+  left: env(safe-area-inset-left, 0px);
+  right: env(safe-area-inset-right, 0px);
 }
 
 @media (min-width: 950px) {
+  .site-navbar-safe-area {
+    padding-top: 0;
+    padding-inline: 0;
+  }
+
   .mobile-nav-content-safe-area {
     padding-bottom: 3rem;
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,6 +25,40 @@ html {
   font-synthesis-weight: none;
 }
 
+:root {
+  --mobile-nav-height: 4rem;
+  --mobile-nav-safe-area: env(safe-area-inset-bottom, 0px);
+  --mobile-nav-clearance: calc(
+    var(--mobile-nav-height) + var(--mobile-nav-safe-area)
+  );
+}
+
+@media (min-width: 950px) {
+  :root {
+    --mobile-nav-clearance: 0px;
+  }
+}
+
+.mobile-nav-content-safe-area {
+  padding-bottom: var(--mobile-nav-clearance);
+}
+
+.mobile-bottom-nav {
+  box-sizing: border-box;
+  height: var(--mobile-nav-clearance);
+  padding-bottom: var(--mobile-nav-safe-area);
+}
+
+@media (min-width: 950px) {
+  .mobile-nav-content-safe-area {
+    padding-bottom: 3rem;
+  }
+
+  .mobile-bottom-nav {
+    padding-bottom: 0;
+  }
+}
+
 body {
   @apply font-sans antialiased text-base leading-relaxed;
 }

--- a/test/navbar-avatar.test.tsx
+++ b/test/navbar-avatar.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { vi } from "vitest";
 import type { AuthUser } from "types/auth";
 import type { NavbarLabels } from "types/props";
+
+let authLoading = false;
 
 const authUser: AuthUser = {
   id: "ff3da805-08f2-4fd0-acd5-6372344aa339",
@@ -40,14 +42,14 @@ vi.mock("@components/ui/primitives/PressableLink", () => ({
 }));
 
 vi.mock("@components/ui/common/navbar/LanguageSwitcher", () => ({
-  default: () => null,
+  default: () => <button type="button" data-testid="language-switcher">CA</button>,
 }));
 
 vi.mock("@components/hooks/useAuth", () => ({
   useAuth: () => ({
     user: authUser,
     isAuthenticated: true,
-    isLoading: false,
+    isLoading: authLoading,
     logout: vi.fn(),
   }),
 }));
@@ -70,6 +72,10 @@ const labels: NavbarLabels = {
 };
 
 describe("NavbarClient avatar", () => {
+  afterEach(() => {
+    authLoading = false;
+  });
+
   it("keeps the logo at its aspect ratio and uses the compact layout below the nav breakpoint", () => {
     render(<NavbarClient navigation={[]} labels={labels} />);
     const logo = screen.getByAltText(labels.logoAlt);
@@ -77,13 +83,27 @@ describe("NavbarClient avatar", () => {
 
     expect(logo).toHaveClass("!h-auto", "aspect-[190/18]");
     expect(navbar).toHaveClass("nav:sticky");
-    expect(screen.getByTestId("compact-navbar-actions")).toHaveClass("nav:hidden");
+    expect(screen.getByTestId("navbar-top-row")).toHaveClass("px-section-x", "nav:px-0");
+    expect(screen.getByTestId("compact-navbar-actions")).toHaveClass("nav:hidden", "shrink-0");
     expect(screen.getByTestId("desktop-navbar-actions")).toHaveClass("hidden", "nav:flex");
-    expect(screen.getByTestId("mobile-bottom-nav")).toHaveClass("nav:hidden");
+    const mobileBottomNav = screen.getByTestId("mobile-bottom-nav");
+    expect(mobileBottomNav).toHaveClass("mobile-bottom-nav", "nav:hidden");
+    expect(mobileBottomNav).not.toHaveClass("h-16");
 
     const mobileAvatar = screen.getByTestId("mobile-avatar-link");
     expect(mobileAvatar).toHaveAttribute("href", "/perfil/alba");
     expect(mobileAvatar).not.toHaveClass("text-primary", "border-b-2", "border-primary");
+  });
+
+  it("reserves the auth action slot while authentication is loading", () => {
+    authLoading = true;
+    render(<NavbarClient navigation={[]} labels={labels} />);
+
+    const compactActions = screen.getByTestId("compact-navbar-actions");
+    expect(compactActions.querySelector('[data-testid="language-switcher"]')).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-auth-slot")).toHaveClass("w-11", "h-11", "shrink-0");
+    expect(screen.queryByTestId("mobile-avatar-link")).toBeNull();
+    expect(screen.queryByTestId("mobile-login-link")).toBeNull();
   });
 
   it("gives a transparent-background upload a neutral backdrop instead of the fallback button color", () => {

--- a/test/navbar-avatar.test.tsx
+++ b/test/navbar-avatar.test.tsx
@@ -108,14 +108,15 @@ describe("NavbarClient avatar", () => {
 
   it("gives a transparent-background upload a neutral backdrop instead of the fallback button color", () => {
     render(<NavbarClient navigation={[]} labels={labels} />);
-    const img = screen.getByTestId("user-avatar-button").querySelector("img");
+    const img = screen.getByTestId("desktop-avatar-link").querySelector("img");
     expect(img).toHaveAttribute("src", authUser.avatarUrl);
     expect(img).toHaveClass("bg-background");
   });
 
   it("gives the avatar toggle a visible focus ring, matching every other nav control", () => {
     render(<NavbarClient navigation={[]} labels={labels} />);
-    const button = screen.getByTestId("user-avatar-button");
-    expect(button).toHaveClass("focus-visible:ring-2", "focus-visible:ring-primary");
+    const avatarLink = screen.getByTestId("desktop-avatar-link");
+    expect(avatarLink).toHaveAttribute("href", "/perfil/alba");
+    expect(avatarLink).toHaveClass("focus-visible:ring-2", "focus-visible:ring-primary");
   });
 });

--- a/test/navbar-avatar.test.tsx
+++ b/test/navbar-avatar.test.tsx
@@ -82,7 +82,7 @@ describe("NavbarClient avatar", () => {
     const navbar = document.getElementById("site-navbar");
 
     expect(logo).toHaveClass("!h-auto", "aspect-[190/18]");
-    expect(navbar).toHaveClass("nav:sticky");
+    expect(navbar).toHaveClass("nav:sticky", "site-navbar-safe-area");
     expect(screen.getByTestId("navbar-top-row")).toHaveClass("px-section-x", "nav:px-0");
     expect(screen.getByTestId("compact-navbar-actions")).toHaveClass("nav:hidden", "shrink-0");
     expect(screen.getByTestId("desktop-navbar-actions")).toHaveClass("hidden", "nav:flex");

--- a/test/navbar-profile-link.test.tsx
+++ b/test/navbar-profile-link.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { AuthUser } from "types/auth";
 import type { NavbarLabels } from "types/props";
@@ -77,11 +77,10 @@ describe("NavbarClient profile link", () => {
       profileCompleted: false,
     };
     render(<NavbarClient navigation={[]} labels={labels} />);
-    fireEvent.click(screen.getByTestId("user-avatar-button"));
-
     expect(
-      screen.getByText("El meu perfil").closest("a")?.getAttribute("href")
+      screen.getByTestId("desktop-avatar-link").getAttribute("href")
     ).toBe("/perfil/edita");
+    expect(screen.queryByTestId("user-dropdown-menu")).toBeNull();
     expect(
       screen.getByTestId("mobile-avatar-link").getAttribute("href")
     ).toBe("/perfil/edita");
@@ -96,11 +95,10 @@ describe("NavbarClient profile link", () => {
       profileCompleted: true,
     };
     render(<NavbarClient navigation={[]} labels={labels} />);
-    fireEvent.click(screen.getByTestId("user-avatar-button"));
-
     expect(
-      screen.getByText("El meu perfil").closest("a")?.getAttribute("href")
+      screen.getByTestId("desktop-avatar-link").getAttribute("href")
     ).toBe("/perfil/alba");
+    expect(screen.queryByTestId("user-dropdown-menu")).toBeNull();
     expect(
       screen.getByTestId("mobile-avatar-link").getAttribute("href")
     ).toBe("/perfil/alba");
@@ -115,11 +113,10 @@ describe("NavbarClient profile link", () => {
       profileCompleted: undefined,
     };
     render(<NavbarClient navigation={[]} labels={labels} />);
-    fireEvent.click(screen.getByTestId("user-avatar-button"));
-
     expect(
-      screen.getByText("El meu perfil").closest("a")?.getAttribute("href")
+      screen.getByTestId("desktop-avatar-link").getAttribute("href")
     ).toBe("/perfil/alba");
+    expect(screen.queryByTestId("user-dropdown-menu")).toBeNull();
     expect(
       screen.getByTestId("mobile-avatar-link").getAttribute("href")
     ).toBe("/perfil/alba");
@@ -144,7 +141,22 @@ describe("NavbarClient profile link", () => {
     ).toBe("/perfil/edita");
   });
 
-  it("falls back to the re-auth link on mobile when the session is only partially enriched", () => {
+  it("uses the same edit-profile fallback on desktop when no usable slug exists", () => {
+    authUser = {
+      id: OWNER_ID,
+      email: "a@b.com",
+      name: "a@b.com",
+      username: "a@b.com",
+      profileCompleted: true,
+    };
+    render(<NavbarClient navigation={[]} labels={labels} />);
+
+    expect(
+      screen.getByTestId("desktop-avatar-link").getAttribute("href")
+    ).toBe("/perfil/edita");
+  });
+
+  it("falls back to the desktop login link when the session is only partially enriched", () => {
     authUser = {
       id: OWNER_ID,
       email: "a@b.com",
@@ -158,7 +170,11 @@ describe("NavbarClient profile link", () => {
     expect(
       screen.getByTestId("mobile-login-link").getAttribute("href")
     ).toBe("/iniciar-sessio");
+    expect(
+      screen.getByTestId("desktop-login-link").getAttribute("href")
+    ).toBe("/iniciar-sessio");
     expect(screen.queryByTestId("mobile-avatar-link")).toBeNull();
+    expect(screen.queryByTestId("desktop-avatar-link")).toBeNull();
   });
 
   it("shows the mobile login link, not the avatar, when signed out", () => {
@@ -169,7 +185,7 @@ describe("NavbarClient profile link", () => {
       screen.getByTestId("mobile-login-link").getAttribute("href")
     ).toBe("/iniciar-sessio");
     expect(screen.queryByTestId("mobile-avatar-link")).toBeNull();
-    expect(screen.queryByTestId("user-avatar-button")).toBeNull();
+    expect(screen.queryByTestId("desktop-avatar-link")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- reserve mobile bottom-navigation clearance through the footer
- account for iOS safe-area insets and enable viewport-fit=cover
- share the clearance offset with mobile fixed surfaces
- add responsive Playwright coverage for page-end overlap and the 950px breakpoint

## Verification
- `yarn test --run`
- `yarn test:e2e e2e/navbar-responsive.spec.ts --project=chromium`
- `yarn typecheck`
- `yarn lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile bottom navigation overlap on iOS by reserving safe-area space and sharing one clearance across mobile fixed elements. Also applies safe-area insets to the navbar, enforces the 950px desktop switch, and makes the desktop avatar a direct profile link.

- **Bug Fixes**
  - Added CSS vars (`--mobile-nav-height`, `--mobile-nav-safe-area`, `--mobile-nav-clearance`) and applied them to `.mobile-bottom-nav`, `.mobile-nav-content-safe-area`, and the navbar (`.site-navbar-safe-area`) to include top/left/right insets.
  - Replaced hardcoded offsets with `bottom-[var(--mobile-nav-clearance)]` in mobile fixed components (Event sticky CTA, Social follow popup); mobile nav height/padding now derive from the clearance.
  - Set `viewportFit: "cover"` to enable iOS safe-area insets; navbar top row now respects compact gutters.
  - Simplified desktop auth: avatar now links directly to the profile (or to `/perfil/edita` when no slug); shows the login link when the session is partially enriched; reserved an auth slot while loading. Updated tests to use `desktop-avatar-link` and added Playwright coverage for compact actions in the 390px gutter, footer/page-end clearance with hardened scroll-root handling, and the 950px desktop switch (clearance `0px`, content keeps `48px` padding).

<sup>Written for commit d59f279ecaf3704cb9a2625f84bc787454035a6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation spacing and safe-area handling across the navbar, footer, sticky CTAs, and popups.
  * Preserved consistent layout spacing while authentication controls are loading.
  * Improved responsive behavior across mobile and desktop breakpoints.

* **Tests**
  * Added coverage for responsive navigation, viewport clearance, scrolling, breakpoints, and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->