### PR TITLE
perf(image-proxy): add Redis origin cache to skip slow upstream fetch

### DIFF
--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -8,6 +8,8 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { Agent, fetch as undiciFetch } from "undici";
+import { createHash } from "node:crypto";
+import { cacheGetJson, cacheSetJson } from "@lib/cache/redis-client";
 import {
   normalizeExternalImageUrl,
   isLegacyFileHandler,
@@ -23,6 +25,29 @@ const TIMEOUT_MS = 5000;
 const SNIFF_BYTES = 64;
 const ONE_YEAR = 31536000;
 const MAX_REDIRECTS = 2;
+
+// Origin-level cache (deploy-independent Redis, same layer as /api/places/nearby).
+// Cloudflare's Free plan does not edge-cache /api/* (see api-layer-patterns
+// skill), and the service worker only helps returning visitors. So a first-time
+// visitor's hero image was a full upstream municipal fetch + Sharp encode on
+// every request — the dominant cause of the ~2.6s field LCP on event pages.
+// This layer makes every request after the first one a near-instant Redis hit.
+const IMAGE_CACHE_PREFIX = "imgproxy:";
+const IMAGE_CACHE_TTL_SECONDS = 60 * 60 * 24; // 24h (matches CDN s-maxage)
+const IMAGE_CACHE_TTL_IMMUTABLE_SECONDS = 60 * 60 * 24 * 30; // 30d for cache-busted URLs
+
+function buildImageCacheKey(
+  normalized: string,
+  width: number,
+  quality: number,
+  useModernFormat: boolean
+): string {
+  // Hash the (potentially long) upstream URL. The source image type is fixed
+  // by that URL, so normalized + width + quality + format fully determines the
+  // output; no need to know the source type separately.
+  const digest = createHash("sha1").update(normalized).digest("hex").slice(0, 24);
+  return `${IMAGE_CACHE_PREFIX}${digest}:${width}:${quality}:${useModernFormat ? "webp" : "legacy"}`;
+}
 
 // Image optimization defaults
 const DEFAULT_QUALITY = 50; // Base quality for mobile - Lighthouse tests on mobile viewport
@@ -342,6 +367,35 @@ export async function GET(request: Request) {
 
   const candidates = buildFetchCandidates(upstreamUrl, originalWasHttp);
 
+  // Serve from the origin cache when possible (skips the slow upstream fetch +
+  // Sharp encode). Fails open: any miss/corrupt entry falls through to fetch.
+  const useModernFormat = preferAvif || preferWebp;
+  const cacheKey = buildImageCacheKey(
+    normalized,
+    width,
+    quality,
+    useModernFormat
+  );
+  const cached = await cacheGetJson<{ ct: string; b64: string }>(cacheKey);
+  if (cached?.ct && cached.b64) {
+    try {
+      return new NextResponse(
+        new Uint8Array(Buffer.from(cached.b64, "base64")),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": cached.ct,
+            "Cache-Control": getCacheControl(hasCacheKey),
+            Vary: "Accept",
+            "X-Image-Proxy-Cache": "hit",
+          },
+        }
+      );
+    } catch {
+      // Corrupt entry — fall through and re-fetch.
+    }
+  }
+
   for (const candidate of candidates) {
     try {
       const response = await fetchWithTimeout(candidate);
@@ -486,6 +540,14 @@ export async function GET(request: Request) {
           (1 - outputBuffer.length / imageBuffer.length) * 100
         );
 
+        // Store the optimized result so the next request skips fetch + encode.
+        // Best-effort: a failed write must never fail the image response.
+        await cacheSetJson(
+          cacheKey,
+          { ct: outputContentType, b64: outputBuffer.toString("base64") },
+          hasCacheKey ? IMAGE_CACHE_TTL_IMMUTABLE_SECONDS : IMAGE_CACHE_TTL_SECONDS
+        );
+
         return new NextResponse(responseBody, {
           status: 200,
           headers: {
@@ -493,6 +555,7 @@ export async function GET(request: Request) {
             "Cache-Control": getCacheControl(hasCacheKey),
             Vary: "Accept", // Cache different formats separately
             "X-Image-Proxy-Optimized": "true",
+            "X-Image-Proxy-Cache": "miss",
             "X-Image-Proxy-Savings": `${savingsPercent}%`,
             "X-Image-Proxy-Original-Size": String(imageBuffer.length),
             "X-Image-Proxy-Final-Size": String(outputBuffer.length),

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -379,8 +379,20 @@ export async function GET(request: Request) {
   const cached = await cacheGetJson<{ ct: string; b64: string }>(cacheKey);
   if (cached?.ct && cached.b64) {
     try {
+      // Validate before serving: bytes must be canonical base64, non-empty,
+      // and sniff back to the same image type the entry declares. A corrupt
+      // or tampered Redis value falls through to the upstream fetch instead
+      // of returning a 200 with invalid image data.
+      const cachedBytes = Buffer.from(cached.b64, "base64");
+      if (
+        cachedBytes.length === 0 ||
+        cachedBytes.toString("base64") !== cached.b64 ||
+        sniffImageContentType(cachedBytes) !== cached.ct
+      ) {
+        throw new Error("Corrupt image cache entry");
+      }
       return new NextResponse(
-        new Uint8Array(Buffer.from(cached.b64, "base64")),
+        new Uint8Array(cachedBytes),
         {
           status: 200,
           headers: {

--- a/bundle-size-baseline.json
+++ b/bundle-size-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "lastUpdated": "2026-06-26T00:00:00+00:00",
+  "lastUpdated": "2026-08-18T00:00:00+00:00",
   "clientTotalBytes": 2283119,
   "thresholds": {
     "warning": {
@@ -246,7 +246,7 @@
       "fileCount": 6
     },
     "/api/image-proxy": {
-      "serverBytes": 23058,
+      "serverBytes": 67199,
       "fileCount": 6
     },
     "/[locale]/noticies/[place]/rss.xml": {

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { createClient } from "redis";
+import { createClient } from "@redis/client";
 
 /**
  * App-level Redis cache, deliberately separate from the Next.js incremental
@@ -15,10 +15,36 @@ import { createClient } from "redis";
 /** Back off this long after a failure so a Redis outage can't trigger a connect attempt on every request. */
 const FAILURE_COOLDOWN_MS = 30_000;
 
-/** Bound a single Redis command so a connected-but-slow server can't hang the
- * request path. The connect phase already has its own 2s timeout
- * (socket.connectTimeout); this covers commands after the handshake. */
+/** Wall-clock bound on a single Redis command. node-redis clears its own
+ * abortSignal/timeout listeners once a command is written to the socket, so
+ * those do NOT bound an in-flight reply — a plain Promise.race does. */
 const COMMAND_TIMEOUT_MS = 1_000;
+
+/**
+ * Race a Redis command against a wall-clock timeout so a connected-but-slow
+ * server can't hang the request path. node-redis's abortSignal/timeout options
+ * are removed when the command is written, so a delayed reply is never settled
+ * by them. Racing against a timer settles with `fallback` regardless, and
+ * stamps the failure cooldown so the slow server is skipped for the next window.
+ */
+async function raceWithTimeout<T>(
+  command: Promise<T>,
+  fallback: T,
+  ms: number
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => {
+      globalForRedis.__appRedisFailedAt = Date.now();
+      resolve(fallback);
+    }, ms);
+  });
+  try {
+    return await Promise.race([command, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 const globalForRedis = globalThis as unknown as {
   __appRedis?: Promise<ReturnType<typeof createClient> | null>;
@@ -108,9 +134,7 @@ export async function cacheGetJson<T>(key: string): Promise<T | null> {
   try {
     const client = await getClient();
     if (!client) return null;
-    const raw = await client
-      .withAbortSignal(AbortSignal.timeout(COMMAND_TIMEOUT_MS))
-      .get(key);
+    const raw = await raceWithTimeout(client.get(key), null, COMMAND_TIMEOUT_MS);
     return raw ? (JSON.parse(raw) as T) : null;
   } catch {
     return null;
@@ -127,9 +151,11 @@ export async function cacheSetJson(
     if (!client) return;
     // SETEX (dedicated helper) avoids the deprecated { EX } option and is
     // stable across redis v5/v6.
-    await client
-      .withAbortSignal(AbortSignal.timeout(COMMAND_TIMEOUT_MS))
-      .setEx(key, ttlSeconds, JSON.stringify(value));
+    await raceWithTimeout(
+      client.setEx(key, ttlSeconds, JSON.stringify(value)),
+      "",
+      COMMAND_TIMEOUT_MS
+    );
   } catch (error) {
     // best-effort: a failed cache write must never fail the request, but log
     // it so write failures aren't silently swallowed.

--- a/lib/cache/redis-client.ts
+++ b/lib/cache/redis-client.ts
@@ -15,6 +15,11 @@ import { createClient } from "redis";
 /** Back off this long after a failure so a Redis outage can't trigger a connect attempt on every request. */
 const FAILURE_COOLDOWN_MS = 30_000;
 
+/** Bound a single Redis command so a connected-but-slow server can't hang the
+ * request path. The connect phase already has its own 2s timeout
+ * (socket.connectTimeout); this covers commands after the handshake. */
+const COMMAND_TIMEOUT_MS = 1_000;
+
 const globalForRedis = globalThis as unknown as {
   __appRedis?: Promise<ReturnType<typeof createClient> | null>;
   __appRedisFailedAt?: number;
@@ -103,7 +108,9 @@ export async function cacheGetJson<T>(key: string): Promise<T | null> {
   try {
     const client = await getClient();
     if (!client) return null;
-    const raw = await client.get(key);
+    const raw = await client
+      .withAbortSignal(AbortSignal.timeout(COMMAND_TIMEOUT_MS))
+      .get(key);
     return raw ? (JSON.parse(raw) as T) : null;
   } catch {
     return null;
@@ -120,7 +127,9 @@ export async function cacheSetJson(
     if (!client) return;
     // SETEX (dedicated helper) avoids the deprecated { EX } option and is
     // stable across redis v5/v6.
-    await client.setEx(key, ttlSeconds, JSON.stringify(value));
+    await client
+      .withAbortSignal(AbortSignal.timeout(COMMAND_TIMEOUT_MS))
+      .setEx(key, ttlSeconds, JSON.stringify(value));
   } catch (error) {
     // best-effort: a failed cache write must never fail the request, but log
     // it so write failures aren't silently swallowed.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@fortedigital/nextjs-cache-handler": "^3.2.0",
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
+    "@redis/client": "5.11.0",
     "@sentry/nextjs": "10.32.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11859,6 +11859,7 @@ __metadata:
     "@opentelemetry/core": "npm:^2.8.0"
     "@opentelemetry/sdk-trace-base": "npm:^2.8.0"
     "@playwright/test": "npm:1.60.0"
+    "@redis/client": "npm:5.11.0"
     "@sentry/nextjs": "npm:10.32.0"
     "@tailwindcss/aspect-ratio": "npm:^0.4.2"
     "@tailwindcss/forms": "npm:^0.5.3"


### PR DESCRIPTION
## Problem

Event detail pages (`/e/...`) show **~2.6s field LCP** on mobile (Search Console CrUX data, ~1.4k affected URLs). Root cause measured live: the LCP element is the hero image served through `/api/image-proxy?url=…`.

That route fetches the external municipal image (slow council servers, up to 5s timeout) and Sharp-encodes it to WebP on **every request**. There is no server-side cache:

- Cloudflare Free does **not** edge-cache `/api/*` (see `api-layer-patterns` skill).
- The service worker only helps returning visitors.

So every first-time visitor pays the full fetch + encode on the critical path.

## Fix

Add a deploy-independent Redis origin cache (same `lib/cache/redis-client.ts` layer as `/api/places/nearby`), keyed on `sha1(upstream URL) + width + quality + format`:

- **Cache check** before the fetch loop → serves optimized image from Redis on hit (`X-Image-Proxy-Cache: hit`).
- **Cache write** after Sharp encode → stores `{contentType, base64}` (`X-Image-Proxy-Cache: miss`).
- **TTL:** 30d for cache-busted (`?v=`) URLs, 24h otherwise — matches existing CDN semantics.
- **Fails open:** any Redis error/miss/corrupt entry falls through to the existing fetch path. Never fails an image.

## Verification

- `yarn typecheck` ✅
- `yarn eslint app/api/image-proxy/route.ts` ✅
- `yarn test --run test/utils/image-cache.test.ts` → 74/74 ✅

## Tradeoffs (for review)

- **Redis memory:** base64 (~33% overhead) per image, bounded by the already-configured `maxmemory-policy allkeys-lru`.
- **Route bundle:** +~44 KB server-side (redis client), same as the Places route — no client impact.
- Uses in-memory object shape `{ ct, b64 }` rather than a `types/` interface to comply with type-governance (single-use inline type).

## Not included (separate follow-up)

- CLS (0.13–0.19) and INP (217ms) on event pages are separate issues — likely injected ads and mobile main-thread work. Needs Lighthouse/PSI mobile diagnostics to pinpoint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Redis-backed origin cache to `/api/image-proxy` to skip slow upstream fetches and repeated Sharp encodes. Previously every request fetched and encoded; now cache hits serve the optimized image and misses use the existing path.

- Uses `cacheGetJson`/`cacheSetJson` from `@lib/cache/redis-client` with a 1s wall-clock bound per command (Promise.race). Imports `@redis/client` to avoid unused command sets. Fails open on timeouts or errors.
- Cache key: sha1(normalized upstream URL) + width + quality + format (`webp`|`legacy`); TTL is 30d for cache-busted (`?v=`) URLs, 24h otherwise.
- Stores `{ ct, b64 }`; validates canonical base64 and sniffed type before serving. Adds `Vary: Accept` and `X-Image-Proxy-Cache: hit|miss`.
- No changes to client API or CDN caching. Records `/api/image-proxy` server bundle growth in `bundle-size-baseline.json`; thresholds unchanged.
- No migration required.

<sup>Written for commit 6d05b346f81d47df36e73584e5028404fee6577e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Esdeveniments/esdeveniments-frontend/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added caching for optimized images to speed up repeat requests.
  * Cached responses remain available for up to 24 hours or 30 days, depending on the image request.
  * Responses now indicate whether content was served from cache or fetched fresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->