### PR TITLE
fix(seo): single h1 on homepage, dedupe JSON-LD payload

### DIFF
--- a/app/[locale]/e/[eventId]/components/EventHeroImageClient.tsx
+++ b/app/[locale]/e/[eventId]/components/EventHeroImageClient.tsx
@@ -38,7 +38,7 @@ export default function EventHeroImageClient({
         src={sources.fallback}
         alt={safeTitle}
         loading="eager"
-        decoding="sync"
+        decoding="async"
         fetchPriority="high"
         sizes={sizes}
         className="object-cover w-full h-full absolute inset-0 z-10"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -43,10 +43,9 @@ export async function generateMetadata() {
 // avoids a language mismatch for crawlers and SEO tools that don't execute JS.
 const STATIC_FALLBACK_CONTENT: Record<
   AppLocale,
-  { h1: string; h2: string; description: string; apiNote: string }
+  { h2: string; description: string; apiNote: string }
 > = {
   ca: {
-    h1: "Què fer a Catalunya - Agenda cultural i plans",
     h2: "Agenda cultural a Catalunya amb concerts, exposicions, teatre, activitats familiars i plans per a totes les edats.",
     description:
       "Esdeveniments.cat és la plataforma gratuïta més completa per descobrir esdeveniments culturals a Catalunya. Consulta l'agenda de concerts, teatre, exposicions, festivals, activitats familiars i molt més en més de 900 municipis catalans. Troba què fer avui, demà o aquest cap de setmana a prop teu.",
@@ -54,7 +53,6 @@ const STATIC_FALLBACK_CONTENT: Record<
       "API pública gratuïta disponible a /llms.txt i /openapi.json — sense autenticació necessària.",
   },
   es: {
-    h1: "Qué hacer en Cataluña - Agenda cultural y planes",
     h2: "Agenda cultural en Cataluña con conciertos, exposiciones, teatro, actividades familiares y planes para todas las edades.",
     description:
       "Esdeveniments.cat es la plataforma gratuita más completa para descubrir eventos culturales en Cataluña. Consulta la agenda de conciertos, teatro, exposiciones, festivales, actividades familiares y mucho más en más de 900 municipios catalanes. Encuentra qué hacer hoy, mañana o este fin de semana cerca de ti.",
@@ -62,7 +60,6 @@ const STATIC_FALLBACK_CONTENT: Record<
       "API pública gratuita disponible en /llms.txt y /openapi.json — sin autenticación necesaria.",
   },
   en: {
-    h1: "What to do in Catalonia - Cultural agenda and plans",
     h2: "Cultural agenda in Catalonia with concerts, exhibitions, theater, family activities and plans for all ages.",
     description:
       "Esdeveniments.cat is the most complete free platform to discover cultural events in Catalonia. Browse the agenda of concerts, theater, exhibitions, festivals, family activities and more across 900+ Catalan municipalities. Find what to do today, tomorrow or this weekend near you.",
@@ -75,7 +72,6 @@ function HomeStaticFallback({ locale }: { locale: AppLocale }) {
   const content = STATIC_FALLBACK_CONTENT[locale] ?? STATIC_FALLBACK_CONTENT.ca;
   return (
     <>
-      <h1 className="sr-only">{content.h1}</h1>
       {/* API doc links — visible to crawlers for agent discovery (orank public-api-docs check).
           Uses <a> not <Link> because these are machine-readable file URLs, not navigable pages. */}
       {/* eslint-disable @next/next/no-html-link-for-pages */}
@@ -244,13 +240,6 @@ async function HomeContent({
 
   return (
     <>
-      {/* h1 is duplicated in HomeContent so that after the Suspense fallback is
-          replaced by the streamed content, the final DOM still contains the h1
-          (important for SEO crawlers that execute JS and for accessibility).
-          The <noscript> stays in HomeStaticFallback only — it is prerendered
-          in the PPR static shell and is what JS-less crawlers see. */}
-      <h1 className="sr-only">{pageData.title}</h1>
-
       {siteNavigationSchema && (
         <JsonLdServer id="site-navigation" data={siteNavigationSchema} />
       )}
@@ -316,7 +305,12 @@ async function HomeStructuredData({
     title: pageData.title,
     description: pageData.metaDescription,
     url: pageData.canonical,
-    mainContentOfPage: itemListSchema || undefined,
+    // Reference the ItemList by @id instead of inlining it: it is emitted
+    // standalone below, so inlining it here tripled the event descriptions
+    // (~300 KB of the homepage payload).
+    mainContentOfPage: itemListSchema
+      ? { "@id": itemListSchema["@id"] }
+      : undefined,
     locale,
     speakableCssSelectors: ["h1", "[data-speakable='description']"],
   });
@@ -328,7 +322,9 @@ async function HomeStructuredData({
         description: pageData.metaDescription,
         url: pageData.canonical,
         numberOfItems: homepageEvents.length,
-        mainEntity: itemListSchema || undefined,
+        mainEntity: itemListSchema
+          ? { "@id": itemListSchema["@id"] }
+          : undefined,
         locale,
       })
       : null;

--- a/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
+++ b/app/[locale]/sitemap/[town]/[year]/[month]/page.tsx
@@ -281,11 +281,15 @@ export default async function Page({
     breadcrumbs,
     locale,
     numberOfItems: filteredEvents.length,
-    mainEntity: eventsItemList || {
-      "@type": "Thing",
-      name: t("itemListTitle", { town: townLabel, month: monthLabel, year }),
-      description: t("collectionFallbackDescription"),
-    },
+    // Reference the ItemList by @id instead of inlining it: it is emitted
+    // standalone below, so inlining it here duplicated the event payload.
+    mainEntity: eventsItemList
+      ? { "@id": eventsItemList["@id"] }
+      : {
+          "@type": "Thing",
+          name: t("itemListTitle", { town: townLabel, month: monthLabel, year }),
+          description: t("collectionFallbackDescription"),
+        },
   });
 
   return (

--- a/components/ui/newsHeroEvent/index.tsx
+++ b/components/ui/newsHeroEvent/index.tsx
@@ -46,7 +46,7 @@ export default async function NewsHeroEvent({ event }: NewsHeroEventProps) {
               src={sources.fallback}
               alt={event.title}
               loading="eager"
-              decoding="sync"
+              decoding="async"
               fetchPriority="high"
               sizes={sizes}
               className="object-cover w-full h-full absolute inset-0"

--- a/components/ui/serverEventsCategorized/index.tsx
+++ b/components/ui/serverEventsCategorized/index.tsx
@@ -207,7 +207,7 @@ async function ServerEventsCategorized({
           alt=""
           aria-hidden="true"
           fetchPriority="high"
-          decoding="sync"
+          decoding="async"
           className="absolute inset-0 w-full h-full object-cover object-[center_60%]"
         />
         {/* Dark overlay for text readability */}


### PR DESCRIPTION
## Summary

Fixes the real issues behind the 2026-08-18 SEO/PageSpeed audit of the homepage. The audit's "5 H1 / 248 H2" numbers were partly tool artifacts — re-measured live production HTML shows **3 h1** (2 invisible `sr-only` + 1 visible hero) and **19 h2**.

## Changes

1. **Single `<h1>`** — removed the two duplicate `sr-only` h1s (PPR static-shell fallback + streamed `HomeContent`). The visible hero heading (`Què fer a Catalunya`) is now the page's only h1. It was already server-rendered into the HTML — the audit's "client-rendered LCP" flag was a grep artifact (single-line regex missed the multi-line h1).
2. **`decoding="sync"` → `"async"`** on the hero `<img>` — stop forcing synchronous decode on first paint.
3. **Dedupe JSON-LD** — the homepage ItemList (20 events with full descriptions) was inlined three times (in `WebPage.mainContentOfPage`, `CollectionPage.mainEntity`, and standalone). The first two now reference it by `@id`, cutting ~300 KB (~22%) off the 1.36 MB homepage HTML.

## Verification

- `yarn typecheck` green
- `yarn eslint` green (both files)
- `test/seo-meta.test.ts` 24/24
- pre-push hook (typecheck + unit tests + i18n) green

## Note

Item 3 is a structured-data change: the ItemList is still emitted once, referenced by `@id` from the WebPage/CollectionPage schemas (valid JSON-LD, same `@id` on the page). Worth a Rich Results Test / Search Console re-check after deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a single h1 on the homepage and dedupes ItemList JSON-LD to cut ~300 KB from the HTML. Also dedupes the monthly sitemap JSON-LD and switches hero images from sync to async decoding to avoid blocking first paint.

- Confirm no hidden h1 remains in the PPR fallback or streamed content; the visible hero heading is the sole, server-rendered h1.
- Validate JSON-LD: the ItemList is emitted once with a stable `@id`; `WebPage.mainContentOfPage` and `CollectionPage.mainEntity` reference it on the homepage and monthly sitemaps. Recheck Rich Results after deploy.
- Spot-check LCP: `decoding="async"` with `fetchPriority="high"` on homepage, event, news, and categorized hero images should not regress image paint.

<sup>Written for commit 1b589562433aaad408ae87545d292463942d80ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate hidden headings from the homepage for cleaner page structure.
  * Improved structured data references for more consistent search engine interpretation.
  * Updated hero image loading behavior to improve page rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->